### PR TITLE
Add response for sourcify verification

### DIFF
--- a/verification/src/http_server/handlers/verification/mod.rs
+++ b/verification/src/http_server/handlers/verification/mod.rs
@@ -1,18 +1,12 @@
 #![allow(dead_code)]
 
-use std::{collections::HashMap, fmt::Display};
+use std::{collections::BTreeMap, fmt::Display};
 
 use serde::{Deserialize, Serialize};
 
 pub mod routes;
 pub mod solidity;
 pub mod sourcify;
-
-#[derive(Debug, Deserialize, Serialize, PartialEq)]
-pub struct ContractLibrary {
-    pub lib_name: String,
-    pub lib_address: String,
-}
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
 pub struct VerificationResponse {
@@ -27,9 +21,10 @@ pub struct VerificationResult {
     pub compiler_version: String,
     pub evm_version: String,
     pub constructor_arguments: Option<String>,
-    pub contract_libraries: Option<Vec<ContractLibrary>>,
+    pub optimization_runs: Option<usize>,
+    pub contract_libraries: BTreeMap<String, String>,
     pub abi: String,
-    pub sources: HashMap<String, String>,
+    pub sources: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq)]
@@ -73,10 +68,11 @@ mod tests {
                     compiler_version: "compiler_version".to_string(),
                     evm_version: "evm_version".to_string(),
                     constructor_arguments: Some("constructor_arguments".to_string()),
-                    contract_libraries: Some(vec![ContractLibrary {
-                        lib_name: "lib_name".to_string(),
-                        lib_address: "lib_address".to_string(),
-                    }]),
+                    optimization_runs: Some(200),
+                    contract_libraries: BTreeMap::from([(
+                        "some_library".into(),
+                        "some_address".into(),
+                    )]),
                     abi: "abi".to_string(),
                     sources: serde_json::from_str(
                         r#"{
@@ -93,10 +89,10 @@ mod tests {
                         "compiler_version": "compiler_version",
                         "evm_version": "evm_version",
                         "constructor_arguments": "constructor_arguments",
-                        "contract_libraries": [{
-                            "lib_name": "lib_name",
-                            "lib_address": "lib_address",
-                        }],
+                        "contract_libraries": {
+                            "some_library": "some_address",
+                        },
+                        "optimization_runs": 200,
                         "abi": "abi",
                         "sources": {
                             "source.sol": "content",

--- a/verification/src/http_server/handlers/verification/solidity/types.rs
+++ b/verification/src/http_server/handlers/verification/solidity/types.rs
@@ -1,4 +1,3 @@
-use crate::http_server::handlers::verification::ContractLibrary;
 use ethers_solc::{
     artifacts::{Libraries, Settings},
     CompilerInput, EvmVersion,
@@ -23,7 +22,7 @@ pub struct FlattenedSource {
     source_code: String,
     evm_version: String,
     optimization_runs: Option<usize>,
-    contract_libraries: Option<Vec<ContractLibrary>>,
+    contract_libraries: Option<BTreeMap<String, String>>,
 }
 
 impl TryFrom<FlattenedSource> for CompilerInput {
@@ -34,13 +33,8 @@ impl TryFrom<FlattenedSource> for CompilerInput {
         settings.optimizer.enabled = source.optimization_runs.map(|_| true);
         settings.optimizer.runs = source.optimization_runs;
         if let Some(source_libraries) = source.contract_libraries {
-            let libraries = BTreeMap::from_iter(
-                source_libraries
-                    .into_iter()
-                    .map(|l| (l.lib_name, l.lib_address)),
-            );
             settings.libraries = Libraries {
-                libs: BTreeMap::from([(PathBuf::from("source.sol"), libraries)]),
+                libs: BTreeMap::from([(PathBuf::from("source.sol"), source_libraries)]),
             };
         }
         if source.evm_version != "default" {
@@ -106,10 +100,10 @@ mod tests {
             source_code: "pragma".into(),
             evm_version: format!("{}", ethers_solc::EvmVersion::London),
             optimization_runs: Some(200),
-            contract_libraries: Some(vec![ContractLibrary {
-                lib_name: "some_library".into(),
-                lib_address: "some_address".into(),
-            }]),
+            contract_libraries: Some(BTreeMap::from([(
+                "some_library".into(),
+                "some_address".into(),
+            )])),
         };
         let expected = r#"{"language":"Solidity","sources":{"source.sol":{"content":"pragma"}},"settings":{"optimizer":{"enabled":true,"runs":200},"outputSelection":{"*":{"":["ast"],"*":["abi","evm.bytecode","evm.deployedBytecode","evm.methodIdentifiers"]}},"evmVersion":"london","libraries":{"source.sol":{"some_library":"some_address"}}}}"#;
         test_to_input(flatten, expected);

--- a/verification/src/http_server/handlers/verification/sourcify/api.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/api.rs
@@ -1,17 +1,33 @@
-use super::types::{ApiFilesResponse, ApiRequest, ApiVerificationResponse};
+use crate::{VerificationResponse, VerificationResult};
+use actix_web::{error, error::Error};
+
+use super::types::{ApiFilesResponse, ApiRequest, ApiVerificationResponse, Files};
+
+#[async_trait::async_trait]
+pub(super) trait SourcifyApi {
+    async fn verification(
+        &self,
+        params: &ApiRequest,
+    ) -> Result<ApiVerificationResponse, reqwest::Error>;
+
+    async fn source_files(&self, params: &ApiRequest) -> Result<ApiFilesResponse, reqwest::Error>;
+}
 
 pub(super) struct SoucifyApiClient {
     host: String,
 }
 
 impl SoucifyApiClient {
-    pub(super) fn new(host: &str) -> Self {
+    pub fn new(host: &str) -> Self {
         Self {
             host: host.to_string(),
         }
     }
+}
 
-    pub(super) async fn verification(
+#[async_trait::async_trait]
+impl SourcifyApi for SoucifyApiClient {
+    async fn verification(
         &self,
         params: &ApiRequest,
     ) -> Result<ApiVerificationResponse, reqwest::Error> {
@@ -24,10 +40,7 @@ impl SoucifyApiClient {
         resp.json().await
     }
 
-    pub(super) async fn source_files(
-        &self,
-        params: &ApiRequest,
-    ) -> Result<ApiFilesResponse, reqwest::Error> {
+    async fn source_files(&self, params: &ApiRequest) -> Result<ApiFilesResponse, reqwest::Error> {
         let url = format!(
             "{host}/files/any/{chain}/{address}",
             host = self.host,
@@ -38,4 +51,47 @@ impl SoucifyApiClient {
 
         resp.json().await
     }
+}
+
+pub(super) async fn verify_using_sourcify_client(
+    sourcify_client: impl SourcifyApi,
+    params: ApiRequest,
+) -> Result<VerificationResponse, Error> {
+    let response = sourcify_client
+        .verification(&params)
+        .await
+        .map_err(error::ErrorInternalServerError)?;
+
+    match response {
+        ApiVerificationResponse::Verified { result: api_result } => {
+            let files = {
+                let contract_was_already_verified = api_result
+                    .first()
+                    .ok_or_else(|| error::ErrorInternalServerError("sourcify empty response"))?
+                    .storage_timestamp
+                    .is_some();
+                if contract_was_already_verified {
+                    let api_files_response = sourcify_client
+                        .source_files(&params)
+                        .await
+                        .map_err(error::ErrorInternalServerError)?;
+                    Files::try_from(api_files_response).map_err(error::ErrorInternalServerError)?
+                } else {
+                    params.files
+                }
+            };
+            let result = VerificationResult::try_from(files).map_err(error::ErrorBadRequest)?;
+            Ok(VerificationResponse::ok(result))
+        }
+        ApiVerificationResponse::Error { error } => Ok(VerificationResponse::err(error)),
+        ApiVerificationResponse::ValidationErrors { message, errors } => {
+            let error_message = format!("{}: {:?}", message, errors);
+            Err(error::ErrorBadRequest(error_message))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: add tests in this PR, using mocked SourcifyApi
 }

--- a/verification/src/http_server/handlers/verification/sourcify/api.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/api.rs
@@ -1,0 +1,27 @@
+use crate::http_server::handlers::verification::sourcify;
+
+pub(super) async fn verification_request(
+    params: &sourcify::types::ApiRequest,
+    sourcify_api_url: &str,
+) -> Result<sourcify::types::ApiVerificationResponse, reqwest::Error> {
+    let resp = reqwest::Client::new()
+        .post(sourcify_api_url)
+        .json(&params)
+        .send()
+        .await?;
+
+    resp.json().await
+}
+
+pub(super) async fn verification_files(
+    params: &sourcify::types::ApiRequest,
+    sourcify_api_url: &str,
+) -> Result<sourcify::types::ApiFilesResponse, reqwest::Error> {
+    let url = format!(
+        "{}/files/any/{}/{}",
+        sourcify_api_url, params.chain, params.address
+    );
+    let resp = reqwest::Client::new().get(url).send().await?;
+
+    resp.json().await
+}

--- a/verification/src/http_server/handlers/verification/sourcify/api.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/api.rs
@@ -1,27 +1,41 @@
-use crate::http_server::handlers::verification::sourcify;
+use super::types::{ApiFilesResponse, ApiRequest, ApiVerificationResponse};
 
-pub(super) async fn verification_request(
-    params: &sourcify::types::ApiRequest,
-    sourcify_api_url: &str,
-) -> Result<sourcify::types::ApiVerificationResponse, reqwest::Error> {
-    let resp = reqwest::Client::new()
-        .post(sourcify_api_url)
-        .json(&params)
-        .send()
-        .await?;
-
-    resp.json().await
+pub(super) struct SoucifyApiClient {
+    host: String,
 }
 
-pub(super) async fn verification_files(
-    params: &sourcify::types::ApiRequest,
-    sourcify_api_url: &str,
-) -> Result<sourcify::types::ApiFilesResponse, reqwest::Error> {
-    let url = format!(
-        "{}/files/any/{}/{}",
-        sourcify_api_url, params.chain, params.address
-    );
-    let resp = reqwest::Client::new().get(url).send().await?;
+impl SoucifyApiClient {
+    pub(super) fn new(host: &str) -> Self {
+        Self {
+            host: host.to_string(),
+        }
+    }
 
-    resp.json().await
+    pub(super) async fn verification(
+        &self,
+        params: &ApiRequest,
+    ) -> Result<ApiVerificationResponse, reqwest::Error> {
+        let resp = reqwest::Client::new()
+            .post(&self.host)
+            .json(&params)
+            .send()
+            .await?;
+
+        resp.json().await
+    }
+
+    pub(super) async fn source_files(
+        &self,
+        params: &ApiRequest,
+    ) -> Result<ApiFilesResponse, reqwest::Error> {
+        let url = format!(
+            "{host}/files/any/{chain}/{address}",
+            host = self.host,
+            chain = params.chain,
+            address = params.address,
+        );
+        let resp = reqwest::get(url).await?;
+
+        resp.json().await
+    }
 }

--- a/verification/src/http_server/handlers/verification/sourcify/metadata.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/metadata.rs
@@ -2,14 +2,65 @@ use ethers_solc::artifacts::Metadata;
 
 use crate::http_server::handlers::verification::VerificationResponse;
 
-pub struct MetadataContent<'a>(pub &'a String);
+use crate::http_server::handlers::verification::sourcify;
 
-impl<'a> TryFrom<MetadataContent<'a>> for VerificationResponse {
+use super::api::verification_files;
+
+const METADATA_FILE_NAME: &str = "metadata.json";
+
+impl TryFrom<Metadata> for VerificationResponse {
     type Error = anyhow::Error;
 
-    fn try_from(metadata_content: MetadataContent) -> Result<Self, Self::Error> {
-        let _metadata: Metadata =
-            serde_json::from_str(metadata_content.0.as_str()).map_err(anyhow::Error::msg)?;
-        todo!()
+    fn try_from(_metadata: Metadata) -> Result<Self, Self::Error> {
+        // let _contract_name = metadata
+        //     .settings
+        //     .compilation_target
+        //     .iter()
+        //     .next()
+        //     .ok_or(Self::Error::msg("compilation target not found"))?
+        //     .1;
+        // let _compiler_version = metadata.compiler.version;
+        // let _evm_version = todo!();
+        // let _contract_libraries = todo!();
+        // let _abi = serde_json::to_string(&metadata.output.abi)?;
+        // let _sources =
+
+        Ok(Self { verified: true })
     }
+}
+
+/// Tries to extract and parse metadata.json file from provided files.  
+/// If it cannot find metadata.json file, but contract is verified,
+/// probably this contract was verified by someone else before,
+/// then we need to make request to sourcify api to get metadata.json file.
+pub async fn try_extract_metadata(
+    params: &sourcify::types::ApiRequest,
+    sourcify_api_url: &str,
+) -> Result<Metadata, anyhow::Error> {
+    if let Some(metadata) = try_extract_provided_metadata(params) {
+        Ok(metadata)
+    } else {
+        try_extract_metadata_from_api(params, sourcify_api_url).await
+    }
+}
+
+fn try_extract_provided_metadata(params: &sourcify::types::ApiRequest) -> Option<Metadata> {
+    params
+        .files
+        .get(METADATA_FILE_NAME)
+        .and_then(|provided_metadata| serde_json::from_str(provided_metadata.as_str()).ok())
+}
+
+async fn try_extract_metadata_from_api(
+    params: &sourcify::types::ApiRequest,
+    sourcify_api_url: &str,
+) -> Result<Metadata, anyhow::Error> {
+    let response = verification_files(params, sourcify_api_url).await?;
+    let metadata_file = response
+        .files
+        .into_iter()
+        .find(|f| f.name == METADATA_FILE_NAME)
+        .ok_or_else(|| anyhow::Error::msg(format!("file {} not found", METADATA_FILE_NAME)))?;
+
+    serde_json::from_str(metadata_file.content.as_str()).map_err(anyhow::Error::msg)
 }

--- a/verification/src/http_server/handlers/verification/sourcify/metadata.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/metadata.rs
@@ -1,0 +1,15 @@
+use ethers_solc::artifacts::Metadata;
+
+use crate::http_server::handlers::verification::VerificationResponse;
+
+pub struct MetadataContent<'a>(pub &'a String);
+
+impl<'a> TryFrom<MetadataContent<'a>> for VerificationResponse {
+    type Error = anyhow::Error;
+
+    fn try_from(metadata_content: MetadataContent) -> Result<Self, Self::Error> {
+        let _metadata: Metadata =
+            serde_json::from_str(metadata_content.0.as_str()).map_err(anyhow::Error::msg)?;
+        todo!()
+    }
+}

--- a/verification/src/http_server/handlers/verification/sourcify/metadata.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/metadata.rs
@@ -1,50 +1,187 @@
-use ethers_solc::artifacts::Metadata;
+use std::collections::BTreeMap;
 
-use crate::http_server::handlers::verification::VerificationResponse;
+use ethers_solc::EvmVersion;
+use serde::Deserialize;
+
+use crate::VerificationResult;
 
 use super::types::Files;
 
 const METADATA_FILE_NAME: &str = "metadata.json";
 
-impl TryFrom<Files> for VerificationResponse {
-    type Error = anyhow::Error;
+#[derive(Debug, PartialEq, Deserialize)]
 
-    fn try_from(files: Files) -> Result<Self, Self::Error> {
-        let metadata = Metadata::try_from(files)?;
-        let _contract_name = metadata
-            .settings
-            .compilation_target
-            .iter()
-            .next()
-            .ok_or_else(|| anyhow::Error::msg("compilation target not found"))?
-            .1;
-        let _compiler_version = metadata.compiler.version;
-        let _evm_version = metadata.settings.inner.evm_version.unwrap_or_default();
-        let _contract_libraries = metadata.settings.inner.libraries;
-        let _abi = serde_json::to_string(&metadata.output.abi)?;
-
-        // let _sources = files
-        //     .0
-        //     .into_iter()
-        //     .filter(|(name, _)| !name.ends_with(METADATA_FILE_NAME));
-
-        log::info!("{:?}", _abi);
-
-        todo!()
-    }
+pub struct Metadata {
+    pub settings: MetadataSettings,
+    pub compiler: Compiler,
+    pub output: Output,
 }
 
-impl TryFrom<Files> for Metadata {
+#[derive(Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataSettings {
+    pub compilation_target: BTreeMap<String, String>,
+    pub optimizer: Optimizer,
+    pub libraries: BTreeMap<String, String>,
+    #[serde(rename = "camelCase")]
+    pub evm_version: Option<EvmVersion>,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Optimizer {
+    pub enabled: Option<bool>,
+    pub runs: Option<usize>,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Compiler {
+    pub version: String,
+}
+
+#[derive(Debug, PartialEq, Deserialize)]
+pub struct Output {
+    pub abi: serde_json::Value,
+}
+
+impl TryFrom<&Files> for Metadata {
     type Error = anyhow::Error;
 
-    fn try_from(files: Files) -> Result<Self, Self::Error> {
+    fn try_from(files: &Files) -> Result<Self, Self::Error> {
         let metadata_content = files
             .0
             .get(METADATA_FILE_NAME)
             .ok_or_else(|| anyhow::Error::msg(format!("file {} not found", METADATA_FILE_NAME)))?;
 
-        serde_json::from_str(metadata_content.as_str()).map_err(Self::Error::msg)
+        serde_json::from_str(metadata_content.as_str()).map_err(anyhow::Error::msg)
     }
 }
 
-// TODO: tests
+impl TryFrom<Files> for VerificationResult {
+    type Error = anyhow::Error;
+
+    fn try_from(files: Files) -> Result<Self, Self::Error> {
+        let metadata = Metadata::try_from(&files)?;
+        let contract_name = metadata
+            .settings
+            .compilation_target
+            .iter()
+            .next()
+            .ok_or_else(|| anyhow::Error::msg("compilation target not found"))?
+            .1
+            .to_string();
+        let compiler_version = metadata.compiler.version;
+        let evm_version = metadata
+            .settings
+            .evm_version
+            .unwrap_or_default()
+            .to_string();
+        let optimization_runs = metadata.settings.optimizer.enabled.and_then(|enabled| {
+            if enabled {
+                metadata.settings.optimizer.runs
+            } else {
+                None
+            }
+        });
+        let contract_libraries = metadata.settings.libraries;
+        let abi = serde_json::to_string(&metadata.output.abi)?;
+        let sources = files
+            .0
+            .into_iter()
+            .filter(|(name, _)| !name.ends_with(METADATA_FILE_NAME))
+            .collect();
+
+        Ok(VerificationResult {
+            contract_name,
+            compiler_version,
+            evm_version,
+            // TODO: extract args
+            constructor_arguments: None,
+            contract_libraries,
+            optimization_runs,
+            abi,
+            sources,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const DEFAULT_METADATA: &str = r#"{
+        "compiler": {
+            "version": "0.8.14+commit.80d49f37"
+        },
+        "output": {
+            "abi": [{"inputs":[],"name":"retrieve","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]
+        },
+        "settings": {
+            "compilationTarget": {
+                "example.sol": "Example"
+            },
+            "evmVersion": "london",
+            "libraries": {
+                "SafeMath": "0xFBe36e5cAD207d5fDee40E6568bb276a351f6713"
+            },
+            "optimizer": {
+                "enabled": false,
+                "runs": 200
+            }
+        }
+    }"#;
+
+    #[test]
+    fn parse_metadata_from_files() {
+        let mut files = Files(BTreeMap::from([
+            ("source.sol".into(), "content".into()),
+            (METADATA_FILE_NAME.into(), DEFAULT_METADATA.into()),
+        ]));
+
+        let meta = Metadata::try_from(&files);
+        assert!(
+            meta.is_ok(),
+            "Parse metadata from files failed: {}",
+            meta.unwrap_err()
+        );
+
+        files.0.remove(METADATA_FILE_NAME.into());
+        let meta = Metadata::try_from(&files);
+        assert!(meta.is_err(), "Parsing files without metadata should fail",);
+    }
+
+    #[test]
+    fn parse_response_from_files() {
+        let files = Files(BTreeMap::from([
+            ("source.sol".into(), "content".into()),
+            (METADATA_FILE_NAME.into(), DEFAULT_METADATA.into()),
+        ]));
+
+        let verification_result = VerificationResult::try_from(files);
+        assert!(
+            verification_result.is_ok(),
+            "Parse response from files failed: {}",
+            verification_result.unwrap_err()
+        );
+        assert_eq!(
+            verification_result.unwrap(),
+            VerificationResult {
+                contract_name: "Example".into(),
+                compiler_version: "0.8.14+commit.80d49f37".into(),
+                evm_version: "london".into(),
+                constructor_arguments: None,
+                contract_libraries: BTreeMap::from([("SafeMath".into(), "0xFBe36e5cAD207d5fDee40E6568bb276a351f6713".into())]),
+                optimization_runs: None,
+                abi: r#"[{"inputs":[],"name":"retrieve","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"}]"#.into(),
+                sources: BTreeMap::from([("source.sol".into(), "content".into())]),
+            }
+        );
+
+        let files = Files(BTreeMap::from([("source.sol".into(), "content".into())]));
+
+        let verification_result = VerificationResult::try_from(files);
+        assert!(
+            verification_result.is_err(),
+            "Parsing files without metadata should fail",
+        );
+    }
+}

--- a/verification/src/http_server/handlers/verification/sourcify/metadata.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/metadata.rs
@@ -2,65 +2,49 @@ use ethers_solc::artifacts::Metadata;
 
 use crate::http_server::handlers::verification::VerificationResponse;
 
-use crate::http_server::handlers::verification::sourcify;
-
-use super::api::verification_files;
+use super::types::Files;
 
 const METADATA_FILE_NAME: &str = "metadata.json";
 
-impl TryFrom<Metadata> for VerificationResponse {
+impl TryFrom<Files> for VerificationResponse {
     type Error = anyhow::Error;
 
-    fn try_from(_metadata: Metadata) -> Result<Self, Self::Error> {
-        // let _contract_name = metadata
-        //     .settings
-        //     .compilation_target
-        //     .iter()
-        //     .next()
-        //     .ok_or(Self::Error::msg("compilation target not found"))?
-        //     .1;
-        // let _compiler_version = metadata.compiler.version;
-        // let _evm_version = todo!();
-        // let _contract_libraries = todo!();
-        // let _abi = serde_json::to_string(&metadata.output.abi)?;
-        // let _sources =
+    fn try_from(files: Files) -> Result<Self, Self::Error> {
+        let metadata = Metadata::try_from(files)?;
+        let _contract_name = metadata
+            .settings
+            .compilation_target
+            .iter()
+            .next()
+            .ok_or_else(|| anyhow::Error::msg("compilation target not found"))?
+            .1;
+        let _compiler_version = metadata.compiler.version;
+        let _evm_version = metadata.settings.inner.evm_version.unwrap_or_default();
+        let _contract_libraries = metadata.settings.inner.libraries;
+        let _abi = serde_json::to_string(&metadata.output.abi)?;
+
+        // let _sources = files
+        //     .0
+        //     .into_iter()
+        //     .filter(|(name, _)| !name.ends_with(METADATA_FILE_NAME));
+
+        log::info!("{:?}", _abi);
 
         Ok(Self { verified: true })
     }
 }
 
-/// Tries to extract and parse metadata.json file from provided files.  
-/// If it cannot find metadata.json file, but contract is verified,
-/// probably this contract was verified by someone else before,
-/// then we need to make request to sourcify api to get metadata.json file.
-pub async fn try_extract_metadata(
-    params: &sourcify::types::ApiRequest,
-    sourcify_api_url: &str,
-) -> Result<Metadata, anyhow::Error> {
-    if let Some(metadata) = try_extract_provided_metadata(params) {
-        Ok(metadata)
-    } else {
-        try_extract_metadata_from_api(params, sourcify_api_url).await
+impl TryFrom<Files> for Metadata {
+    type Error = anyhow::Error;
+
+    fn try_from(files: Files) -> Result<Self, Self::Error> {
+        let metadata_content = files
+            .0
+            .get(METADATA_FILE_NAME)
+            .ok_or_else(|| anyhow::Error::msg(format!("file {} not found", METADATA_FILE_NAME)))?;
+
+        serde_json::from_str(metadata_content.as_str()).map_err(Self::Error::msg)
     }
 }
 
-fn try_extract_provided_metadata(params: &sourcify::types::ApiRequest) -> Option<Metadata> {
-    params
-        .files
-        .get(METADATA_FILE_NAME)
-        .and_then(|provided_metadata| serde_json::from_str(provided_metadata.as_str()).ok())
-}
-
-async fn try_extract_metadata_from_api(
-    params: &sourcify::types::ApiRequest,
-    sourcify_api_url: &str,
-) -> Result<Metadata, anyhow::Error> {
-    let response = verification_files(params, sourcify_api_url).await?;
-    let metadata_file = response
-        .files
-        .into_iter()
-        .find(|f| f.name == METADATA_FILE_NAME)
-        .ok_or_else(|| anyhow::Error::msg(format!("file {} not found", METADATA_FILE_NAME)))?;
-
-    serde_json::from_str(metadata_file.content.as_str()).map_err(anyhow::Error::msg)
-}
+// TODO: tests

--- a/verification/src/http_server/handlers/verification/sourcify/mod.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/mod.rs
@@ -1,7 +1,9 @@
+mod api;
 mod metadata;
 mod types;
 
-use self::metadata::MetadataContent;
+use self::api::verification_request;
+use self::metadata::try_extract_metadata;
 use self::types::{ApiRequest, ApiVerificationResponse};
 use crate::Config;
 use actix_web::web;
@@ -9,30 +11,22 @@ use actix_web::{error, error::Error, web::Json};
 
 use super::VerificationResponse;
 
-async fn verification_request(
-    config: &Config,
-    params: &ApiRequest,
+pub async fn verify(
+    config: web::Data<Config>,
+    params: Json<ApiRequest>,
 ) -> Result<Json<VerificationResponse>, Error> {
-    let resp = reqwest::Client::new()
-        .post(&config.sourcify.api_url)
-        .json(&params)
-        .send()
+    let params = params.into_inner();
+    let response = verification_request(&params, &config.sourcify.api_url)
         .await
         .map_err(error::ErrorInternalServerError)?;
 
-    let response_body: ApiVerificationResponse =
-        resp.json().await.map_err(error::ErrorInternalServerError)?;
-
-    match response_body {
+    match response {
         ApiVerificationResponse::Verified { result: _ } => {
-            // TODO: if metadata.json not found, make request to sourcify to get these files
-            let metadata_content = params
-                .files
-                .get("metadata.json")
-                .ok_or_else(|| error::ErrorBadRequest("metadata.json file not found"))?;
-            let _response =
-                VerificationResponse::try_from(MetadataContent(metadata_content)).unwrap();
-            Ok(Json(VerificationResponse { verified: true }))
+            let metadata = try_extract_metadata(&params, &config.sourcify.api_url)
+                .await
+                .map_err(error::ErrorInternalServerError)?;
+            let response = VerificationResponse::try_from(metadata).unwrap();
+            Ok(Json(response))
         }
         ApiVerificationResponse::Error { error } => Err(error::ErrorBadRequest(error)),
         ApiVerificationResponse::ValidationErrors { message, errors } => {
@@ -40,11 +34,4 @@ async fn verification_request(
             Err(error::ErrorBadRequest(error_message))
         }
     }
-}
-
-pub async fn verify(
-    config: web::Data<Config>,
-    params: Json<ApiRequest>,
-) -> Result<Json<VerificationResponse>, Error> {
-    verification_request(config.as_ref(), &params.into_inner()).await
 }

--- a/verification/src/http_server/handlers/verification/sourcify/types.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/types.rs
@@ -41,3 +41,14 @@ pub(super) struct FieldError {
     field: String,
     message: String,
 }
+
+#[derive(Deserialize, Debug)]
+pub(super) struct ApiFilesResponse {
+    pub files: Vec<FileItem>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(super) struct FileItem {
+    pub name: String,
+    pub content: String,
+}

--- a/verification/src/http_server/handlers/verification/sourcify/types.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/types.rs
@@ -19,7 +19,6 @@ pub struct Files(pub BTreeMap<String, String>);
 #[serde(untagged)]
 pub(super) enum ApiVerificationResponse {
     Verified {
-        #[allow(unused)]
         result: Vec<ResultItem>,
     },
     Error {
@@ -31,7 +30,6 @@ pub(super) enum ApiVerificationResponse {
     },
 }
 
-#[allow(unused)]
 #[derive(Deserialize)]
 pub(super) struct ResultItem {
     pub address: String,
@@ -40,7 +38,6 @@ pub(super) struct ResultItem {
     pub storage_timestamp: Option<String>,
 }
 
-#[allow(unused)]
 #[derive(Deserialize, Debug)]
 pub(super) struct FieldError {
     field: String,

--- a/verification/src/http_server/handlers/verification/sourcify/types.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/types.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 // This struct is used as input for our endpoint and as
 // input for sourcify endpoint at the same time
@@ -7,8 +7,11 @@ use std::collections::HashMap;
 pub struct ApiRequest {
     pub address: String,
     pub chain: String,
-    pub files: HashMap<String, String>,
+    pub files: Files,
 }
+
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+pub struct Files(pub BTreeMap<String, String>);
 
 // Definition of sourcify.dev API response
 // https://docs.sourcify.dev/docs/api/server/v1/verify/
@@ -31,8 +34,10 @@ pub(super) enum ApiVerificationResponse {
 #[allow(unused)]
 #[derive(Deserialize)]
 pub(super) struct ResultItem {
-    address: String,
-    status: String,
+    pub address: String,
+    pub status: String,
+    #[serde(rename = "storageTimestamp")]
+    pub storage_timestamp: Option<String>,
 }
 
 #[allow(unused)]
@@ -51,4 +56,14 @@ pub(super) struct ApiFilesResponse {
 pub(super) struct FileItem {
     pub name: String,
     pub content: String,
+}
+
+impl TryFrom<ApiFilesResponse> for Files {
+    type Error = anyhow::Error;
+
+    fn try_from(response: ApiFilesResponse) -> Result<Self, Self::Error> {
+        let files_map =
+            BTreeMap::from_iter(response.files.into_iter().map(|f| (f.name, f.content)));
+        Ok(Files(files_map))
+    }
 }

--- a/verification/src/http_server/handlers/verification/sourcify/types.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/types.rs
@@ -16,6 +16,7 @@ pub struct ApiRequest {
 #[serde(untagged)]
 pub(super) enum ApiVerificationResponse {
     Verified {
+        #[allow(unused)]
         result: Vec<ResultItem>,
     },
     Error {

--- a/verification/tests/sourcify.rs
+++ b/verification/tests/sourcify.rs
@@ -38,12 +38,79 @@ async fn should_return_200() {
         resp.status()
     );
 
-    let body: VerificationResponse = test::read_body_json(resp).await;
+    let body: serde_json::Value = test::read_body_json(resp).await;
     assert_eq!(
-        body.status,
-        VerificationStatus::Ok,
-        "invalid verification status",
-    )
+        body,
+        serde_json::json!({
+            "message": "OK",
+            "result": {
+                "contract_name": "Storage",
+                "compiler_version": "0.8.7+commit.e28d00a7",
+                "evm_version": "london",
+                "constructor_arguments": null,
+                "optimization_runs": null,
+                "contract_libraries": {},
+                "abi": "[{\"inputs\":[],\"name\":\"retrieve\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"store\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+                "sources": {
+                    "1_Storage.sol": "// SPDX-License-Identifier: GPL-3.0\n\npragma solidity >=0.7.0 <0.9.0;\n\n/**\n * @title Storage\n * @dev Store & retrieve value in a variable\n * @custom:dev-run-script ./scripts/deploy_with_ethers.ts\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retrieve() public view returns (uint256){\n        return number;\n    }\n}"
+                }
+            },
+            "status": "0"
+        }),
+    );
+}
 
-    // TODO: check response body and consider negative cases
+#[actix_rt::test]
+async fn invalid_contracts() {
+    let config = Config::parse().expect("Failed to parse config");
+    let mut app = test::init_service(
+        App::new().configure(|service_config| routes::config(service_config, config)),
+    )
+    .await;
+
+    let metadata_content = include_str!("contracts/storage/metadata.json");
+    for (request_body, error_message) in [
+        (
+            json!({
+                // relies on fact that the kovan HASN'T any contract with this address
+                "address": "0x1234567890123456789012345678901234567890",
+                "chain": "42",
+                "files": {"metadata.json": metadata_content},
+            }),
+            "Kovan does not have a contract",
+        ),
+        (
+            json!({
+                "address": "0x1234567890123456789012345678901234567890",
+                "chain": "42",
+                "files": {},
+            }),
+            "Metadata file not found",
+        ),
+        (
+            json!({
+                // relies on fact that kovan has some contract, but it is not verified in
+                // sourcify and `files` contains invalid source code
+                "address": "0x14132d1e8f4AaFCef230f5900bf8A3fFA4CCCC22",
+                "chain": "42",
+                "files": {
+                    "metadata.json": metadata_content,
+                    "source.sol": "",
+                },
+            }),
+            "deployed and recompiled bytecode don't match",
+        ),
+    ] {
+        let resp = TestRequest::get()
+            .uri("/api/v1/verification/sourcify")
+            .set_json(&request_body)
+            .send_request(&mut app)
+            .await;
+
+        let body: VerificationResponse = test::read_body_json(resp).await;
+
+        assert!(body.result.is_none());
+        assert_eq!(body.status, VerificationStatus::Failed);
+        assert!(body.message.contains(error_message));
+    }
 }


### PR DESCRIPTION
> NOTE: I noted that we had wrong structure for `libraries` field, I asked customer about it, so it is better to do it as JSON map, not list of JSON maps. So, I  replaced `ContractLibrary` with `BTreeMap`

Sourcify verification takes 3 steps (see `verify_using_sourcify_client`):

1. Make sourcify request for verification
2. If needed, make sourcify request to get actual source files
3. Construct response from actual source files

`SourcifyApiClient` struct is responsible for API calls

`Files` struct  is wrapper for BTreeMap. I implemented type conversion functions for it. These functions are used for constructing response from metadata and `.sol` sources.

Note that using trait `SourcifyApi` allow to use [mock](https://docs.rs/mockall/latest/mockall/) in tests. 
