### PR TITLE
fixed repo name + blocking

### DIFF
--- a/verification/src/http_server/handlers/verification/routes.rs
+++ b/verification/src/http_server/handlers/verification/routes.rs
@@ -6,7 +6,7 @@ use actix_web::web;
 pub fn config(service_config: &mut web::ServiceConfig) {
     let fetcher = tokio::task::block_in_place(move || {
         futures::executor::block_on(GithubFetcher::new(
-            "blockscout-rs",
+            "blockscout",
             "solc-bin",
             "compilers/".into(),
         ))

--- a/verification/src/http_server/handlers/verification/routes.rs
+++ b/verification/src/http_server/handlers/verification/routes.rs
@@ -4,14 +4,11 @@ use crate::{compiler::download_cache::DownloadCache, solidity::github_fetcher::G
 use actix_web::web;
 
 pub fn config(service_config: &mut web::ServiceConfig) {
-    let fetcher = tokio::task::block_in_place(move || {
-        futures::executor::block_on(GithubFetcher::new(
-            "blockscout",
-            "solc-bin",
-            "compilers/".into(),
-        ))
-    })
-    .expect("couldn't initialize github fetcher");
+    let fetcher = futures::executor::block_on(GithubFetcher::new(
+        "blockscout",
+        "solc-bin",
+        "compilers/".into(),
+    ));
     let cache = DownloadCache::new(fetcher);
     service_config
         .app_data(web::Data::new(cache))


### PR DESCRIPTION
Fixes repo name for fetching, also removes `block_in_place`, because we just want to block the thread here, while `block_in_place` tries to do smart things like moving the task from the thread, which is not needed here