### PR TITLE
fix tests: remove config parsing

### DIFF
--- a/verification/tests/sourcify.rs
+++ b/verification/tests/sourcify.rs
@@ -7,7 +7,7 @@ use verification::{routes, Config, VerificationResponse, VerificationStatus};
 
 #[actix_rt::test]
 async fn should_return_200() {
-    let config = Config::parse().expect("Failed to parse config");
+    let config = Config::default();
     let mut app = test::init_service(
         App::new().configure(|service_config| routes::config(service_config, config)),
     )


### PR DESCRIPTION
tests should not read from cli args