### PR TITLE
Update workflow: enable integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,26 +46,26 @@ jobs:
       - name: cargo test
         run: cargo test --locked --workspace --all-features --doc
 
-#  integration:
-#    name: Integration tests
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Checkout sources
-#        uses: actions/checkout@v2
-#
-#      - name: Install toolchain
-#        uses: actions-rs/toolchain@v1
-#        with:
-#          toolchain: stable
-#          profile: minimal
-#          override: true
-#      - name: Rust cache
-#        uses: Swatinem/rust-cache@v1
-#        with:
-#          cache-on-failure: true
-#
-#      - name: cargo test
-#        run: cargo test --locked --workspace --test '*'
+  integration:
+    name: Integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v1
+        with:
+          cache-on-failure: true
+
+      - name: cargo test
+        run: cargo test --locked --workspace --test '*'
 
   lint:
     name: Linting


### PR DESCRIPTION
Integration tests were disabled because corresponding workflow had been failing when there were no integration tests. This PR activates that workflow back