### PR TITLE
Update workflow: add imports granularity option to `cargo fmt`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
           cache-on-failure: true
 
       - name: cargo fmt
-        run: cargo fmt --all -- --check
+        run: cargo fmt --all -- --check --config imports_granularity=Crate
 
       - name: cargo clippy
         run: cargo clippy --all --all-features -- -D warnings

--- a/verification/src/config.rs
+++ b/verification/src/config.rs
@@ -2,8 +2,7 @@ use crate::cli;
 use clap::Parser;
 use config::{Config as LibConfig, File};
 use serde::Deserialize;
-use std::num::NonZeroUsize;
-use std::{net::SocketAddr, str::FromStr};
+use std::{net::SocketAddr, num::NonZeroUsize, str::FromStr};
 use url::Url;
 
 #[derive(Deserialize, Clone, Default)]

--- a/verification/src/http_server/handlers/mod.rs
+++ b/verification/src/http_server/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod status;
 pub mod verification;
 
-pub use self::verification::solidity::flatten;
-pub use self::verification::solidity::standard_json;
-pub use self::verification::sourcify;
+pub use self::verification::{
+    solidity::{flatten, standard_json},
+    sourcify,
+};

--- a/verification/src/http_server/handlers/verification/sourcify/api.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/api.rs
@@ -2,8 +2,7 @@ use crate::{VerificationResponse, VerificationResult};
 use actix_web::{error, error::Error};
 use futures::Future;
 use reqwest::Url;
-use std::num::NonZeroUsize;
-use std::sync::Arc;
+use std::{num::NonZeroUsize, sync::Arc};
 
 use super::types::{ApiFilesResponse, ApiRequest, ApiVerificationResponse, Files};
 

--- a/verification/src/http_server/handlers/verification/sourcify/mod.rs
+++ b/verification/src/http_server/handlers/verification/sourcify/mod.rs
@@ -5,8 +5,7 @@ mod types;
 pub use self::api::SourcifyApiClient;
 
 use self::types::ApiRequest;
-use actix_web::web;
-use actix_web::{error::Error, web::Json};
+use actix_web::{error::Error, web, web::Json};
 
 use super::VerificationResponse;
 

--- a/verification/src/http_server/routers/mod.rs
+++ b/verification/src/http_server/routers/mod.rs
@@ -4,8 +4,7 @@ mod sourcify;
 
 pub use self::app::AppRouter;
 
-use self::solidity::SolidityRouter;
-use self::sourcify::SourcifyRouter;
+use self::{solidity::SolidityRouter, sourcify::SourcifyRouter};
 
 pub trait Router {
     fn register_routes(&self, service_config: &mut actix_web::web::ServiceConfig);

--- a/verification/src/http_server/routers/solidity.rs
+++ b/verification/src/http_server/routers/solidity.rs
@@ -1,8 +1,11 @@
 use actix_web::web;
 
 use super::Router;
-use crate::http_server::handlers::{flatten, standard_json};
-use crate::{compiler::download_cache::DownloadCache, solidity::github_fetcher::GithubFetcher};
+use crate::{
+    compiler::download_cache::DownloadCache,
+    http_server::handlers::{flatten, standard_json},
+    solidity::github_fetcher::GithubFetcher,
+};
 
 pub struct SolidityRouter {
     cache: web::Data<DownloadCache<GithubFetcher>>,

--- a/verification/src/http_server/routers/sourcify.rs
+++ b/verification/src/http_server/routers/sourcify.rs
@@ -1,8 +1,10 @@
 use actix_web::web;
 
 use super::Router;
-use crate::config::SourcifyConfiguration;
-use crate::http_server::handlers::sourcify::{self, SourcifyApiClient};
+use crate::{
+    config::SourcifyConfiguration,
+    http_server::handlers::sourcify::{self, SourcifyApiClient},
+};
 
 pub struct SourcifyRouter {
     api_client: web::Data<SourcifyApiClient>,

--- a/verification/src/lib.rs
+++ b/verification/src/lib.rs
@@ -9,9 +9,8 @@ mod types;
 mod tests;
 
 pub use self::config::Config;
-pub use http_server::run as run_http_server;
 pub use http_server::{
     configure_router,
     handlers::verification::{VerificationResponse, VerificationResult, VerificationStatus},
-    AppRouter, Router,
+    run as run_http_server, AppRouter, Router,
 };

--- a/verification/src/main.rs
+++ b/verification/src/main.rs
@@ -1,5 +1,4 @@
-use verification::run_http_server;
-use verification::Config;
+use verification::{run_http_server, Config};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {


### PR DESCRIPTION
Adds a `imports_granularity=Crate` option for the `cargo fmt` check. Updates existing code to conform with the option.