### PR TITLE
Add containerization for multichain service

### DIFF
--- a/multichain-api-gateway/.dockerignore
+++ b/multichain-api-gateway/.dockerignore
@@ -1,0 +1,2 @@
+target
+.github

--- a/multichain-api-gateway/Dockerfile
+++ b/multichain-api-gateway/Dockerfile
@@ -1,0 +1,25 @@
+FROM rust:1 AS builder
+
+WORKDIR /build_app
+
+# Cache dependencies
+RUN cargo init
+COPY ./Cargo.toml ./
+RUN cargo build --release
+RUN rm -rf ./src
+
+# Build stage
+RUN apt update && apt install lld clang -y
+COPY . .
+
+RUN cargo build --release
+
+# Runtime stage
+FROM debian:bullseye-slim AS runtime
+
+RUN apt-get update && apt-get install -y libssl1.1 libssl-dev ca-certificates
+
+WORKDIR /app
+COPY --from=builder /build_app/target/release/multichain-api-gateway multichain-api-gateway
+
+ENTRYPOINT ["./multichain-api-gateway"]

--- a/multichain-api-gateway/docker-compose.yaml
+++ b/multichain-api-gateway/docker-compose.yaml
@@ -14,5 +14,3 @@ services:
     volumes:
       ## optional: you can use default config or provide custom via file
       - ./config/base.toml:/app/config.toml
-      ## optional: provide volume or folder to store compilers between launches
-      - /tmp/compilers:/tmp/compilers

--- a/multichain-api-gateway/docker-compose.yaml
+++ b/multichain-api-gateway/docker-compose.yaml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  multichain-api-gateway:
+    ## you can build an image locally, or use pre-built images from registry
+    build: .
+    ports:
+      - "8044:8044"
+    environment:
+      ## optional: if provided, would be used as a configuration file
+      - MULTICHAIN_API_GATEWAY__CONFIG=/app/config.toml
+    env_file:
+      ## optional: if provided, would overwrite values from configuration file
+      - config/base.env
+    volumes:
+      ## optional: you can use default config or provide custom via file
+      - ./config/base.toml:/app/config.toml
+      ## optional: provide volume or folder to store compilers between launches
+      - /tmp/compilers:/tmp/compilers


### PR DESCRIPTION
- Added Dockerfile
Example use:
```shell
docker build -f Dockerfile -t multichain-api-gateway .
docker run -dp 8044:8044 multichain-api-gateway
```

- Added docker-compose file
Example use:
```shell
docker-compose up -d
```

Also, I tried utilizing `cargo-chef` for dependencies building but met a strange error with the crates.io index