### PR TITLE
Github actions hot fix

### DIFF
--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -99,7 +99,7 @@ jobs:
   #       id: regex
   #       with:
   #         text: ${{ github.ref }}
-  #         regex: '^(refs\/tags\/sig-provider\/(v\d+\.\d+\.\d+))|(refs\/head\/(main))$'
+  #         regex: '^(refs\/tags\/sig-provider\/(v\d+\.\d+\.\d+))|(refs\/heads\/(main))$'
       
   #     - name: Extract tag name
   #       id: tags_extractor

--- a/.github/workflows/smart-contract-verifier.yml
+++ b/.github/workflows/smart-contract-verifier.yml
@@ -99,7 +99,7 @@ jobs:
         id: regex
         with:
           text: ${{ github.ref }}
-          regex: '^(refs\/tags\/smart-contract-verifier\/(v\d+\.\d+\.\d+))|(refs\/head\/(main))$'
+          regex: '^(refs\/tags\/smart-contract-verifier\/(v\d+\.\d+\.\d+))|(refs\/heads\/(main))$'
       
       - name: Extract tag name
         id: tags_extractor


### PR DESCRIPTION
When commit is `main`, `github.ref` [contains](https://docs.github.com/en/actions/learn-github-actions/contexts) `refs/heads/main`, not `refs/head/main`. this pr fixes this

![image](https://user-images.githubusercontent.com/41516657/198081411-f3c0d504-7cf3-45fd-813e-aee59ddc07e4.png)
