### PR TITLE
Change name of visualizer image

### DIFF
--- a/.github/workflows/visualizer.yml
+++ b/.github/workflows/visualizer.yml
@@ -11,7 +11,7 @@ name: Test, lint and docker (visualizer)
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: blockscout/visualizer-server
+  IMAGE_NAME: blockscout/visualizer
 
 defaults:
   run:


### PR DESCRIPTION
Old name was `visualizer-server`, we decided to remove `-server` suffix