### PR TITLE
Bump rust version to 1.65.0

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier-http/src/routers/solidity.rs
+++ b/smart-contract-verifier/smart-contract-verifier-http/src/routers/solidity.rs
@@ -16,7 +16,7 @@ pub struct SolidityRouter {
 }
 
 fn new_region(region: Option<String>, endpoint: Option<String>) -> Option<Region> {
-    let region = region.unwrap_or_else(|| "".to_string());
+    let region = region.unwrap_or_default();
     if let Some(endpoint) = endpoint {
         return Some(Region::Custom { region, endpoint });
     }

--- a/visualizer/visualizer/src/solidity/visualize_contracts.rs
+++ b/visualizer/visualizer/src/solidity/visualize_contracts.rs
@@ -45,7 +45,7 @@ pub async fn visualize_contracts(
             .arg("--hideFilename")
             .args(["-f", "svg"])
             .arg("-o")
-            .arg(&output_file)
+            .arg(output_file)
             .call()
             .await?;
 

--- a/visualizer/visualizer/src/solidity/visualize_storage.rs
+++ b/visualizer/visualizer/src/solidity/visualize_storage.rs
@@ -54,10 +54,10 @@ pub async fn visualize_storage(
             .arg("-c")
             .arg(&request.contract_name)
             .arg("-cf")
-            .arg(&file_name)
+            .arg(file_name)
             .args(["-f", "svg"])
             .arg("-o")
-            .arg(&output_file)
+            .arg(output_file)
             .call()
             .await?;
 


### PR DESCRIPTION
Fix `cargo clippy` warnings revealed after rust 1.65.0 update