### PR TITLE
Rename 2 type columns

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db/entity/src/bytecodes.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/bytecodes.rs
@@ -7,11 +7,11 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "bytecodes")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: i64,
     pub created_at: DateTime,
     pub updated_at: DateTime,
     pub source_id: i64,
-    pub r#type: BytecodeType,
+    pub bytecode_type: BytecodeType,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/files.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/files.rs
@@ -6,7 +6,7 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "files")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: i64,
     pub created_at: DateTime,
     pub updated_at: DateTime,
     pub name: String,

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/parts.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/parts.rs
@@ -7,10 +7,10 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "parts")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: i64,
     pub created_at: DateTime,
     pub updated_at: DateTime,
-    pub r#type: PartType,
+    pub part_type: PartType,
     pub data: Vec<u8>,
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/sea_orm_active_enums.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/sea_orm_active_enums.rs
@@ -11,6 +11,14 @@ pub enum PartType {
     Metadata,
 }
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "bytecode_type")]
+pub enum BytecodeType {
+    #[sea_orm(string_value = "creation_input")]
+    CreationInput,
+    #[sea_orm(string_value = "deployed_bytecode")]
+    DeployedBytecode,
+}
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "verification_type")]
 pub enum VerificationType {
     #[sea_orm(string_value = "flattened_contract")]
@@ -21,14 +29,6 @@ pub enum VerificationType {
     MultiPartFiles,
     #[sea_orm(string_value = "standard_json")]
     StandardJson,
-}
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "bytecode_type")]
-pub enum BytecodeType {
-    #[sea_orm(string_value = "creation_input")]
-    CreationInput,
-    #[sea_orm(string_value = "deployed_bytecode")]
-    DeployedBytecode,
 }
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "source_type")]

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/sources.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/sources.rs
@@ -7,7 +7,7 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "sources")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: i64,
     pub created_at: DateTime,
     pub updated_at: DateTime,
     pub source_type: SourceType,
@@ -22,23 +22,23 @@ pub struct Model {
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
-    #[sea_orm(has_many = "super::bytecodes::Entity")]
-    Bytecodes,
     #[sea_orm(has_many = "super::source_files::Entity")]
     SourceFiles,
+    #[sea_orm(has_many = "super::bytecodes::Entity")]
+    Bytecodes,
     #[sea_orm(has_many = "super::verified_contracts::Entity")]
     VerifiedContracts,
-}
-
-impl Related<super::bytecodes::Entity> for Entity {
-    fn to() -> RelationDef {
-        Relation::Bytecodes.def()
-    }
 }
 
 impl Related<super::source_files::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::SourceFiles.def()
+    }
+}
+
+impl Related<super::bytecodes::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Bytecodes.def()
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/verified_contracts.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/verified_contracts.rs
@@ -7,7 +7,7 @@ use sea_orm::entity::prelude::*;
 #[sea_orm(table_name = "verified_contracts")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: i64,
     pub created_at: DateTime,
     pub updated_at: DateTime,
     pub source_id: i64,

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
@@ -2,13 +2,17 @@ pub use sea_orm_migration::prelude::*;
 use sea_orm_migration::sea_orm::{ConnectionTrait, Statement, TransactionTrait};
 
 mod m20220101_000001_initial;
+mod m20221118_182727_rename_types;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20220101_000001_initial::Migration)]
+        vec![
+            Box::new(m20220101_000001_initial::Migration),
+            Box::new(m20221118_182727_rename_types::Migration),
+        ]
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20221118_182727_rename_types.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20221118_182727_rename_types.rs
@@ -1,0 +1,23 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+        ALTER TABLE bytecodes RENAME COLUMN type TO bytecode_type;
+        ALTER TABLE parts RENAME COLUMN type TO part_type;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+        ALTER TABLE bytecodes RENAME COLUMN bytecode_type TO type;
+        ALTER TABLE parts RENAME COLUMN part_type TO type;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+}


### PR DESCRIPTION
Re-generate entities to get valid type for `id` fields. Rename `bytecodes.type` and parts.type` to `bytecodes.bytecode_type` and `parts.part_type` correspondingly