### PR TITLE
Fix derive for solidity-metadata

### DIFF
--- a/libs/solidity-metadata/src/lib.rs
+++ b/libs/solidity-metadata/src/lib.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 /// (https://docs.soliditylang.org/en/v0.8.14/metadata.html#encoding-of-the-metadata-hash-in-the-bytecode).
 ///
 /// Currently we are interested only in `solc` value.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct MetadataHash {
     pub solc: Option<Version>,
 }
@@ -21,7 +21,7 @@ impl MetadataHash {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error, PartialEq, Eq, Hash)]
 enum ParseMetadataHashError {
     #[error("invalid solc type. Expected \"string\" or \"bytes\", found \"{0}\"")]
     InvalidSolcType(Type),


### PR DESCRIPTION
Added necessary Derive's to make the `solidity-metadata` library interface more user-convenient