### PR TITLE
Make http server to use camelCase

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier-proto/build.rs
+++ b/smart-contract-verifier/smart-contract-verifier-proto/build.rs
@@ -17,7 +17,7 @@ fn compile(
         .protoc_arg("grpc_api_configuration=proto/api_config_http.yaml,output_format=yaml,allow_merge=true,merge_file_name=smart-contract-verifier")
         .bytes(["."])
         .btree_map(["."])
-        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)] #[serde(rename_all = \"snake_case\")]");
+        .type_attribute(".", "#[actix_prost_macros::serde]");
     config.compile_protos(protos, includes)?;
     Ok(())
 }

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_multiple.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_multiple.rs
@@ -76,22 +76,22 @@ async fn test_setup(dir: &str, input: &mut TestInput) -> (ServiceResponse, Optio
 
     let request = if let Some(optimization_runs) = input.optimization_runs {
         json!({
-            "deployed_bytecode": input.deployed_bytecode.as_ref().unwrap(),
-            "creation_bytecode": input.creation_tx_input.as_ref(),
-            "compiler_version": input.compiler_version,
+            "deployedBytecode": input.deployed_bytecode.as_ref().unwrap(),
+            "creationBytecode": input.creation_tx_input.as_ref(),
+            "compilerVersion": input.compiler_version,
             "sources": BTreeMap::from([(contract_path, input.source_code.as_ref().unwrap())]),
-            "evm_version": input.evm_version,
-            "contract_libraries": input.contract_libraries,
-            "optimization_runs": optimization_runs
+            "evmVersion": input.evm_version,
+            "contractLibraries": input.contract_libraries,
+            "optimizationRuns": optimization_runs
         })
     } else {
         json!({
-            "deployed_bytecode": input.deployed_bytecode.as_ref().unwrap(),
-            "creation_bytecode": input.creation_tx_input.as_ref(),
-            "compiler_version": input.compiler_version,
+            "deployedBytecode": input.deployed_bytecode.as_ref().unwrap(),
+            "creationBytecode": input.creation_tx_input.as_ref(),
+            "compilerVersion": input.compiler_version,
             "sources": BTreeMap::from([(contract_path, input.source_code.as_ref().unwrap())]),
-            "evm_version": input.evm_version,
-            "contract_libraries": input.contract_libraries
+            "evmVersion": input.evm_version,
+            "contractLibraries": input.contract_libraries
         })
     };
 

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/sourcify.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/sourcify.rs
@@ -61,21 +61,21 @@ async fn should_return_200() {
         serde_json::json!({
             "message": "OK",
             "result": {
-                "file_name": "contracts/1_Storage.sol",
-                "contract_name": "Storage",
-                "compiler_version": "0.8.7+commit.e28d00a7",
-                "evm_version": "london",
-                "constructor_arguments": null,
+                "fileName": "contracts/1_Storage.sol",
+                "contractName": "Storage",
+                "compilerVersion": "0.8.7+commit.e28d00a7",
+                "evmVersion": "london",
+                "constructorArguments": null,
                 "optimization": false,
-                "optimization_runs": 200,
-                "contract_libraries": {},
+                "optimizationRuns": 200,
+                "contractLibraries": {},
                 "abi": "[{\"inputs\":[],\"name\":\"retrieve\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"store\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
                 "sources": {
                     "1_Storage.sol": "// SPDX-License-Identifier: GPL-3.0\n\npragma solidity >=0.7.0 <0.9.0;\n\n/**\n * @title Storage\n * @dev Store & retrieve value in a variable\n * @custom:dev-run-script ./scripts/deploy_with_ethers.ts\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retrieve() public view returns (uint256){\n        return number;\n    }\n}"
                 },
-                "compiler_settings": "{\"compilationTarget\":{\"contracts/1_Storage.sol\":\"Storage\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]}",
-                "local_creation_input_parts": [],
-                "local_deployed_bytecode_parts": []
+                "compilerSettings": "{\"compilationTarget\":{\"contracts/1_Storage.sol\":\"Storage\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]}",
+                "localCreationInputParts": [],
+                "localDeployedBytecodeParts": []
             },
             "status": "0"
         }),

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json.rs
@@ -76,9 +76,9 @@ async fn test_setup(dir: &str, input: &mut TestInput) -> (ServiceResponse, Optio
     });
 
     let request = json!({
-        "deployed_bytecode": input.deployed_bytecode.as_ref().unwrap(),
-        "creation_bytecode": input.creation_tx_input.as_ref(),
-        "compiler_version": input.compiler_version,
+        "deployedBytecode": input.deployed_bytecode.as_ref().unwrap(),
+        "creationBytecode": input.creation_tx_input.as_ref(),
+        "compilerVersion": input.compiler_version,
         "input": input.standard_input
     });
 

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/vyper.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/vyper.rs
@@ -73,9 +73,9 @@ async fn test_setup(test_case: &TestCase) -> ServiceResponse {
     .await;
 
     let request = serde_json::json!({
-        "deployed_bytecode": test_case.deployed_bytecode,
-        "creation_bytecode": test_case.creation_bytecode,
-        "compiler_version": test_case.compiler_version,
+        "deployedBytecode": test_case.deployed_bytecode,
+        "creationBytecode": test_case.creation_bytecode,
+        "compilerVersion": test_case.compiler_version,
         "sources": {
             format!("{}.vy", test_case.contract_name): test_case.source_code
         },


### PR DESCRIPTION
Make http server to use `camelCase` instead of `snake_case`. The reason is to use `#[actix_prost_macros::serde]` derivation, as without that enums are handled incorrectly