### PR TITLE
Extract verification request definition to be generic

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier/src/lib.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/lib.rs
@@ -9,6 +9,7 @@ mod compiler;
 mod consts;
 mod metrics;
 mod scheduler;
+mod verification_request;
 mod verifier;
 
 #[cfg(test)]

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/multi_part.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/multi_part.rs
@@ -1,9 +1,9 @@
 use super::client::Client;
 use crate::{
     compiler::Version,
+    verification_request,
     verifier::{ContractVerifier, Error, Success},
 };
-use bytes::Bytes;
 use ethers_solc::{
     artifacts::{BytecodeHash, Libraries, Settings, SettingsMetadata, Source, Sources},
     CompilerInput, EvmVersion,
@@ -11,14 +11,7 @@ use ethers_solc::{
 use semver::VersionReq;
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VerificationRequest {
-    pub deployed_bytecode: Bytes,
-    pub creation_bytecode: Option<Bytes>,
-    pub compiler_version: Version,
-
-    pub content: MultiFileContent,
-}
+pub type VerificationRequest = verification_request::VerificationRequest<MultiFileContent>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MultiFileContent {

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/standard_json.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/standard_json.rs
@@ -1,20 +1,14 @@
 use super::client::Client;
 use crate::{
-    compiler::Version,
+    verification_request,
     verifier::{ContractVerifier, Error, Success},
 };
-use bytes::Bytes;
 use ethers_solc::{artifacts::output_selection::OutputSelection, CompilerInput};
 use std::sync::Arc;
 
-pub struct VerificationRequest {
-    pub deployed_bytecode: Bytes,
-    pub creation_bytecode: Option<Bytes>,
-    pub compiler_version: Version,
+pub type VerificationRequest = verification_request::VerificationRequest<StandardJsonContent>;
 
-    pub content: StandardJsonContent,
-}
-
+#[derive(Debug, Clone)]
 pub struct StandardJsonContent {
     pub input: CompilerInput,
 }

--- a/smart-contract-verifier/smart-contract-verifier/src/verification_request.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/verification_request.rs
@@ -1,0 +1,23 @@
+use crate::compiler::Version;
+use bytes::Bytes;
+
+/// A request structure that is generic over its content.
+/// Is suitable only for verification methods implemented explicitly
+/// (currently, all options except Sourcify verification)
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerificationRequest<T> {
+    /// Deployed bytecode of the contract to be verified.
+    /// Is only used if creation bytecode was not provided.
+    /// Otherwise it is completely ignored.
+    pub deployed_bytecode: Bytes,
+    /// Creation transaction input of the contract to be verified.
+    /// If present, is used for the actual verification.
+    /// Otherwise, deployed bytecode argument is used.
+    pub creation_bytecode: Option<Bytes>,
+    /// Compiler version the contract being verified should be compiled with.
+    pub compiler_version: Version,
+
+    /// Verification method specific field. Contains all data that
+    /// the concrete method requires for the verification.
+    pub content: T,
+}

--- a/smart-contract-verifier/smart-contract-verifier/src/vyper/multi_part.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/vyper/multi_part.rs
@@ -1,23 +1,15 @@
 use super::client::Client;
 use crate::{
-    compiler::Version,
+    verification_request,
     verifier::{ContractVerifier, Error, Success},
 };
-use bytes::Bytes;
 use ethers_solc::{
     artifacts::{Settings, Source, Sources},
     CompilerInput, EvmVersion,
 };
 use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct VerificationRequest {
-    pub deployed_bytecode: Bytes,
-    pub creation_bytecode: Option<Bytes>,
-    pub compiler_version: Version,
-
-    pub content: MultiFileContent,
-}
+pub type VerificationRequest = verification_request::VerificationRequest<MultiFileContent>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MultiFileContent {


### PR DESCRIPTION
Extract verification request to be generic for all verification options. 

It is done to improve maintainability, as currently every verification option has the same (but its own) definition of that structure. All verification option-specific fields are stored inside a content anyway. If any of the common fields change, we would need to update it in all structures, which may become quite cumbersome task.

The reason we make it now, is because I am going to add one more verification option (for solidity metadata file, and probably for vyper standard json in the future), so it looked like a good place to make that extraction before.