### PR TITLE
Make test helpers optional to compile

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -40,3 +40,15 @@ rstest = "0.16"
 sea-orm = { version = "*", features = ["mock"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 url = "2.3"
+
+[features]
+# When activated includes and makes public helper methods for database filling
+test-bins = []
+
+[[bin]]
+name = "database_populate"
+required-features = ["test-bins"]
+
+[[bin]]
+name = "database_search"
+required-features = ["test-bins"]

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -42,13 +42,13 @@ tokio-stream = { version = "0.1", features = ["net"] }
 url = "2.3"
 
 [features]
-# When activated includes and makes public helper methods for database filling
-test-bins = []
+# When activated includes helper methods for tests and benchmarking
+test-utils = []
 
 [[bin]]
 name = "database_populate"
-required-features = ["test-bins"]
+required-features = ["test-utils"]
 
 [[bin]]
 name = "database_search"
-required-features = ["test-bins"]
+required-features = ["test-utils"]

--- a/eth-bytecode-db/eth-bytecode-db/src/lib.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod search;
 pub mod verification;
 
-#[cfg(feature = "test-bins")]
+#[cfg(feature = "test-utils")]
 pub mod tests;

--- a/eth-bytecode-db/eth-bytecode-db/src/lib.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod search;
-pub mod tests;
 pub mod verification;
+
+#[cfg(feature = "test-bins")]
+pub mod tests;

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/db.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/db.rs
@@ -10,14 +10,6 @@ use sea_orm::{
 };
 use std::collections::BTreeMap;
 
-#[cfg(feature = "test-bins")]
-pub async fn _insert_test_data(
-    db_client: &DatabaseConnection,
-    source_response: types::Source,
-) -> Result<i64, anyhow::Error> {
-    insert_data(db_client, source_response).await
-}
-
 pub(crate) async fn insert_data(
     db_client: &DatabaseConnection,
     source_response: types::Source,

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/db.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/db.rs
@@ -10,6 +10,14 @@ use sea_orm::{
 };
 use std::collections::BTreeMap;
 
+#[cfg(feature = "test-bins")]
+pub async fn _insert_test_data(
+    db_client: &DatabaseConnection,
+    source_response: types::Source,
+) -> Result<i64, anyhow::Error> {
+    insert_data(db_client, source_response).await
+}
+
 pub(crate) async fn insert_data(
     db_client: &DatabaseConnection,
     source_response: types::Source,

--- a/eth-bytecode-db/eth-bytecode-db/tests/test_search.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/test_search.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "test-bins")]
+
 use entity::sea_orm_active_enums::BytecodeType;
 use eth_bytecode_db::{
     search::{find_partial_match_contract, BytecodeRemote},

--- a/eth-bytecode-db/eth-bytecode-db/tests/test_search.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/test_search.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "test-bins")]
+#![cfg(feature = "test-utils")]
 
 use entity::sea_orm_active_enums::BytecodeType;
 use eth_bytecode_db::{


### PR DESCRIPTION
Add "test-bins" feature and make it required for test binaries and search test to compile. That allows us not to expose modules required only for testing purposes for library users. That way, the Api provided by the library is more concise.

That is a part of refactoring, where eventually we would like to extract the common functionality from verification and search modules.