### PR TITLE
Add postgres to eth-bytecode-db cicd

### DIFF
--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -23,6 +23,19 @@ jobs:
   test:
     name: Unit, doc and integration tests
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: admin
+          POSTGRES_USER: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -50,10 +63,11 @@ jobs:
         run: cargo test --locked --workspace --all-features --doc
         if: success() || failure()
 
-#       TODO: Uncomment when integration test added
-#      - name: Integration tests
-#        run: RUST_BACKTRACE=1 RUST_LOG=info cargo test --locked --workspace --test '*' -- --nocapture
-#        if: success() || failure()
+      - name: Integration tests
+        run: RUST_BACKTRACE=1 RUST_LOG=info cargo test --locked --workspace --test '*' -- --nocapture --include-ignored
+        if: success() || failure()
+        env:
+          DATABASE_URL: postgres://postgres:admin@localhost:5432/
 
   lint:
     name: Linting


### PR DESCRIPTION
Updates workflow to run tests with postgresql db as a dependency