### PR TITLE
Fix clippy warnings

### DIFF
--- a/sig-provider/sig-provider/src/aggregator.rs
+++ b/sig-provider/sig-provider/src/aggregator.rs
@@ -321,7 +321,7 @@ mod tests {
                 ]),
             ]),
         ]);
-        hex::encode(&res)
+        hex::encode(res)
     }
 
     #[tokio::test]

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/multi_part.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/multi_part.rs
@@ -38,8 +38,8 @@ impl From<MultiFileContent> for Vec<CompilerInput> {
             // so we assume that every file MAY contains all libraries
             let libs = content
                 .sources
-                .iter()
-                .map(|(filename, _)| (PathBuf::from(filename), libs.clone()))
+                .keys()
+                .map(|filename| (PathBuf::from(filename), libs.clone()))
                 .collect();
             settings.libraries = Libraries { libs };
         }


### PR DESCRIPTION
Fix `cargo clippy` warnings appeared after v1.66.0 rust release