### PR TITLE
Add compiler versions endpoints

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -75,7 +75,7 @@ dependencies = [
 [[package]]
 name = "actix-prost"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/actix-prost#90e4f961ecbce12cc81071e3e55da6045fb97d1b"
+source = "git+https://github.com/blockscout/actix-prost#6b3e058b8fa7ae9641f63b73627fed77f1418605"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -89,7 +89,7 @@ dependencies = [
 [[package]]
 name = "actix-prost-build"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/actix-prost#90e4f961ecbce12cc81071e3e55da6045fb97d1b"
+source = "git+https://github.com/blockscout/actix-prost#6b3e058b8fa7ae9641f63b73627fed77f1418605"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -104,7 +104,7 @@ dependencies = [
 [[package]]
 name = "actix-prost-macros"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/actix-prost#90e4f961ecbce12cc81071e3e55da6045fb97d1b"
+source = "git+https://github.com/blockscout/actix-prost#6b3e058b8fa7ae9641f63b73627fed77f1418605"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/eth-bytecode-db/eth-bytecode-db-proto/proto/api_config_http.yaml
+++ b/eth-bytecode-db/eth-bytecode-db-proto/proto/api_config_http.yaml
@@ -40,3 +40,9 @@ http:
     - selector: blockscout.ethBytecodeDb.v1.Sourcify.Verify
       post: /sourcify:verify
       body: "*"
+
+    - selector: blockscout.ethBytecodeDb.v1.Compilers.ListSolidityVersions
+      get: /compilers/solidity/versions
+
+    - selector: blockscout.ethBytecodeDb.v1.Compilers.ListVyperVersions
+      get: /compilers/vyper/versions

--- a/eth-bytecode-db/eth-bytecode-db-proto/proto/eth-bytecode-db.proto
+++ b/eth-bytecode-db/eth-bytecode-db-proto/proto/eth-bytecode-db.proto
@@ -28,6 +28,12 @@ service Sourcify {
   rpc Verify(VerifySourcifyRequest) returns (VerifyResponse) {}
 }
 
+service Compilers {
+  rpc ListSolidityVersions(ListVersionsRequest) returns (ListVersionsResponse) {}
+
+  rpc ListVyperVersions(ListVersionsRequest) returns (ListVersionsResponse) {}
+}
+
 message Source {
   /// The name of the file verified contract was located at
   string file_name = 1;
@@ -145,4 +151,11 @@ message VerifySourcifyRequest {
   map<string, string> source_files = 3;
   // (optional) see Sourcify Api
   optional int32 chosenContract = 4;
+}
+
+message ListVersionsRequest {}
+
+message ListVersionsResponse {
+  /// Compiler versions available
+  repeated string versions = 1;
 }

--- a/eth-bytecode-db/eth-bytecode-db-proto/swagger/eth-bytecode-db.swagger.yaml
+++ b/eth-bytecode-db/eth-bytecode-db-proto/swagger/eth-bytecode-db.swagger.yaml
@@ -6,6 +6,7 @@ tags:
   - name: CreationBytecodeDatabase
   - name: DeployedBytecodeDatabase
   - name: Sourcify
+  - name: Compilers
 consumes:
   - application/json
 produces:
@@ -171,6 +172,34 @@ paths:
             $ref: '#/definitions/v1SearchSourcesRequest'
       tags:
         - DeployedBytecodeDatabase
+  /compilers/solidity/versions:
+    get:
+      operationId: Compilers_ListSolidityVersions
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListVersionsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Compilers
+  /compilers/vyper/versions:
+    get:
+      operationId: Compilers_ListVyperVersions
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1ListVersionsResponse'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/googlerpcStatus'
+      tags:
+        - Compilers
   /sourcify:verify:
     post:
       operationId: Sourcify_Verify
@@ -234,6 +263,14 @@ definitions:
       '@type':
         type: string
     additionalProperties: {}
+  v1ListVersionsResponse:
+    type: object
+    properties:
+      versions:
+        type: array
+        items:
+          type: string
+        title: / Compiler versions available
   v1SearchSourcesRequest:
     type: object
     properties:


### PR DESCRIPTION
Adds `compilers/solidity/versions` and `compiler/vyper/versions` endpoints in proto definition. Those endpoints should return compiler versions which client may use for the verification. Internally, should just proxy GET requests to the `smart-contract-verifier`