### PR TITLE
Download protoc from static url

### DIFF
--- a/.github/actions/deps/action.yml
+++ b/.github/actions/deps/action.yml
@@ -11,23 +11,13 @@ runs:
     - id: install-protoc
       shell: bash
       run: |
-        curl -s https://api.github.com/repos/protocolbuffers/protobuf/releases/latest \
-          | grep "browser_download_url" \
-          | grep "protoc-.*-linux-x86_64" \
-          | cut -d : -f 2,3 \
-          | tr -d \" \
-          | xargs wget -O ./protoc.zip
+        wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -O ./protoc.zip
         unzip protoc.zip
         sudo mv ./include/* /usr/include/
         sudo mv ./bin/protoc /usr/bin/protoc
     - id: install-protoc-gen-openapiv2
       shell: bash
       run: |
-        curl -s https://api.github.com/repos/grpc-ecosystem/grpc-gateway/releases/latest \
-          | grep "browser_download_url" \
-          | grep "protoc-gen-openapiv2-.*-linux-x86_64" \
-          | cut -d : -f 2,3 \
-          | tr -d \" \
-          | xargs wget -O ./protoc-gen-openapiv2
+        wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-x86_64 -O ./protoc-gen-openapiv2
         chmod +x protoc-gen-openapiv2
         sudo mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - eth-bytecode-db/**
       - .github/workflows/eth-bytecode-db.yml
+      - .github/actions/deps/**
 
 name: Test, lint and docker (eth-bytecode-db)
 

--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - libs/**
       - .github/workflows/libs.yml
+      - .github/actions/deps/**
 
 name: Test, lint (libs)
 

--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - sig-provider/**
       - .github/workflows/sig-provider.yml
+      - .github/actions/deps/**
 
 
 name: Test, lint and docker (sig-provider)

--- a/.github/workflows/smart-contract-verifier.yml
+++ b/.github/workflows/smart-contract-verifier.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - smart-contract-verifier/**
       - .github/workflows/smart-contract-verifier.yml
+      - .github/actions/deps/**
 
 
 name: Test, lint and docker (smart-contract-verifier)

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - stats/**
       - .github/workflows/stats.yml
+      - .github/actions/deps/**
 
 
 name: Test, lint and docker (stats)

--- a/.github/workflows/visualizer.yml
+++ b/.github/workflows/visualizer.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - visualizer/**
       - .github/workflows/visualizer.yml
+      - .github/actions/deps/**
 
 
 name: Test, lint and docker (visualizer)


### PR DESCRIPTION
Currently we obtain the latest version of protoc from Github releases page obtained through Github API. As the request occurs for every service workflow, often the free limits are reached and some workflow fails.

This PR fixes that issue by fixing the link to download `protoc v21.12` and avoid Github Api requests