### PR TITLE
Add option to disable tracing 

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.1.0"
+version = "0.2.0"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/launch.rs
+++ b/libs/blockscout-service-launcher/src/launch.rs
@@ -24,7 +24,7 @@ pub async fn launch<R>(
 where
     R: HttpRouter + Send + Sync + Clone + 'static,
 {
-    init_logs(&settings.service_name, &settings.jaeger);
+    init_logs(&settings.service_name, &settings.tracing, &settings.jaeger);
     let metrics = Metrics::new(&settings.service_name, &settings.metrics.route);
 
     let mut futures = vec![];

--- a/libs/blockscout-service-launcher/src/launch.rs
+++ b/libs/blockscout-service-launcher/src/launch.rs
@@ -1,7 +1,7 @@
 use crate::{
     metrics::Metrics,
     router::{configure_router, HttpRouter},
-    settings::{JaegerSettings, MetricsSettings, ServerSettings},
+    settings::{JaegerSettings, MetricsSettings, ServerSettings, TracingSettings},
     tracing::init_logs,
 };
 use actix_web::{App, HttpServer};
@@ -12,6 +12,7 @@ pub struct LaunchSettings {
     pub service_name: String,
     pub server: ServerSettings,
     pub metrics: MetricsSettings,
+    pub tracing: TracingSettings,
     pub jaeger: JaegerSettings,
 }
 

--- a/libs/blockscout-service-launcher/src/settings.rs
+++ b/libs/blockscout-service-launcher/src/settings.rs
@@ -60,6 +60,20 @@ impl Default for MetricsSettings {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
+pub struct TracingSettings {
+    /// If disabled, tracing is not initialized for neither
+    /// stdout, nor jaeger (enabled by default).
+    pub enabled: bool,
+}
+
+impl Default for TracingSettings {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
 pub struct JaegerSettings {
     pub enabled: bool,
     pub agent_endpoint: String,

--- a/libs/blockscout-service-launcher/src/tracing.rs
+++ b/libs/blockscout-service-launcher/src/tracing.rs
@@ -5,9 +5,18 @@ use opentelemetry::{
 };
 use tracing_subscriber::{filter::LevelFilter, layer::SubscriberExt, prelude::*};
 
-use crate::JaegerSettings;
+use crate::{JaegerSettings, TracingSettings};
 
-pub fn init_logs(service_name: &str, jaeger_settings: &JaegerSettings) {
+pub fn init_logs(
+    service_name: &str,
+    tracing_settings: &TracingSettings,
+    jaeger_settings: &JaegerSettings,
+) {
+    // If tracing is disabled, there is nothing to initialize
+    if !tracing_settings.enabled {
+        return;
+    }
+
     let stdout = tracing_subscriber::fmt::layer().with_filter(
         tracing_subscriber::EnvFilter::builder()
             .with_default_directive(LevelFilter::INFO.into())


### PR DESCRIPTION
Add option to disable tracing completely when launching services. 

That may be required for integration tests, when the same process (though different tests) run several services. In that case, if always enabled, setting default registry would fail for the second service, as it is set globally and only once. An option to disable traces completely, helps to avoid that problem