### PR TITLE
Fix mocked range for average gas price

### DIFF
--- a/stats/stats/src/charts/lines/average_gas_price.rs
+++ b/stats/stats/src/charts/lines/average_gas_price.rs
@@ -46,7 +46,7 @@ impl crate::Chart for AverageGasPrice {
             .await?;
 
         // TODO: remove mock
-        let data = mocked_double_lines(0.000000004..0.0001)
+        let data = mocked_double_lines(5.0..200.0)
             .into_iter()
             .map(|item| item.active_model(id));
         insert_double_data_many(db, data).await?;


### PR DESCRIPTION
Value of average gas price should be in Gwei, not in Eth, therefore we have to change mocked range for this chart