### PR TITLE
Make init_logs public in service launcher

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.2.0"
+version = "0.3.0"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/launch.rs
+++ b/libs/blockscout-service-launcher/src/launch.rs
@@ -24,7 +24,7 @@ pub async fn launch<R>(
 where
     R: HttpRouter + Send + Sync + Clone + 'static,
 {
-    init_logs(&settings.service_name, &settings.tracing, &settings.jaeger);
+    let _ = init_logs(&settings.service_name, &settings.tracing, &settings.jaeger);
     let metrics = Metrics::new(&settings.service_name, &settings.metrics.route);
 
     let mut futures = vec![];

--- a/libs/blockscout-service-launcher/src/lib.rs
+++ b/libs/blockscout-service-launcher/src/lib.rs
@@ -4,6 +4,7 @@ mod router;
 mod settings;
 mod tracing;
 
+pub use crate::tracing::init_logs;
 pub use launch::{launch, LaunchSettings};
 pub use router::HttpRouter;
 pub use settings::*;

--- a/libs/blockscout-service-launcher/src/tracing.rs
+++ b/libs/blockscout-service-launcher/src/tracing.rs
@@ -11,10 +11,10 @@ pub fn init_logs(
     service_name: &str,
     tracing_settings: &TracingSettings,
     jaeger_settings: &JaegerSettings,
-) {
+) -> Result<(), anyhow::Error> {
     // If tracing is disabled, there is nothing to initialize
     if !tracing_settings.enabled {
-        return;
+        return Ok(());
     }
 
     let stdout = tracing_subscriber::fmt::layer().with_filter(
@@ -26,8 +26,7 @@ pub fn init_logs(
         // output logs (tracing) to stdout with log level taken from env (default is INFO)
         .with(stdout);
     if jaeger_settings.enabled {
-        let tracer = init_jaeger_tracer(service_name, &jaeger_settings.agent_endpoint)
-            .expect("failed to init tracer");
+        let tracer = init_jaeger_tracer(service_name, &jaeger_settings.agent_endpoint)?;
         registry
             // output traces to jaeger with default log level (default is DEBUG)
             .with(
@@ -38,8 +37,8 @@ pub fn init_logs(
             .try_init()
     } else {
         registry.try_init()
-    }
-    .expect("failed to register tracer with registry");
+    }?;
+    Ok(())
 }
 
 pub fn init_jaeger_tracer(


### PR DESCRIPTION
Make init logs as public function in order to initilize logs before starting server. 