### PR TITLE
Fix consensus=true bug

### DIFF
--- a/stats/stats/src/blockscout_indexing.rs
+++ b/stats/stats/src/blockscout_indexing.rs
@@ -16,7 +16,8 @@ pub async fn is_blockscout_indexing(
         min_block_saved = min_block_saved,
         "checking min block in blockscout database"
     );
-    Ok((min_block_blockscout < min_block_saved, min_block_blockscout))
+    let is_indexing = min_block_blockscout != min_block_saved;
+    Ok((is_indexing, min_block_blockscout))
 }
 
 #[derive(FromQueryResult)]
@@ -28,6 +29,7 @@ async fn get_min_block_blockscout(blockscout: &DatabaseConnection) -> Result<i64
     let min_block = blocks::Entity::find()
         .select_only()
         .column_as(Expr::col(blocks::Column::Number).min(), "min_block")
+        .filter(blocks::Column::Consensus.eq(true))
         .into_model::<MinBlock>()
         .one(blockscout)
         .await?;

--- a/stats/stats/src/charts/counters/average_block_time.rs
+++ b/stats/stats/src/charts/counters/average_block_time.rs
@@ -25,6 +25,7 @@ impl AverageBlockTime {
                         EPOCH FROM timestamp - lag(timestamp) OVER (ORDER BY timestamp)
                     ) as diff
                 FROM "blocks"
+                WHERE consensus = true
             ) t
             "#,
             vec![],

--- a/stats/stats/src/charts/counters/total_blocks.rs
+++ b/stats/stats/src/charts/counters/total_blocks.rs
@@ -41,6 +41,7 @@ impl crate::Chart for TotalBlocks {
             .select_only()
             .column_as(Expr::col(blocks::Column::Number).count(), "number")
             .column_as(Expr::col(blocks::Column::Timestamp).max(), "timestamp")
+            .filter(blocks::Column::Consensus.eq(true))
             .into_model::<TotalBlocksData>()
             .one(blockscout)
             .await?;

--- a/stats/stats/src/charts/insert.rs
+++ b/stats/stats/src/charts/insert.rs
@@ -3,9 +3,24 @@ use entity::chart_data;
 use sea_orm::{prelude::*, sea_query, ConnectionTrait, FromQueryResult, Set};
 
 #[derive(FromQueryResult)]
+pub struct DateValueDouble {
+    pub date: NaiveDate,
+    pub value: f64,
+}
+
+#[derive(FromQueryResult)]
 pub struct DateValue {
     pub date: NaiveDate,
     pub value: String,
+}
+
+impl From<DateValueDouble> for DateValue {
+    fn from(double: DateValueDouble) -> Self {
+        Self {
+            date: double.date,
+            value: double.value.to_string(),
+        }
+    }
 }
 
 impl DateValue {

--- a/stats/stats/src/tests/mock_blockscout.rs
+++ b/stats/stats/src/tests/mock_blockscout.rs
@@ -15,7 +15,7 @@ pub async fn fill_mock_blockscout_data(blockscout: &DatabaseConnection, max_date
     .await
     .unwrap();
 
-    let block_timestamps = vec![
+    let blocks = vec![
         "2022-11-09T23:59:59",
         "2022-11-10T00:00:00",
         "2022-11-10T12:00:00",
@@ -31,14 +31,14 @@ pub async fn fill_mock_blockscout_data(blockscout: &DatabaseConnection, max_date
         NaiveDateTime::from_str(val).unwrap().date() <= NaiveDate::from_str(max_date).unwrap()
     })
     .enumerate()
-    .map(|(ind, ts)| mock_block(ind as i64, ts))
+    .map(|(ind, ts)| mock_block(ind as i64, ts, true))
     .collect::<Vec<_>>();
-    blocks::Entity::insert_many(block_timestamps.clone())
+    blocks::Entity::insert_many(blocks.clone())
         .exec(blockscout)
         .await
         .unwrap();
 
-    let transactios = block_timestamps
+    let txns = blocks
         .iter()
         // make 1/3 of blocks empty
         .filter(|b| b.number.as_ref() % 3 != 1)
@@ -49,23 +49,39 @@ pub async fn fill_mock_blockscout_data(blockscout: &DatabaseConnection, max_date
                 (b.number.as_ref() * 1_123_456_789) % 70_000_000_000,
             )
         });
-    transactions::Entity::insert_many(transactios)
+    transactions::Entity::insert_many(txns)
+        .exec(blockscout)
+        .await
+        .unwrap();
+
+    let useless_blocks = [
+        "1970-01-01T00:00:00",
+        "2010-11-01T23:59:59",
+        "2022-11-08T12:00:00",
+    ]
+    .into_iter()
+    .filter(|val| {
+        NaiveDateTime::from_str(val).unwrap().date() <= NaiveDate::from_str(max_date).unwrap()
+    })
+    .enumerate()
+    .map(|(ind, ts)| mock_block((ind + blocks.len()) as i64, ts, false));
+    blocks::Entity::insert_many(useless_blocks)
         .exec(blockscout)
         .await
         .unwrap();
 }
 
-fn mock_block(index: i64, ts: &str) -> blocks::ActiveModel {
+fn mock_block(index: i64, ts: &str, consensus: bool) -> blocks::ActiveModel {
     blocks::ActiveModel {
         number: Set(index),
         hash: Set(index.to_le_bytes().to_vec()),
         timestamp: Set(NaiveDateTime::from_str(ts).unwrap()),
-        consensus: Set(Default::default()),
+        consensus: Set(consensus),
         gas_limit: Set(Default::default()),
         gas_used: Set(Default::default()),
         miner_hash: Set(Default::default()),
         nonce: Set(Default::default()),
-        parent_hash: Set(Default::default()),
+        parent_hash: Set((index - 1).to_le_bytes().to_vec()),
         inserted_at: Set(Default::default()),
         updated_at: Set(Default::default()),
         ..Default::default()


### PR DESCRIPTION
Blockscout can save unprepared blocks with `consensus = false` field. For extracing blocks blockscout always [uses](https://github.com/blockscout/blockscout/blob/102d9a338065b51c1eeb8e3e1c8a77202e6bd024/apps/explorer/lib/explorer/chain.ex#L2373) `consensus=true` filter, so we have to also use it