### PR TITLE
Fix general metrics namespace and labels

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.5.0"
+version = "0.5.1"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/metrics.rs
+++ b/libs/blockscout-service-launcher/src/metrics.rs
@@ -11,7 +11,7 @@ pub struct Metrics {
 impl Metrics {
     pub fn new(service_name: &str, endpoint: &str) -> Self {
         let registry = prometheus::default_registry();
-        let const_labels = HashMap::from([("service".into(), service_name.into())]);
+        let const_labels = HashMap::from([("rust_service".into(), service_name.into())]);
         let metrics_middleware = PrometheusMetricsBuilder::new("rust_microservices")
             .registry(registry.clone())
             .endpoint(endpoint)

--- a/libs/blockscout-service-launcher/src/metrics.rs
+++ b/libs/blockscout-service-launcher/src/metrics.rs
@@ -1,6 +1,6 @@
 use actix_web::{App, HttpServer};
 use actix_web_prom::{PrometheusMetrics, PrometheusMetricsBuilder};
-use std::net::SocketAddr;
+use std::{collections::HashMap, net::SocketAddr};
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -11,12 +11,13 @@ pub struct Metrics {
 impl Metrics {
     pub fn new(service_name: &str, endpoint: &str) -> Self {
         let registry = prometheus::default_registry();
-        let metrics_middleware =
-            PrometheusMetricsBuilder::new(&(service_name.to_owned() + "_metrics"))
-                .registry(registry.clone())
-                .endpoint(endpoint)
-                .build()
-                .unwrap();
+        let const_labels = HashMap::from([("service".into(), service_name.into())]);
+        let metrics_middleware = PrometheusMetricsBuilder::new("rust_microservices")
+            .registry(registry.clone())
+            .endpoint(endpoint)
+            .const_labels(const_labels)
+            .build()
+            .unwrap();
         let http_middleware = PrometheusMetricsBuilder::new(service_name)
             .registry(registry.clone())
             .build()

--- a/libs/blockscout-service-launcher/src/metrics.rs
+++ b/libs/blockscout-service-launcher/src/metrics.rs
@@ -11,7 +11,7 @@ pub struct Metrics {
 impl Metrics {
     pub fn new(service_name: &str, endpoint: &str) -> Self {
         let registry = prometheus::default_registry();
-        let const_labels = HashMap::from([("rust_service".into(), service_name.into())]);
+        let const_labels = HashMap::from([("service_name".into(), service_name.into())]);
         let metrics_middleware = PrometheusMetricsBuilder::new("rust_microservices")
             .registry(registry.clone())
             .endpoint(endpoint)


### PR DESCRIPTION
Fix actix metrics, so they will have the same name across all services with constant label pointing to specific service. It helps making one generic dashboard with parameter