### PR TITLE
Add max-body-size to server settings

### DIFF
--- a/libs/blockscout-db/migration/src/lib.rs
+++ b/libs/blockscout-db/migration/src/lib.rs
@@ -59,7 +59,7 @@ pub async fn from_sql(manager: &SchemaManager<'_>, content: &str) -> Result<(), 
             st.to_string(),
         ))
         .await
-        .map_err(|e| DbErr::Migration(format!("{}\nQuery: {}", e, st)))?;
+        .map_err(|e| DbErr::Migration(format!("{e}\nQuery: {st}")))?;
     }
     txn.commit().await
 }

--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.5.2"
+version = "0.6.0"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.5.1"
+version = "0.5.2"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/settings.rs
+++ b/libs/blockscout-service-launcher/src/settings.rs
@@ -13,6 +13,7 @@ pub struct ServerSettings {
 pub struct HttpServerSettings {
     pub enabled: bool,
     pub addr: SocketAddr,
+    pub max_body_size: usize,
 }
 
 impl Default for HttpServerSettings {
@@ -20,6 +21,7 @@ impl Default for HttpServerSettings {
         Self {
             enabled: true,
             addr: SocketAddr::from_str("0.0.0.0:8043").unwrap(),
+            max_body_size: 10 * 1024 * 1024, // 10 Mb
         }
     }
 }

--- a/libs/mismatch/src/lib.rs
+++ b/libs/mismatch/src/lib.rs
@@ -34,7 +34,7 @@ impl<T: fmt::Display> fmt::Display for Mismatch<T> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_fmt(format_args!("Expected {}", self.expected))?;
         match &self.found {
-            Some(found) => f.write_fmt(format_args!(", found {}", found)),
+            Some(found) => f.write_fmt(format_args!(", found {found}")),
             None => Ok(()),
         }
     }
@@ -53,10 +53,10 @@ mod test {
         let mismatch = Mismatch::new(expected, found);
 
         // when
-        let actual = format!("{}", mismatch);
+        let actual = format!("{mismatch}");
 
         // then
-        assert_eq!(format!("Expected {}, found {}", expected, found), actual);
+        assert_eq!(format!("Expected {expected}, found {found}"), actual);
     }
 
     #[test]
@@ -66,9 +66,9 @@ mod test {
         let mismatch = Mismatch::expected(expected);
 
         // when
-        let actual = format!("{}", mismatch);
+        let actual = format!("{mismatch}");
 
         // then
-        assert_eq!(format!("Expected {}", expected), actual);
+        assert_eq!(format!("Expected {expected}"), actual);
     }
 }

--- a/libs/solidity-metadata/src/lib.rs
+++ b/libs/solidity-metadata/src/lib.rs
@@ -133,7 +133,7 @@ mod metadata_hash_deserialization_tests {
             ParseMetadataHashError::InvalidSolcVersion(_) => "InvalidSolcVersion",
             ParseMetadataHashError::DuplicateKeys => "DuplicateKeys",
         };
-        format!("{:?}", error).contains(parse_metadata_hash_error_to_string(expected))
+        format!("{error:?}").contains(parse_metadata_hash_error_to_string(expected))
     }
 
     #[test]
@@ -206,7 +206,7 @@ mod metadata_hash_deserialization_tests {
         let first = "a2646970667358221220bcc988b1311237f2c00ccd0bfbd8b01d24dc18f720603b0de93fe6327df5362564736f6c634300080e";
         let second =
             "a165627a7a72305820d4fba422541feba2d648f6657d9354ec14ea9f5919b520abe0feb60981d7b17c";
-        let hex = format!("{}{}", first, second);
+        let hex = format!("{first}{second}");
         let encoded = DisplayBytes::from_str(&hex).unwrap().0;
         let expected = MetadataHash {
             solc: Some(Version::new(0, 8, 14)),


### PR DESCRIPTION
This PR starts fix error with limited max-body-size: https://github.com/blockscout/blockscout-rs/issues/307. It updates common library for starting blockscout servers. Next PR will update lib version in smart-contract-verifier
