### PR TITLE
eth-bytecode-db: run migrations on startup

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 eth-bytecode-db-proto = { path = "../eth-bytecode-db-proto" }
 eth-bytecode-db = { path = "../eth-bytecode-db" }
+migration = { path = "../eth-bytecode-db/migration" }
 
 actix-web = "4.2"
 amplify = { version = "3.13.0", features = ["derive"] }
@@ -23,7 +24,6 @@ tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 
 [dev-dependencies]
-migration = { path = "../eth-bytecode-db/migration" }
 smart-contract-verifier-proto = { path = "../../smart-contract-verifier/smart-contract-verifier-proto" }
 
 mockall = "0.11"

--- a/eth-bytecode-db/eth-bytecode-db-server/src/server.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/server.rs
@@ -15,6 +15,7 @@ use crate::{
 };
 use blockscout_service_launcher::LaunchSettings;
 use eth_bytecode_db::verification::Client;
+use migration::{Migrator, MigratorTrait};
 use std::sync::Arc;
 
 const SERVICE_NAME: &str = "eth_bytecode_db";
@@ -76,6 +77,10 @@ pub async fn run(settings: Settings) -> Result<(), anyhow::Error> {
     let health = Arc::new(HealthService::default());
 
     let db_connection = Arc::new(sea_orm::Database::connect(settings.database.url).await?);
+    if settings.database.run_migrations {
+        Migrator::up(&db_connection, None).await?;
+    }
+
     let client = Client::new_arc(db_connection.clone(), settings.verifier.uri).await?;
 
     let database = Arc::new(DatabaseService::new_arc(db_connection));

--- a/eth-bytecode-db/eth-bytecode-db-server/src/settings.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/settings.rs
@@ -45,6 +45,7 @@ pub struct Settings {
 #[serde(deny_unknown_fields)]
 pub struct DatabaseSettings {
     pub url: String,
+    pub run_migrations: bool,
 }
 
 #[serde_as]
@@ -78,7 +79,10 @@ impl Settings {
             metrics: Default::default(),
             tracing: Default::default(),
             jaeger: Default::default(),
-            database: DatabaseSettings { url: database_url },
+            database: DatabaseSettings {
+                url: database_url,
+                run_migrations: false,
+            },
             verifier: VerifierSettings { uri: verifier_uri },
             config_path: Default::default(),
         }


### PR DESCRIPTION
Add an option to run migrations on startup