### PR TITLE
Enable tls for tonic connections

### DIFF
--- a/deploy/values/eth-bytecode-db/values.yaml
+++ b/deploy/values/eth-bytecode-db/values.yaml
@@ -82,7 +82,7 @@ ethBytecodeDb:
     ETH_BYTECODE_DB__SERVER__HTTP__MAX_BODY_SIZE:
       _default: '10485760' # 10 Mb
     ETH_BYTECODE_DB__VERIFIER__URI:
-      _default: https://grpc.sc-verifier-test.aws-k8s.blockscout.com
+      _default: http://grpc.sc-verifier-test.aws-k8s.blockscout.com
     ETH_BYTECODE_DB__DATABASE__RUN_MIGRATIONS:
       _default: true
     ETH_BYTECODE_DB__TRACING__FORMAT:

--- a/deploy/values/eth-bytecode-db/values.yaml
+++ b/deploy/values/eth-bytecode-db/values.yaml
@@ -82,7 +82,7 @@ ethBytecodeDb:
     ETH_BYTECODE_DB__SERVER__HTTP__MAX_BODY_SIZE:
       _default: '10485760' # 10 Mb
     ETH_BYTECODE_DB__VERIFIER__URI:
-      _default: http://grpc.sc-verifier-test.aws-k8s.blockscout.com
+      _default: https://grpc.sc-verifier-test.aws-k8s.blockscout.com
     ETH_BYTECODE_DB__DATABASE__RUN_MIGRATIONS:
       _default: true
     ETH_BYTECODE_DB__TRACING__FORMAT:

--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -3382,6 +3382,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0167bac7a9f490495f3c33013e7722b53cb087ecbe082fb0c6387c96f634ea50"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,7 +4361,10 @@ dependencies = [
  "pin-project",
  "prost",
  "prost-derive",
+ "rustls-native-certs",
+ "rustls-pemfile",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tower",

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -28,7 +28,7 @@ smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscou
 solidity-metadata = "1.0"
 thiserror = "1.0"
 tokio = "1.22"
-tonic = { version = "0.8", features = ["channel"] }
+tonic = { version = "0.8", features = ["tls-roots"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"]}
 


### PR DESCRIPTION
Enables "tls-roots" features for tonic crate which makes the tonic automatically connect with tls if https schema is specified.
Updates deploy values for eth-bytecode-db to use https with verifier service