### PR TITLE
Handle the same sources

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
@@ -83,3 +83,28 @@ async fn test_verify_then_search(service: MockSolidityVerifierService) {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_verify_same_source_twice(service: MockSolidityVerifierService) {
+    let default_request = VerifySolidityMultiPartRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        evm_version: None,
+        optimization_runs: None,
+        source_files: Default::default(),
+        libraries: Default::default(),
+    };
+    let source_type = verification::SourceType::Solidity;
+    test_cases::test_verify_same_source_twice(
+        TEST_SUITE_NAME,
+        service,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
@@ -77,3 +77,25 @@ async fn test_verify_then_search(service: MockSolidityVerifierService) {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_verify_same_source_twice(service: MockSolidityVerifierService) {
+    let default_request = VerifySolidityStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+    };
+    let source_type = verification::SourceType::Solidity;
+    test_cases::test_verify_same_source_twice(
+        TEST_SUITE_NAME,
+        service,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/verification_test_helpers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/verification_test_helpers/mod.rs
@@ -253,7 +253,7 @@ pub mod test_cases {
         Service: VerifierService<smart_contract_verifier_v2::VerifyResponse>,
         Request: Serialize,
     {
-        let db = init_db(test_suite_name, "test_verify_then_search").await;
+        let db = init_db(test_suite_name, "test_verify_same_source_twice").await;
 
         let test_data = test_input_data::basic(source_type, MatchType::Full);
         let creation_input = test_data.creation_input().unwrap();

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
@@ -81,3 +81,27 @@ async fn test_verify_then_search(service: MockVyperVerifierService) {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_verify_same_source_twice(service: MockVyperVerifierService) {
+    let default_request = VerifyVyperMultiPartRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        evm_version: None,
+        source_files: Default::default(),
+        optimizations: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_verify_same_source_twice(
+        TEST_SUITE_NAME,
+        service,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -19,6 +19,7 @@ sea-orm = { version = "0.11", features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
     "macros",
+    "postgres-array",
 ] }
 futures = "0.3"
 semver = "1.0"

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/sea_orm_active_enums.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/sea_orm_active_enums.rs
@@ -3,14 +3,6 @@
 use sea_orm::entity::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "part_type")]
-pub enum PartType {
-    #[sea_orm(string_value = "main")]
-    Main,
-    #[sea_orm(string_value = "metadata")]
-    Metadata,
-}
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "verification_type")]
 pub enum VerificationType {
     #[sea_orm(string_value = "flattened_contract")]
@@ -23,6 +15,22 @@ pub enum VerificationType {
     StandardJson,
 }
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "bytecode_type")]
+pub enum BytecodeType {
+    #[sea_orm(string_value = "creation_input")]
+    CreationInput,
+    #[sea_orm(string_value = "deployed_bytecode")]
+    DeployedBytecode,
+}
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "part_type")]
+pub enum PartType {
+    #[sea_orm(string_value = "main")]
+    Main,
+    #[sea_orm(string_value = "metadata")]
+    Metadata,
+}
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "source_type")]
 pub enum SourceType {
     #[sea_orm(string_value = "solidity")]
@@ -31,12 +39,4 @@ pub enum SourceType {
     Vyper,
     #[sea_orm(string_value = "yul")]
     Yul,
-}
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "bytecode_type")]
-pub enum BytecodeType {
-    #[sea_orm(string_value = "creation_input")]
-    CreationInput,
-    #[sea_orm(string_value = "deployed_bytecode")]
-    DeployedBytecode,
 }

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/sources.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/sources.rs
@@ -18,6 +18,7 @@ pub struct Model {
     pub abi: Option<Json>,
     pub raw_creation_input: Vec<u8>,
     pub raw_deployed_bytecode: Vec<u8>,
+    pub file_ids_hash: Uuid,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
@@ -6,6 +6,7 @@ mod m20221122_222955_add_indexes;
 mod m20221130_231403_add_unique_files_name_and_content_index;
 mod m20221201_015147_add_unique_bytecodes_source_id_and_type_index;
 mod m20230222_194726_add_unique_parts_type_and_data_index;
+mod m20230227_014110_add_unique_source_index;
 
 pub struct Migrator;
 
@@ -18,6 +19,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221130_231403_add_unique_files_name_and_content_index::Migration),
             Box::new(m20221201_015147_add_unique_bytecodes_source_id_and_type_index::Migration),
             Box::new(m20230222_194726_add_unique_parts_type_and_data_index::Migration),
+            Box::new(m20230227_014110_add_unique_source_index::Migration),
         ]
     }
 }

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20220101_000001_initial_tables.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20220101_000001_initial_tables.rs
@@ -41,7 +41,8 @@ impl MigrationTrait for Migration {
               "contract_name" varchar NOT NULL,
               "abi" jsonb,
               "raw_creation_input" bytea NOT NULL,
-              "raw_deployed_bytecode" bytea NOT NULL
+              "raw_deployed_bytecode" bytea NOT NULL,
+              "file_ids_hash" uuid NOT NULL
             );
 
             CREATE TABLE "files" (

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20230227_014110_add_unique_source_index.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20230227_014110_add_unique_source_index.rs
@@ -1,0 +1,22 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+// (md5(row(col1, col2, col3)::uuid))
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            CREATE UNIQUE INDEX unique_source_index ON "sources"
+            ("compiler_version", md5("compiler_settings"::text), "file_name", "contract_name", "file_ids_hash");
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            DROP INDEX unique_source_index;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+}

--- a/eth-bytecode-db/eth-bytecode-db/src/search/match_contract.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/search/match_contract.rs
@@ -146,6 +146,7 @@ mod tests {
                 .unwrap(),
             created_at: Default::default(),
             updated_at: Default::default(),
+            file_ids_hash: Default::default(),
         }
     }
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
@@ -103,3 +103,15 @@ async fn test_historical_data_is_added_into_database(service: MockSolidityVerifi
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_same_source_results_stored_once(
+    service: MockSolidityVerifierService,
+) {
+    verification_test_helpers::test_verification_of_same_source_results_stored_once(
+        DB_PREFIX, service,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
@@ -97,3 +97,15 @@ async fn test_historical_data_is_added_into_database(service: MockSolidityVerifi
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_same_source_results_stored_once(
+    service: MockSolidityVerifierService,
+) {
+    verification_test_helpers::test_verification_of_same_source_results_stored_once(
+        DB_PREFIX, service,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -97,3 +97,13 @@ async fn test_historical_data_is_added_into_database(service: MockVyperVerifierS
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_same_source_results_stored_once(service: MockVyperVerifierService) {
+    verification_test_helpers::test_verification_of_same_source_results_stored_once(
+        DB_PREFIX, service,
+    )
+    .await;
+}


### PR DESCRIPTION
Before, if the same verification request sent more than once, all of them would create a new entry in the database. Then requesting for the sources for the given bytecode returned all those entries in the result, even though they all have been identical.

The PR fixes that problem, and makes sure that only distinct sources are stored into the database