### PR TITLE
eth-bytecode-db: add chain id and contract address verification metadata

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-proto/proto/v2/eth-bytecode-db.proto
+++ b/eth-bytecode-db/eth-bytecode-db-proto/proto/v2/eth-bytecode-db.proto
@@ -75,6 +75,13 @@ enum BytecodeType {
   DEPLOYED_BYTECODE = 2;
 }
 
+message VerificationMetadata {
+  /// Id of the chain the contract is verified on
+  string chain_id = 1;
+  /// The address of the contract to be verified
+  string contract_address = 2;
+}
+
 message VerifySolidityMultiPartRequest {
   /// Bytecode to compare local compilation result with
   string bytecode = 1;
@@ -91,6 +98,9 @@ message VerifySolidityMultiPartRequest {
   map<string, string> source_files = 6;
   /// Map from a library name to its address
   map<string, string> libraries = 7;
+
+  /// An optional field to be filled by explorers
+  optional VerificationMetadata metadata = 8;
 }
 
 message VerifySolidityStandardJsonRequest {
@@ -102,6 +112,9 @@ message VerifySolidityStandardJsonRequest {
   string compiler_version = 3;
   /// https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
   string input = 4;
+
+  /// An optional field to be filled by explorers
+  optional VerificationMetadata metadata = 5;
 }
 
 message VerifyVyperMultiPartRequest {
@@ -117,6 +130,9 @@ message VerifyVyperMultiPartRequest {
   optional bool optimizations = 5;
   /// Source file name to the actual source code
   map<string, string> source_files = 6;
+
+  /// An optional field to be filled by explorers
+  optional VerificationMetadata metadata = 7;
 }
 
 message VerifyResponse {

--- a/eth-bytecode-db/eth-bytecode-db-proto/swagger/v2/eth-bytecode-db.swagger.yaml
+++ b/eth-bytecode-db/eth-bytecode-db-proto/swagger/v2/eth-bytecode-db.swagger.yaml
@@ -279,6 +279,15 @@ definitions:
           type: string
       sourceType:
         $ref: '#/definitions/SourceSourceType'
+  v2VerificationMetadata:
+    type: object
+    properties:
+      chainId:
+        type: string
+        title: / Id of the chain the contract is verified on
+      contractAddress:
+        type: string
+        title: / The address of the contract to be verified
   v2VerifyResponse:
     type: object
     properties:
@@ -315,6 +324,9 @@ definitions:
         additionalProperties:
           type: string
         title: / Map from a library name to its address
+      metadata:
+        $ref: '#/definitions/v2VerificationMetadata'
+        title: / An optional field to be filled by explorers
       optimizationRuns:
         type: integer
         format: int32
@@ -341,6 +353,9 @@ definitions:
       input:
         type: string
         title: / https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description
+      metadata:
+        $ref: '#/definitions/v2VerificationMetadata'
+        title: / An optional field to be filled by explorers
   v2VerifySourcifyRequest:
     type: object
     properties:
@@ -379,6 +394,9 @@ definitions:
       evmVersion:
         type: string
         title: / Version of the EVM to compile for. If absent results in default EVM version
+      metadata:
+        $ref: '#/definitions/v2VerificationMetadata'
+        title: / An optional field to be filled by explorers
       optimizations:
         type: boolean
         title: / Flag enabling optimizations. If absent, default value is `true`

--- a/eth-bytecode-db/eth-bytecode-db-server/src/proto.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/proto.rs
@@ -4,6 +4,6 @@ pub use eth_bytecode_db_proto::blockscout::eth_bytecode_db::v2::{
     sourcify_verifier_server, verify_response, vyper_verifier_actix, vyper_verifier_server,
     BytecodeType, HealthCheckRequest, HealthCheckResponse, ListCompilerVersionsRequest,
     ListCompilerVersionsResponse, SearchSourcesRequest, SearchSourcesResponse, Source,
-    VerifyResponse, VerifySolidityMultiPartRequest, VerifySolidityStandardJsonRequest,
-    VerifySourcifyRequest, VerifyVyperMultiPartRequest,
+    VerificationMetadata, VerifyResponse, VerifySolidityMultiPartRequest,
+    VerifySolidityStandardJsonRequest, VerifySourcifyRequest, VerifyVyperMultiPartRequest,
 };

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/solidity_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/solidity_verifier.rs
@@ -4,7 +4,7 @@ use crate::{
         solidity_verifier_server, ListCompilerVersionsRequest, ListCompilerVersionsResponse,
         VerifyResponse, VerifySolidityMultiPartRequest, VerifySolidityStandardJsonRequest,
     },
-    types::BytecodeTypeWrapper,
+    types::{BytecodeTypeWrapper, VerificationMetadataWrapper},
 };
 use amplify::Wrapper;
 use async_trait::async_trait;
@@ -41,6 +41,10 @@ impl solidity_verifier_server::SolidityVerifier for SolidityVerifierService {
                 optimization_runs: request.optimization_runs,
                 libraries: request.libraries,
             },
+            metadata: request
+                .metadata
+                .map(|metadata| VerificationMetadataWrapper::from_inner(metadata).try_into())
+                .transpose()?,
         };
         let result = solidity_multi_part::verify(self.client.clone(), verification_request).await;
 
@@ -61,6 +65,10 @@ impl solidity_verifier_server::SolidityVerifier for SolidityVerifierService {
             content: solidity_standard_json::StandardJson {
                 input: request.input,
             },
+            metadata: request
+                .metadata
+                .map(|metadata| VerificationMetadataWrapper::from_inner(metadata).try_into())
+                .transpose()?,
         };
         let result =
             solidity_standard_json::verify(self.client.clone(), verification_request).await;

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
@@ -4,7 +4,7 @@ use crate::{
         vyper_verifier_server, ListCompilerVersionsRequest, ListCompilerVersionsResponse,
         VerifyResponse, VerifyVyperMultiPartRequest,
     },
-    types::BytecodeTypeWrapper,
+    types::{BytecodeTypeWrapper, VerificationMetadataWrapper},
 };
 use amplify::Wrapper;
 use async_trait::async_trait;
@@ -40,6 +40,10 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
                 evm_version: request.evm_version,
                 optimizations: request.optimizations,
             },
+            metadata: request
+                .metadata
+                .map(|metadata| VerificationMetadataWrapper::from_inner(metadata).try_into())
+                .transpose()?,
         };
         let result = vyper_multi_part::verify(self.client.clone(), verification_request).await;
 

--- a/eth-bytecode-db/eth-bytecode-db-server/src/types/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/types/mod.rs
@@ -1,7 +1,9 @@
 mod enums;
 mod source;
+mod verification_metadata;
 mod verify_response;
 
 pub use enums::{BytecodeTypeWrapper, MatchTypeWrapper, SourceTypeWrapper};
 pub use source::SourceWrapper;
+pub use verification_metadata::VerificationMetadataWrapper;
 pub use verify_response::VerifyResponseWrapper;

--- a/eth-bytecode-db/eth-bytecode-db-server/src/types/verification_metadata.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/types/verification_metadata.rs
@@ -1,0 +1,52 @@
+use crate::proto;
+use amplify::{From, Wrapper};
+use blockscout_display_bytes::Bytes as DisplayBytes;
+use eth_bytecode_db::verification;
+use std::str::FromStr;
+
+#[derive(Wrapper, From, Clone, Debug, PartialEq)]
+pub struct VerificationMetadataWrapper(proto::VerificationMetadata);
+
+impl TryFrom<VerificationMetadataWrapper> for verification::VerificationMetadata {
+    type Error = tonic::Status;
+
+    fn try_from(value: VerificationMetadataWrapper) -> Result<Self, Self::Error> {
+        let value = value.0;
+        Ok(verification::VerificationMetadata {
+            chain_id: i64::from_str(&value.chain_id)
+                .map_err(|_err| tonic::Status::invalid_argument("Invalid metadata.chain_id"))?,
+            contract_address: DisplayBytes::from_str(&value.contract_address)
+                .map_err(|_err| tonic::Status::invalid_argument("Invalid contract address"))?
+                .0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_proto_to_verification_metadata() {
+        let proto_type = proto::VerificationMetadata {
+            chain_id: "1".into(),
+            contract_address: "0xcafecafecafecafecafecafecafecafecafecafe".into(),
+        };
+
+        let expected = verification::VerificationMetadata {
+            chain_id: 1,
+            contract_address: DisplayBytes::from_str("0xcafecafecafecafecafecafecafecafecafecafe")
+                .unwrap()
+                .0,
+        };
+
+        let wrapper: VerificationMetadataWrapper = proto_type.into();
+        let result = verification::VerificationMetadata::try_from(wrapper);
+
+        assert_eq!(
+            result.expect("Valid metadata should not result in error"),
+            expected,
+            "Invalid metadata conversion result"
+        );
+    }
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
@@ -47,6 +47,7 @@ async fn test_returns_valid_source(service: MockSolidityVerifierService) {
         optimization_runs: None,
         source_files: Default::default(),
         libraries: Default::default(),
+        metadata: None,
     };
     let source_type = verification::SourceType::Solidity;
     test_cases::test_returns_valid_source(
@@ -72,6 +73,7 @@ async fn test_verify_then_search(service: MockSolidityVerifierService) {
         optimization_runs: None,
         source_files: Default::default(),
         libraries: Default::default(),
+        metadata: None,
     };
     let source_type = verification::SourceType::Solidity;
     test_cases::test_verify_then_search(
@@ -97,6 +99,7 @@ async fn test_verify_same_source_twice(service: MockSolidityVerifierService) {
         optimization_runs: None,
         source_files: Default::default(),
         libraries: Default::default(),
+        metadata: None,
     };
     let source_type = verification::SourceType::Solidity;
     test_cases::test_verify_same_source_twice(

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
@@ -44,6 +44,7 @@ async fn test_returns_valid_source(service: MockSolidityVerifierService) {
         bytecode_type: BytecodeType::CreationInput.into(),
         compiler_version: "".to_string(),
         input: "".to_string(),
+        metadata: None,
     };
     let source_type = verification::SourceType::Solidity;
     test_cases::test_returns_valid_source(
@@ -66,6 +67,7 @@ async fn test_verify_then_search(service: MockSolidityVerifierService) {
         bytecode_type: BytecodeType::CreationInput.into(),
         compiler_version: "".to_string(),
         input: "".to_string(),
+        metadata: None,
     };
     let source_type = verification::SourceType::Solidity;
     test_cases::test_verify_then_search(
@@ -88,6 +90,7 @@ async fn test_verify_same_source_twice(service: MockSolidityVerifierService) {
         bytecode_type: BytecodeType::CreationInput.into(),
         compiler_version: "".to_string(),
         input: "".to_string(),
+        metadata: None,
     };
     let source_type = verification::SourceType::Solidity;
     test_cases::test_verify_same_source_twice(

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
@@ -46,6 +46,7 @@ async fn test_returns_valid_source(service: MockVyperVerifierService) {
         evm_version: None,
         source_files: Default::default(),
         optimizations: None,
+        metadata: None,
     };
     let source_type = verification::SourceType::Vyper;
     test_cases::test_returns_valid_source(
@@ -70,6 +71,7 @@ async fn test_verify_then_search(service: MockVyperVerifierService) {
         evm_version: None,
         source_files: Default::default(),
         optimizations: None,
+        metadata: None,
     };
     let source_type = verification::SourceType::Vyper;
     test_cases::test_verify_then_search(
@@ -94,6 +96,7 @@ async fn test_verify_same_source_twice(service: MockVyperVerifierService) {
         evm_version: None,
         source_files: Default::default(),
         optimizations: None,
+        metadata: None,
     };
     let source_type = verification::SourceType::Vyper;
     test_cases::test_verify_same_source_twice(

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/sea_orm_active_enums.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/sea_orm_active_enums.rs
@@ -3,32 +3,12 @@
 use sea_orm::entity::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "verification_type")]
-pub enum VerificationType {
-    #[sea_orm(string_value = "flattened_contract")]
-    FlattenedContract,
-    #[sea_orm(string_value = "metadata")]
-    Metadata,
-    #[sea_orm(string_value = "multi_part_files")]
-    MultiPartFiles,
-    #[sea_orm(string_value = "standard_json")]
-    StandardJson,
-}
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "bytecode_type")]
 pub enum BytecodeType {
     #[sea_orm(string_value = "creation_input")]
     CreationInput,
     #[sea_orm(string_value = "deployed_bytecode")]
     DeployedBytecode,
-}
-#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
-#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "part_type")]
-pub enum PartType {
-    #[sea_orm(string_value = "main")]
-    Main,
-    #[sea_orm(string_value = "metadata")]
-    Metadata,
 }
 #[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "source_type")]
@@ -39,4 +19,24 @@ pub enum SourceType {
     Vyper,
     #[sea_orm(string_value = "yul")]
     Yul,
+}
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "part_type")]
+pub enum PartType {
+    #[sea_orm(string_value = "main")]
+    Main,
+    #[sea_orm(string_value = "metadata")]
+    Metadata,
+}
+#[derive(Debug, Clone, PartialEq, Eq, EnumIter, DeriveActiveEnum)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "verification_type")]
+pub enum VerificationType {
+    #[sea_orm(string_value = "flattened_contract")]
+    FlattenedContract,
+    #[sea_orm(string_value = "metadata")]
+    Metadata,
+    #[sea_orm(string_value = "multi_part_files")]
+    MultiPartFiles,
+    #[sea_orm(string_value = "standard_json")]
+    StandardJson,
 }

--- a/eth-bytecode-db/eth-bytecode-db/entity/src/verified_contracts.rs
+++ b/eth-bytecode-db/eth-bytecode-db/entity/src/verified_contracts.rs
@@ -15,6 +15,8 @@ pub struct Model {
     pub bytecode_type: BytecodeType,
     pub verification_settings: Json,
     pub verification_type: VerificationType,
+    pub chain_id: Option<i64>,
+    pub contract_address: Option<Vec<u8>>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
@@ -7,6 +7,7 @@ mod m20221130_231403_add_unique_files_name_and_content_index;
 mod m20221201_015147_add_unique_bytecodes_source_id_and_type_index;
 mod m20230222_194726_add_unique_parts_type_and_data_index;
 mod m20230227_014110_add_unique_source_index;
+mod m20230316_020341_verified_contracts_add_chain_id_contract_address_columns;
 
 pub struct Migrator;
 
@@ -20,6 +21,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20221201_015147_add_unique_bytecodes_source_id_and_type_index::Migration),
             Box::new(m20230222_194726_add_unique_parts_type_and_data_index::Migration),
             Box::new(m20230227_014110_add_unique_source_index::Migration),
+            Box::new(m20230316_020341_verified_contracts_add_chain_id_contract_address_columns::Migration),
         ]
     }
 }

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20230316_020341_verified_contracts_add_chain_id_contract_address_columns.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20230316_020341_verified_contracts_add_chain_id_contract_address_columns.rs
@@ -1,0 +1,25 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            ALTER TABLE "verified_contracts"
+            ADD COLUMN "chain_id" bigint,
+            ADD COLUMN "contract_address" bytea;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            ALTER TABLE "verified_contracts"
+            DROP COLUMN "chain_id",
+            DROP COLUMN "contract_address";
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+}

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
@@ -10,7 +10,7 @@ use super::{
     db,
     errors::Error,
     smart_contract_verifier,
-    types::{BytecodePart, BytecodeType, Source, VerificationType},
+    types::{BytecodePart, BytecodeType, Source, VerificationMetadata, VerificationType},
 };
 use anyhow::Context;
 use sea_orm::DatabaseConnection;
@@ -22,6 +22,7 @@ enum ProcessResponseAction {
         raw_request_bytecode: Vec<u8>,
         verification_settings: serde_json::Value,
         verification_type: VerificationType,
+        verification_metadata: Option<VerificationMetadata>,
     },
 }
 
@@ -103,6 +104,7 @@ async fn process_verify_response(
                 raw_request_bytecode,
                 verification_settings,
                 verification_type,
+                verification_metadata: _verification_metadata,
             } => {
                 let source_id = db::insert_data(db_client, source.clone())
                     .await

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
@@ -104,7 +104,7 @@ async fn process_verify_response(
                 raw_request_bytecode,
                 verification_settings,
                 verification_type,
-                verification_metadata: _verification_metadata,
+                verification_metadata,
             } => {
                 let source_id = db::insert_data(db_client, source.clone())
                     .await
@@ -118,6 +118,7 @@ async fn process_verify_response(
                     bytecode_type,
                     verification_settings,
                     verification_type,
+                    verification_metadata,
                 )
                 .await
                 .context("Insert verified contract data")?;

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
@@ -82,6 +82,7 @@ mod tests {
                 optimization_runs: Some(200),
                 libraries: BTreeMap::from([("lib1".into(), "0xcafe".into())]),
             },
+            metadata: None,
         };
         let expected = VerifySolidityMultiPartRequest {
             bytecode: "0x1234".to_string(),
@@ -117,6 +118,7 @@ mod tests {
                 optimization_runs: Some(200),
                 libraries: BTreeMap::from([("lib1".into(), "0xcafe".into())]),
             },
+            metadata: None,
         };
         let expected = VerifySolidityMultiPartRequest {
             bytecode: "0x1234".to_string(),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
@@ -40,6 +40,7 @@ pub async fn verify(
     let raw_request_bytecode = hex::decode(request.bytecode.clone().trim_start_matches("0x"))
         .map_err(|err| Error::InvalidArgument(format!("invalid bytecode: {err}")))?;
     let verification_settings = serde_json::json!(&request);
+    let verification_metadata = request.metadata.clone();
 
     let request: VerifySolidityMultiPartRequest = request.into();
     let response = client
@@ -57,6 +58,7 @@ pub async fn verify(
             raw_request_bytecode,
             verification_settings,
             verification_type: VerificationType::MultiPartFiles,
+            verification_metadata,
         },
     )
     .await

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
@@ -69,6 +69,7 @@ mod tests {
             content: StandardJson {
                 input: "standard_json_input".to_string(),
             },
+            metadata: None,
         };
         let expected = VerifySolidityStandardJsonRequest {
             bytecode: "0x1234".to_string(),
@@ -92,6 +93,7 @@ mod tests {
             content: StandardJson {
                 input: "standard_json_input".to_string(),
             },
+            metadata: None,
         };
         let expected = VerifySolidityStandardJsonRequest {
             bytecode: "0x1234".to_string(),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
@@ -33,6 +33,7 @@ pub async fn verify(
     let raw_request_bytecode = hex::decode(request.bytecode.clone().trim_start_matches("0x"))
         .map_err(|err| Error::InvalidArgument(format!("invalid bytecode: {err}")))?;
     let verification_settings = serde_json::json!(&request);
+    let verification_metadata = request.metadata.clone();
 
     let request: VerifySolidityStandardJsonRequest = request.into();
     let response = client
@@ -50,6 +51,7 @@ pub async fn verify(
             raw_request_bytecode,
             verification_settings,
             verification_type: VerificationType::StandardJson,
+            verification_metadata,
         },
     )
     .await

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -79,6 +79,7 @@ mod tests {
                     ("source_file2".into(), "content2".into()),
                 ]),
             },
+            metadata: None,
         };
         let expected = VerifyVyperMultiPartRequest {
             bytecode: "0x1234".to_string(),
@@ -112,6 +113,7 @@ mod tests {
                     ("source_file2".into(), "content2".into()),
                 ]),
             },
+            metadata: None,
         };
         let expected = VerifyVyperMultiPartRequest {
             bytecode: "0x1234".to_string(),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -38,6 +38,7 @@ pub async fn verify(
     let raw_request_bytecode = hex::decode(request.bytecode.clone().trim_start_matches("0x"))
         .map_err(|err| Error::InvalidArgument(format!("invalid bytecode: {err}")))?;
     let verification_settings = serde_json::json!(&request);
+    let verification_metadata = request.metadata.clone();
 
     let request: VerifyVyperMultiPartRequest = request.into();
     let response = client
@@ -55,6 +56,7 @@ pub async fn verify(
             raw_request_bytecode,
             verification_settings,
             verification_type: VerificationType::MultiPartFiles,
+            verification_metadata,
         },
     )
     .await

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/mod.rs
@@ -10,4 +10,7 @@ pub use errors::Error;
 pub use handlers::{
     compiler_versions, solidity_multi_part, solidity_standard_json, sourcify, vyper_multi_part,
 };
-pub use types::{BytecodePart, BytecodeType, MatchType, Source, SourceType, VerificationRequest};
+pub use types::{
+    BytecodePart, BytecodeType, MatchType, Source, SourceType, VerificationMetadata,
+    VerificationRequest,
+};

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/types.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/types.rs
@@ -173,12 +173,19 @@ pub struct Source {
 /********** Verification Request **********/
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationMetadata {
+    pub chain_id: i64,
+    pub contract_address: bytes::Bytes,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VerificationRequest<T> {
     pub bytecode: String,
     pub bytecode_type: BytecodeType,
     pub compiler_version: String,
     #[serde(flatten)]
     pub content: T,
+    pub metadata: Option<VerificationMetadata>,
 }
 
 /********** Verification Type **********/

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use entity::sea_orm_active_enums;
 use eth_bytecode_db::verification::{
     solidity_multi_part, solidity_multi_part::MultiPartFiles, Client, Error, Source, SourceType,
-    VerificationRequest,
+    VerificationMetadata, VerificationRequest,
 };
 use rstest::{fixture, rstest};
 use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
@@ -46,8 +46,12 @@ impl VerifierService<VerificationRequest<MultiPartFiles>> for MockSolidityVerifi
         SmartContractVerifierServer::new().solidity_service(self)
     }
 
-    fn generate_request(&self, id: u8) -> VerificationRequest<MultiPartFiles> {
-        generate_verification_request(id, default_request_content())
+    fn generate_request(
+        &self,
+        id: u8,
+        metadata: Option<VerificationMetadata>,
+    ) -> VerificationRequest<MultiPartFiles> {
+        generate_verification_request(id, default_request_content(), metadata)
     }
 
     fn source_type(&self) -> SourceType {
@@ -100,6 +104,18 @@ async fn test_historical_data_is_added_into_database(service: MockSolidityVerifi
         service,
         verification_settings,
         verification_type,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_historical_data_saves_chain_id_and_contract_address(
+    service: MockSolidityVerifierService,
+) {
+    verification_test_helpers::test_historical_data_saves_chain_id_and_contract_address(
+        DB_PREFIX, service,
     )
     .await;
 }

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use entity::sea_orm_active_enums;
 use eth_bytecode_db::verification::{
     solidity_standard_json, solidity_standard_json::StandardJson, Client, Error, Source,
-    SourceType, VerificationRequest,
+    SourceType, VerificationMetadata, VerificationRequest,
 };
 use rstest::{fixture, rstest};
 use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
@@ -43,8 +43,12 @@ impl VerifierService<VerificationRequest<StandardJson>> for MockSolidityVerifier
         SmartContractVerifierServer::new().solidity_service(self)
     }
 
-    fn generate_request(&self, id: u8) -> VerificationRequest<StandardJson> {
-        generate_verification_request(id, default_request_content())
+    fn generate_request(
+        &self,
+        id: u8,
+        metadata: Option<VerificationMetadata>,
+    ) -> VerificationRequest<StandardJson> {
+        generate_verification_request(id, default_request_content(), metadata)
     }
 
     fn source_type(&self) -> SourceType {
@@ -94,6 +98,18 @@ async fn test_historical_data_is_added_into_database(service: MockSolidityVerifi
         service,
         verification_settings,
         verification_type,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_historical_data_saves_chain_id_and_contract_address(
+    service: MockSolidityVerifierService,
+) {
+    verification_test_helpers::test_historical_data_saves_chain_id_and_contract_address(
+        DB_PREFIX, service,
     )
     .await;
 }

--- a/eth-bytecode-db/eth-bytecode-db/tests/sourcify.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/sourcify.rs
@@ -3,6 +3,7 @@ mod verification_test_helpers;
 use async_trait::async_trait;
 use eth_bytecode_db::verification::{
     sourcify, sourcify::VerificationRequest, Client, Error, Source, SourceType,
+    VerificationMetadata,
 };
 use rstest::{fixture, rstest};
 use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
@@ -30,7 +31,11 @@ impl VerifierService<VerificationRequest> for MockSourcifyVerifierService {
         SmartContractVerifierServer::new().sourcify_service(self)
     }
 
-    fn generate_request(&self, id: u8) -> VerificationRequest {
+    fn generate_request(
+        &self,
+        id: u8,
+        _metadata: Option<VerificationMetadata>,
+    ) -> VerificationRequest {
         VerificationRequest {
             address: "0x1234".to_string(),
             chain: "77".to_string(),

--- a/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/mod.rs
@@ -43,6 +43,7 @@ pub fn generate_verification_request<T>(id: u8, content: T) -> VerificationReque
         bytecode_type: BytecodeType::CreationInput,
         compiler_version: "compiler_version".to_string(),
         content,
+        metadata: None,
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/mod.rs
@@ -12,10 +12,10 @@ use entity::{
     verified_contracts,
 };
 use eth_bytecode_db::verification::{
-    BytecodeType, Client, Error, Source, SourceType, VerificationRequest,
+    BytecodeType, Client, Error, Source, SourceType, VerificationMetadata, VerificationRequest,
 };
 use pretty_assertions::assert_eq;
-use sea_orm::{DatabaseConnection, EntityTrait};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::VerifyResponse;
 use smart_contract_veriifer_mock::SmartContractVerifierServer;
 use std::{collections::HashSet, str::FromStr, sync::Arc};
@@ -30,20 +30,28 @@ pub trait VerifierService<Request> {
 
     fn build_server(self) -> SmartContractVerifierServer;
 
-    fn generate_request(&self, id: u8) -> Request;
+    fn generate_request(
+        &self,
+        id: u8,
+        verification_metadata: Option<VerificationMetadata>,
+    ) -> Request;
 
     fn source_type(&self) -> SourceType;
 
     async fn verify(client: Client, request: Request) -> Result<Source, Error>;
 }
 
-pub fn generate_verification_request<T>(id: u8, content: T) -> VerificationRequest<T> {
+pub fn generate_verification_request<T>(
+    id: u8,
+    content: T,
+    metadata: Option<VerificationMetadata>,
+) -> VerificationRequest<T> {
     VerificationRequest {
         bytecode: DisplayBytes::from([id]).to_string(),
         bytecode_type: BytecodeType::CreationInput,
         compiler_version: "compiler_version".to_string(),
         content,
-        metadata: None,
+        metadata,
     }
 }
 
@@ -87,7 +95,7 @@ where
 {
     let db = init_db(db_prefix, "test_returns_valid_source").await;
     let input_data =
-        test_input_data::input_data_1(service.generate_request(1), service.source_type());
+        test_input_data::input_data_1(service.generate_request(1, None), service.source_type());
     let client =
         start_server_and_init_client(db.client().clone(), service, vec![input_data.clone()]).await;
 
@@ -105,7 +113,7 @@ where
 {
     let source_type = service.source_type();
     let db = init_db(db_prefix, "test_data_is_added_into_database").await;
-    let input_data = test_input_data::input_data_1(service.generate_request(1), source_type);
+    let input_data = test_input_data::input_data_1(service.generate_request(1, None), source_type);
     let client =
         start_server_and_init_client(db.client().clone(), service, vec![input_data.clone()]).await;
 
@@ -397,7 +405,7 @@ where
 pub async fn test_historical_data_is_added_into_database<Service, Request>(
     db_prefix: &str,
     service: Service,
-    verification_settings: serde_json::Value,
+    mut verification_settings: serde_json::Value,
     verification_type: sea_orm_active_enums::VerificationType,
 ) where
     Request: Clone,
@@ -405,7 +413,7 @@ pub async fn test_historical_data_is_added_into_database<Service, Request>(
 {
     let source_type = service.source_type();
     let db = init_db(db_prefix, "test_historical_data_is_added_into_database").await;
-    let input_data = test_input_data::input_data_1(service.generate_request(1), source_type);
+    let input_data = test_input_data::input_data_1(service.generate_request(1, None), source_type);
     let client =
         start_server_and_init_client(db.client().clone(), service, vec![input_data.clone()]).await;
 
@@ -446,17 +454,78 @@ pub async fn test_historical_data_is_added_into_database<Service, Request>(
         verified_contract.bytecode_type,
         "Invalid bytecode type"
     );
-    println!(
-        "{}",
-        serde_json::to_string(&verified_contract.verification_settings).unwrap()
-    );
+    verification_settings
+        .as_object_mut()
+        .expect("Verification settings is not a map")
+        .insert("metadata".into(), serde_json::Value::Null);
     assert_eq!(
         verification_settings, verified_contract.verification_settings,
-        "Invalid verificaiton settings"
+        "Invalid verification settings"
     );
     assert_eq!(
         verification_type, verified_contract.verification_type,
         "Invalid verification type"
+    );
+}
+
+pub async fn test_historical_data_saves_chain_id_and_contract_address<Service, Request>(
+    db_prefix: &str,
+    service: Service,
+) where
+    Request: Clone,
+    Service: VerifierService<Request>,
+{
+    let source_type = service.source_type();
+    let db = init_db(
+        db_prefix,
+        "test_historical_data_saves_chain_id_and_contract_address",
+    )
+    .await;
+    let chain_id = 1;
+    let contract_address = bytes::Bytes::from([10u8; 20].as_ref());
+    let input_data = test_input_data::input_data_1(
+        service.generate_request(
+            1,
+            Some(VerificationMetadata {
+                chain_id,
+                contract_address: contract_address.clone(),
+            }),
+        ),
+        source_type,
+    );
+    let client =
+        start_server_and_init_client(db.client().clone(), service, vec![input_data.clone()]).await;
+
+    let _source = Service::verify(client, input_data.request)
+        .await
+        .expect("Verification failed");
+
+    let db_client = db.client();
+    let db_client = db_client.as_ref();
+
+    let source_id = sources::Entity::find()
+        .one(db_client)
+        .await
+        .expect("Error while reading source")
+        .unwrap()
+        .id;
+
+    let verified_contract = verified_contracts::Entity::find()
+        .filter(verified_contracts::Column::SourceId.eq(source_id))
+        .one(db_client)
+        .await
+        .expect("Error while reading verified contracts")
+        .expect("No contract was found");
+
+    assert_eq!(
+        Some(chain_id),
+        verified_contract.chain_id,
+        "Invalid chain id saved"
+    );
+    assert_eq!(
+        Some(contract_address.to_vec()),
+        verified_contract.contract_address,
+        "Invalid contract address saved"
     );
 }
 
@@ -473,7 +542,7 @@ pub async fn test_verification_of_same_source_results_stored_once<Service, Reque
         "test_verification_of_same_source_results_stored_once",
     )
     .await;
-    let input_data = test_input_data::input_data_1(service.generate_request(1), source_type);
+    let input_data = test_input_data::input_data_1(service.generate_request(1, None), source_type);
     let client =
         start_server_and_init_client(db.client().clone(), service, vec![input_data.clone()]).await;
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use entity::sea_orm_active_enums;
 use eth_bytecode_db::verification::{
     vyper_multi_part, vyper_multi_part::MultiPartFiles, Client, Error, Source, SourceType,
-    VerificationRequest,
+    VerificationMetadata, VerificationRequest,
 };
 use rstest::{fixture, rstest};
 use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
@@ -41,8 +41,12 @@ impl VerifierService<VerificationRequest<MultiPartFiles>> for MockVyperVerifierS
         SmartContractVerifierServer::new().vyper_service(self)
     }
 
-    fn generate_request(&self, id: u8) -> VerificationRequest<MultiPartFiles> {
-        generate_verification_request(id, default_request_content())
+    fn generate_request(
+        &self,
+        id: u8,
+        metadata: Option<VerificationMetadata>,
+    ) -> VerificationRequest<MultiPartFiles> {
+        generate_verification_request(id, default_request_content(), metadata)
     }
 
     fn source_type(&self) -> SourceType {
@@ -94,6 +98,18 @@ async fn test_historical_data_is_added_into_database(service: MockVyperVerifierS
         service,
         verification_settings,
         verification_type,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_historical_data_saves_chain_id_and_contract_address(
+    service: MockVyperVerifierService,
+) {
+    verification_test_helpers::test_historical_data_saves_chain_id_and_contract_address(
+        DB_PREFIX, service,
     )
     .await;
 }


### PR DESCRIPTION
Add optional metadata when verifying contracts. For now that contains only chain id and contract address required for logging.