### PR TITLE
sig-provider: add tests for source apis

### DIFF
--- a/sig-provider/Cargo.lock
+++ b/sig-provider/Cargo.lock
@@ -63,7 +63,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -91,7 +91,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_yaml",
- "syn",
+ "syn 1.0.102",
  "thiserror",
 ]
 
@@ -102,7 +102,7 @@ source = "git+https://github.com/blockscout/actix-prost#90e4f961ecbce12cc81071e3
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -217,7 +217,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -410,6 +410,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e97ce7de6cf12de5d7226c73f5ba9811622f4db3a5b91b55c53e987e5f91cba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,7 +465,7 @@ checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -471,7 +482,7 @@ checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -861,7 +872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -919,7 +930,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -936,7 +947,7 @@ checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -960,7 +971,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -971,7 +982,7 @@ checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -997,7 +1008,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -1288,7 +1299,7 @@ checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -1601,7 +1612,7 @@ checksum = "11d7a9f6330b71fea57921c9b61c47ee6e84f72d394754eff6163ae67e7395eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -1941,7 +1952,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2067,7 +2078,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2220,7 +2231,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2300,7 +2311,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2356,7 +2367,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2452,7 +2463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2481,9 +2492,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2530,7 +2541,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.102",
  "tempfile",
  "which",
 ]
@@ -2545,7 +2556,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2566,9 +2577,9 @@ checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2792,7 +2803,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 1.0.102",
  "unicode-ident",
 ]
 
@@ -2901,7 +2912,7 @@ checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -2962,7 +2973,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -3013,6 +3024,7 @@ name = "sig-provider"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-recursion",
  "async-trait",
  "ethabi",
  "futures",
@@ -3187,6 +3199,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3264,7 +3287,7 @@ checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -3379,7 +3402,7 @@ checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -3468,7 +3491,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -3543,7 +3566,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
 ]
 
 [[package]]
@@ -3770,7 +3793,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -3804,7 +3827,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/sig-provider/Cargo.lock
+++ b/sig-provider/Cargo.lock
@@ -1304,6 +1304,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2765,6 +2771,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1bb486a691878cd320c2f0d319ba91eeaa2e894066d8b5f8f117c000e9d962"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290ca1a1c8ca7edb7c3283bd44dc35dd54fdec6253a3912e201ba1072018fca8"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2991,6 +3023,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
+ "rstest",
  "serde",
  "serde_json",
  "sig-provider-proto",

--- a/sig-provider/sig-provider/Cargo.toml
+++ b/sig-provider/sig-provider/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = "1.0"
 ethabi = "17"
 mockall = "0.11"
 itertools = "0.10"
+async-recursion = "1.0.0"
 
 [dev-dependencies]
 pretty_assertions = "1.3"

--- a/sig-provider/sig-provider/Cargo.toml
+++ b/sig-provider/sig-provider/Cargo.toml
@@ -23,3 +23,4 @@ itertools = "0.10"
 
 [dev-dependencies]
 pretty_assertions = "1.3"
+rstest = "0.17.0"

--- a/sig-provider/sig-provider/src/sources/fourbyte.rs
+++ b/sig-provider/sig-provider/src/sources/fourbyte.rs
@@ -84,3 +84,52 @@ mod json {
         pub results: Vec<Signature>,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    const DEFAULT_HOST: &str = "https://www.4byte.directory/";
+
+    #[rstest::fixture]
+    fn source() -> Source {
+        let host = url::Url::from_str(DEFAULT_HOST).expect("default host is not an url");
+        Source::new(host)
+    }
+
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn create(source: Source) {
+        let abi = r#"[{"constant":false,"inputs":[],"name":"f","outputs":[],"type":"function"},{"inputs":[],"type":"constructor"},{"anonymous":false,"inputs":[{"name":"","type":"string","indexed":true}],"name":"E","type":"event"}]"#;
+        source
+            .create_signatures(abi)
+            .await
+            .expect("error while submitting a new signature");
+    }
+
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn get_function_signatures(source: Source) {
+        let (signature, hex) = ("f()", "0x26121ff0");
+        let result = source
+            .get_function_signatures(hex)
+            .await
+            .expect("error while getting function signature");
+        assert!(result.contains(&signature.into()))
+    }
+
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn get_event_signatures(source: Source) {
+        let (signature, hex) = (
+            "E(string)",
+            "0x3e9992c940c54ea252d3a34557cc3d3014281525c43d694f89d5f3dfd820b07d",
+        );
+        let result = source
+            .get_event_signatures(hex)
+            .await
+            .expect("error while getting event signature");
+        assert!(result.contains(&signature.into()))
+    }
+}

--- a/sig-provider/sig-provider/src/sources/mod.rs
+++ b/sig-provider/sig-provider/src/sources/mod.rs
@@ -4,7 +4,7 @@ pub mod sigeth;
 use async_trait::async_trait;
 use mockall::automock;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
-use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware, Retryable};
 use std::time::Duration;
 
 #[automock]
@@ -21,13 +21,9 @@ pub trait SignatureSource {
 }
 
 pub fn new_client() -> ClientWithMiddleware {
-    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
-    ClientBuilder::new(
-        reqwest::Client::builder()
-            .timeout(Duration::from_secs(10))
-            .build()
-            .unwrap(),
-    )
-    .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-    .build()
+    let retry_policy =
+        ExponentialBackoff::builder().build_with_total_retry_duration(Duration::from_secs(10));
+    ClientBuilder::new(reqwest::Client::builder().build().unwrap())
+        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+        .build()
 }

--- a/sig-provider/sig-provider/src/sources/mod.rs
+++ b/sig-provider/sig-provider/src/sources/mod.rs
@@ -21,9 +21,13 @@ pub trait SignatureSource {
 }
 
 pub fn new_client() -> ClientWithMiddleware {
-    let retry_policy =
-        ExponentialBackoff::builder().build_with_total_retry_duration(Duration::from_secs(10));
-    ClientBuilder::new(reqwest::Client::builder().build().unwrap())
-        .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-        .build()
+    let retry_policy = ExponentialBackoff::builder().build_with_max_retries(1);
+    ClientBuilder::new(
+        reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap(),
+    )
+    .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+    .build()
 }

--- a/sig-provider/sig-provider/src/sources/mod.rs
+++ b/sig-provider/sig-provider/src/sources/mod.rs
@@ -4,7 +4,7 @@ pub mod sigeth;
 use async_trait::async_trait;
 use mockall::automock;
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
-use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware, Retryable};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use std::time::Duration;
 
 #[automock]

--- a/sig-provider/sig-provider/src/sources/sigeth.rs
+++ b/sig-provider/sig-provider/src/sources/sigeth.rs
@@ -113,3 +113,52 @@ mod json {
         pub result: SigTypes,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    const DEFAULT_HOST: &str = "https://sig.eth.samczsun.com/";
+
+    #[rstest::fixture]
+    fn source() -> Source {
+        let host = url::Url::from_str(DEFAULT_HOST).expect("default host is not an url");
+        Source::new(host)
+    }
+
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn create(source: Source) {
+        let abi = r#"[{"constant":false,"inputs":[],"name":"f","outputs":[],"type":"function"},{"inputs":[],"type":"constructor"},{"anonymous":false,"inputs":[{"name":"","type":"string","indexed":true}],"name":"E","type":"event"}]"#;
+        source
+            .create_signatures(abi)
+            .await
+            .expect("error while submitting a new signature");
+    }
+
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn get_function_signatures(source: Source) {
+        let (signature, hex) = ("f()", "0x26121ff0");
+        let result = source
+            .get_function_signatures(hex)
+            .await
+            .expect("error while getting function signature");
+        assert!(result.contains(&signature.into()))
+    }
+
+    #[rstest::rstest]
+    #[tokio::test]
+    async fn get_event_signatures(source: Source) {
+        let (signature, hex) = (
+            "E(string)",
+            "0x3e9992c940c54ea252d3a34557cc3d3014281525c43d694f89d5f3dfd820b07d",
+        );
+        let result = source
+            .get_event_signatures(hex)
+            .await
+            .expect("error while getting event signature");
+        assert!(result.contains(&signature.into()))
+    }
+}


### PR DESCRIPTION
Adds tests for 4bytes and sig.eth.samczsun source apis. Explicitly parses invalid status codes