### PR TITLE
Turn off new contracts charts and related counters

### DIFF
--- a/stats/config/charts.toml
+++ b/stats/config/charts.toml
@@ -39,16 +39,16 @@ id = "totalTxns"
 title = "Total Txns"
 update_schedule = "0 10 */3 * * * *"
 
-[[counters]]
-id = "lastNewContracts"
-title = "Number of deployed contracts today"
-update_schedule = "0 15 */3 * * * *"
-relevant_or_zero = true
+# [[counters]]
+# id = "lastNewContracts"
+# title = "Number of deployed contracts today"
+# update_schedule = "0 15 */3 * * * *"
+# relevant_or_zero = true
 
-[[counters]]
-id = "totalContracts"
-title = "Total contracts"
-update_schedule = "0 20 */3 * * * *"
+# [[counters]]
+# id = "totalContracts"
+# title = "Total contracts"
+# update_schedule = "0 20 */3 * * * *"
 
 [[counters]]
 id = "lastNewVerifiedContracts"
@@ -234,16 +234,16 @@ update_schedule = "0 0 7 * * * *"
 drop_last_point = false
 
 
-[[lines.sections.charts]]
-id = "newContracts"
-title = "New contracts"
-description = "New contracts number for the period"
-update_schedule = "0 0 16 * * * *"
-drop_last_point = true
+# [[lines.sections.charts]]
+# id = "newContracts"
+# title = "New contracts"
+# description = "New contracts number for the period"
+# update_schedule = "0 0 16 * * * *"
+# drop_last_point = true
 
-[[lines.sections.charts]]
-id = "contractsGrowth"
-title = "Contracts growth"
-description = "Cumulative number of contracts for the period"
-update_schedule = "0 0 8 * * * *"
-drop_last_point = false
+# [[lines.sections.charts]]
+# id = "contractsGrowth"
+# title = "Contracts growth"
+# description = "Cumulative number of contracts for the period"
+# update_schedule = "0 0 8 * * * *"
+# drop_last_point = false

--- a/stats/stats-server/tests/counters.rs
+++ b/stats/stats-server/tests/counters.rs
@@ -62,9 +62,9 @@ async fn test_counters_ok() {
         "totalTokens",
         "totalNativeCoinHolders",
         "totalNativeCoinTransfers",
-        "lastNewContracts",
+        //"lastNewContracts",
         "lastNewVerifiedContracts",
-        "totalContracts",
+        //"totalContracts",
         "totalVerifiedContracts",
     ]
     .into_iter()

--- a/stats/stats-server/tests/lines.rs
+++ b/stats/stats-server/tests/lines.rs
@@ -60,7 +60,9 @@ async fn test_lines_ok() {
         "txnsGrowth",
         "txnsSuccessRate",
         "newVerifiedContracts",
-        "newContracts",
+        //"newContracts",
+        "verifiedContractsGrowth",
+        //"contractsGrowth",
     ] {
         let resp = client
             .get(format!("{base}/api/v1/lines/{line_name}"))


### PR DESCRIPTION
SQL request for new contracts is quite big and we decided to turn it off for now until https://github.com/blockscout/blockscout/issues/7406 is solved