### PR TITLE
eth-bytecode-db: speedup search

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
@@ -14,6 +14,7 @@ mod m20230509_103951_add_trigger_parts_convert_data_to_text_value;
 mod m20230509_123554_duplicate_sources_existing_bytecode_to_text_columns;
 mod m20230509_123604_duplicate_parts_existing_data_to_text_column;
 mod m20230509_132647_add_non_null_sources_and_parts_raw_bytecode_text_columns;
+mod m20230510_151046_add_indexes_on_parts_sources_to_search_speedup;
 
 pub struct Migrator;
 
@@ -34,6 +35,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230509_123554_duplicate_sources_existing_bytecode_to_text_columns::Migration),
             Box::new(m20230509_123604_duplicate_parts_existing_data_to_text_column::Migration),
             Box::new(m20230509_132647_add_non_null_sources_and_parts_raw_bytecode_text_columns::Migration),
+            Box::new(m20230510_151046_add_indexes_on_parts_sources_to_search_speedup::Migration),
         ]
     }
 }

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20230510_151046_add_indexes_on_parts_sources_to_search_speedup.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20230510_151046_add_indexes_on_parts_sources_to_search_speedup.rs
@@ -1,0 +1,25 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            CREATE INDEX IF NOT EXISTS "idx_sources_raw_creation_input_text_prefix" ON "sources" USING btree (LEFT("raw_creation_input_text", 500) text_pattern_ops);
+            CREATE INDEX IF NOT EXISTS "idx_sources_rraw_deployed_bytecode_text_prefix" ON "sources" USING btree (LEFT("raw_deployed_bytecode_text", 500) text_pattern_ops);
+            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_prefix" ON "parts" USING btree (LEFT("data_text", 500) text_pattern_ops);
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+        DROP INDEX IF EXISTS "idx_sources_raw_creation_input_text_prefix";
+        DROP INDEX IF EXISTS "idx_sources_rraw_deployed_bytecode_text_prefix";
+        DROP INDEX IF EXISTS "idx_parts_data_text_prefix";
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+}

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20230510_151046_add_indexes_on_parts_sources_to_search_speedup.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20230510_151046_add_indexes_on_parts_sources_to_search_speedup.rs
@@ -7,18 +7,24 @@ pub struct Migration;
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let sql = r#"
-            CREATE INDEX IF NOT EXISTS "idx_sources_raw_creation_input_text_prefix" ON "sources" USING btree (LEFT("raw_creation_input_text", 500) text_pattern_ops);
-            CREATE INDEX IF NOT EXISTS "idx_sources_rraw_deployed_bytecode_text_prefix" ON "sources" USING btree (LEFT("raw_deployed_bytecode_text", 500) text_pattern_ops);
-            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_prefix" ON "parts" USING btree (LEFT("data_text", 500) text_pattern_ops);
+            CREATE INDEX IF NOT EXISTS "idx_sources_raw_creation_input_text_prefix" ON "sources" (LEFT("raw_creation_input_text", 500) text_pattern_ops);
+            CREATE INDEX IF NOT EXISTS "idx_sources_raw_creation_input_text_length" ON "sources" (LENGTH("raw_creation_input_text"));
+            CREATE INDEX IF NOT EXISTS "idx_sources_raw_deployed_bytecode_text_prefix" ON "sources" (LEFT("raw_deployed_bytecode_text", 500) text_pattern_ops);
+            CREATE INDEX IF NOT EXISTS "idx_sources_raw_deployed_bytecode_text_length" ON "sources" (LENGTH("raw_deployed_bytecode_text"));
+            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_prefix" ON "parts" (LENGTH("data_text"));
+            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_length" ON "parts" (LEFT("data_text", 500) text_pattern_ops);
         "#;
         crate::from_sql(manager, sql).await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let sql = r#"
-        DROP INDEX IF EXISTS "idx_sources_raw_creation_input_text_prefix";
-        DROP INDEX IF EXISTS "idx_sources_rraw_deployed_bytecode_text_prefix";
-        DROP INDEX IF EXISTS "idx_parts_data_text_prefix";
+            DROP INDEX IF EXISTS "idx_sources_raw_creation_input_text_prefix";
+            DROP INDEX IF EXISTS "idx_sources_raw_creation_input_text_length";
+            DROP INDEX IF EXISTS "idx_sources_raw_deployed_bytecode_text_prefix";
+            DROP INDEX IF EXISTS "idx_sources_raw_deployed_bytecode_text_length";
+            DROP INDEX IF EXISTS "idx_parts_data_text_prefix";
+            DROP INDEX IF EXISTS "idx_parts_data_text_length";
         "#;
         crate::from_sql(manager, sql).await
     }

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20230510_151046_add_indexes_on_parts_sources_to_search_speedup.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20230510_151046_add_indexes_on_parts_sources_to_search_speedup.rs
@@ -11,8 +11,8 @@ impl MigrationTrait for Migration {
             CREATE INDEX IF NOT EXISTS "idx_sources_raw_creation_input_text_length" ON "sources" (LENGTH("raw_creation_input_text"));
             CREATE INDEX IF NOT EXISTS "idx_sources_raw_deployed_bytecode_text_prefix" ON "sources" (LEFT("raw_deployed_bytecode_text", 500) text_pattern_ops);
             CREATE INDEX IF NOT EXISTS "idx_sources_raw_deployed_bytecode_text_length" ON "sources" (LENGTH("raw_deployed_bytecode_text"));
-            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_prefix" ON "parts" (LENGTH("data_text"));
-            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_length" ON "parts" (LEFT("data_text", 500) text_pattern_ops);
+            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_prefix" ON "parts" (LEFT("data_text", 500) text_pattern_ops);
+            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_length" ON "parts" (LENGTH("data_text"));
         "#;
         crate::from_sql(manager, sql).await
     }

--- a/eth-bytecode-db/eth-bytecode-db/src/search/full_match.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/search/full_match.rs
@@ -44,6 +44,8 @@ where
     }
     .to_string();
 
+    // Here we make use of the index we have on the first 500 symbols
+    // of the "raw_creation_input_text" and "raw_deployed_bytecode_text" columns
     let sql = format!(
         r#"
             SELECT "sources"."id"

--- a/eth-bytecode-db/eth-bytecode-db/src/search/partial_match.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/search/partial_match.rs
@@ -85,14 +85,14 @@ where
     let part_ids = PartCandidate::find_by_statement(Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
-            SELECT *
+            SELECT "parts"."id"
             FROM parts
             WHERE LENGTH("data_text") >= 500
               AND LEFT($1, 500) = LEFT("data_text", 500)
               AND "part_type" = 'main'
               AND $1 LIKE "data_text" || '%'
             UNION
-            SELECT *
+            SELECT "parts"."id"
             FROM parts
             WHERE LENGTH("data_text") < 500
               AND $1 LIKE "data_text" || '%'

--- a/eth-bytecode-db/eth-bytecode-db/src/search/partial_match.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/search/partial_match.rs
@@ -81,15 +81,23 @@ async fn find_part_id_candidates<C>(db: &C, data: &str) -> Result<Vec<i64>, DbEr
 where
     C: ConnectionTrait,
 {
+    // Here we make use of the index we have on the first 500 symbols of the "data_text" column
     let part_ids = PartCandidate::find_by_statement(Statement::from_sql_and_values(
         db.get_database_backend(),
         r#"
-        SELECT *
-        FROM parts
-        WHERE 
-        $1
-        LIKE "data_text" || '%'
-        AND parts.part_type = 'main';"#,
+            SELECT *
+            FROM parts
+            WHERE LENGTH("data_text") >= 500
+              AND LEFT($1, 500) = LEFT("data_text", 500)
+              AND "part_type" = 'main'
+              AND $1 LIKE "data_text" || '%'
+            UNION
+            SELECT *
+            FROM parts
+            WHERE LENGTH("data_text") < 500
+              AND $1 LIKE "data_text" || '%'
+              AND "part_type" = 'main';
+        "#,
         vec![data.into()],
     ))
     .all(db)


### PR DESCRIPTION
Add indexes and make use of them to speed up the bytecode search. 

We expect up to ~100-1000 search time decrease