### PR TITLE
eth-bytecode-db: search speedup (eliminate full_match search)

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-server/tests/verification_test_helpers/test_input_data.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/verification_test_helpers/test_input_data.rs
@@ -69,7 +69,7 @@ pub fn basic(source_type: SourceType, match_type: MatchType) -> TestInputData {
                     },
                     smart_contract_verifier_proto_v2::verify_response::extra_data::BytecodePart {
                         r#type: "meta".to_string(),
-                        data: "0x4567".to_string(),
+                        data: "0xa2646970667358221220ad5a5e9ea0429c6665dc23af78b0acca8d56235be9dc3573672141811ea4a0da64736f6c63430008070033".to_string(),
                     },
                 ],
                 local_deployed_bytecode_parts: vec![
@@ -79,7 +79,7 @@ pub fn basic(source_type: SourceType, match_type: MatchType) -> TestInputData {
                     },
                     smart_contract_verifier_proto_v2::verify_response::extra_data::BytecodePart {
                         r#type: "meta".to_string(),
-                        data: "0xcdef".to_string(),
+                        data: "0xa2646970667358221220ad5a5e9ea0429c6665dc23af78b0acca8d56235be9dc3573672141811ea4a0da64736f6c63430008070033".to_string(),
                     },
                 ],
             },

--- a/eth-bytecode-db/eth-bytecode-db/src/search/any_match.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/search/any_match.rs
@@ -1,6 +1,4 @@
-use super::{
-    find_full_match_contract, find_partial_match_contracts, BytecodeRemote, MatchContract,
-};
+use super::{find_partial_match_contracts, BytecodeRemote, MatchContract};
 use sea_orm::ConnectionTrait;
 
 pub async fn find_contract<C>(
@@ -10,10 +8,10 @@ pub async fn find_contract<C>(
 where
     C: ConnectionTrait,
 {
-    let full_matches = find_full_match_contract(db, remote).await?;
-    if !full_matches.is_empty() {
-        return Ok(full_matches);
-    };
+    // let full_matches = find_full_match_contract(db, remote).await?;
+    // if !full_matches.is_empty() {
+    //     return Ok(full_matches);
+    // };
 
     let partial_matches = find_partial_match_contracts(db, remote).await?;
     if !partial_matches.is_empty() {

--- a/eth-bytecode-db/eth-bytecode-db/src/search/candidates.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/search/candidates.rs
@@ -15,7 +15,7 @@ pub struct BytecodeCandidate {
 impl BytecodeCandidate {
     /// Compare self with remote bytecode.
     /// Return Ok(()) if this candidate meets the requirements
-    pub fn is_match(&self, remote_data: &Bytes) -> Result<(), CompareError> {
+    pub fn is_match(&self, remote_data: &Bytes) -> Result<MatchType, CompareError> {
         let local =
             LocalBytecode::new(&self.parts).expect("local bytecode should contain valid metadata");
         let result = compare(remote_data, &local);
@@ -36,17 +36,23 @@ where
 {
     let filtered_bytecodes: Vec<_> = candidates
         .into_iter()
-        .filter(|c| c.is_match(&remote.data).is_ok())
+        .filter_map(|c| {
+            c.is_match(&remote.data)
+                .ok()
+                .map(|match_type| (c, match_type))
+        })
         .collect();
     if !filtered_bytecodes.is_empty() {
-        let ids: Vec<i64> = filtered_bytecodes.iter().map(|b| b.bytecode.id).collect();
+        let ids: Vec<i64> = filtered_bytecodes
+            .iter()
+            .map(|(b, _)| b.bytecode.id)
+            .collect();
         tracing::debug!(ids = ?ids, "found filtered bytecodes");
     }
     let mut matches = vec![];
-    for bytecode in filtered_bytecodes.iter() {
+    for (bytecode, match_type) in filtered_bytecodes.iter() {
         let contract_match =
-            MatchContract::build(db, bytecode.bytecode.source_id, remote, MatchType::Partial)
-                .await?;
+            MatchContract::build(db, bytecode.bytecode.source_id, remote, *match_type).await?;
         matches.push(contract_match);
     }
     Ok(matches)


### PR DESCRIPTION
Eliminate full_match search. Integrate match type retrieval into partial_match search.

Just to validate the performance speedup. If successful, the code would be refactored in the next PR