### PR TITLE
eth-bytecode-db: add generated data_text column

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/lib.rs
@@ -12,6 +12,7 @@ mod m20230508_114425_add_parts_data_text_column;
 mod m20230509_103951_add_trigger_parts_convert_data_to_text_value;
 mod m20230509_123604_duplicate_parts_existing_data_to_text_column;
 mod m20230509_132647_add_non_null_parts_data_text_column;
+mod m20230509_132648_add_parts_data_text_length_generated_column;
 mod m20230510_151046_add_search_speedup_indexes_on_parts_data_text;
 
 pub struct Migrator;
@@ -31,6 +32,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230509_103951_add_trigger_parts_convert_data_to_text_value::Migration),
             Box::new(m20230509_123604_duplicate_parts_existing_data_to_text_column::Migration),
             Box::new(m20230509_132647_add_non_null_parts_data_text_column::Migration),
+            Box::new(m20230509_132648_add_parts_data_text_length_generated_column::Migration),
             Box::new(m20230510_151046_add_search_speedup_indexes_on_parts_data_text::Migration),
         ]
     }

--- a/eth-bytecode-db/eth-bytecode-db/migration/src/m20230509_132648_add_parts_data_text_length_generated_column.rs
+++ b/eth-bytecode-db/eth-bytecode-db/migration/src/m20230509_132648_add_parts_data_text_length_generated_column.rs
@@ -7,16 +7,16 @@ pub struct Migration;
 impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let sql = r#"
-            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_prefix" ON "parts" (LEFT("data_text", 500) text_pattern_ops);
-            CREATE INDEX IF NOT EXISTS "idx_parts_data_text_length" ON "parts" ("data_text_length");
+            ALTER TABLE "parts"
+            ADD COLUMN "data_text_length" INT GENERATED ALWAYS AS (length("data_text")) STORED;
         "#;
         crate::from_sql(manager, sql).await
     }
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let sql = r#"
-            DROP INDEX IF EXISTS "idx_parts_data_text_prefix";
-            DROP INDEX IF EXISTS "idx_parts_data_text_length";
+            ALTER TABLE "parts"
+            DROP COLUMN "data_text_length";
         "#;
         crate::from_sql(manager, sql).await
     }


### PR DESCRIPTION
Is required, as data_text_length index does not work properly without that