### PR TITLE
eth-bytecode-db: update Vyper endpoint implementations

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -3902,7 +3902,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "smart-contract-verifier-proto"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=95e4f0b7#95e4f0b74d11c2b5d316bd14c8576510c8dff5f5"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=d393fa3#d393fa3e84d01eecd5143cb1f2cda999a4c4f00b"
 dependencies = [
  "actix-prost",
  "actix-prost-build",

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 
 [dev-dependencies]
-smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "95e4f0b7" }
+smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "d393fa3" }
 
 hex = "0.4.3"
 mockall = "0.11"

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
@@ -9,7 +9,7 @@ use crate::{
 use amplify::Wrapper;
 use async_trait::async_trait;
 use eth_bytecode_db::verification::{
-    compiler_versions, vyper_multi_part, Client, VerificationRequest,
+    compiler_versions, vyper_multi_part, vyper_standard_json, Client, VerificationRequest,
 };
 
 pub struct VyperVerifierService {
@@ -53,11 +53,26 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
 
     async fn verify_standard_json(
         &self,
-        _request: tonic::Request<VerifyVyperStandardJsonRequest>,
+        request: tonic::Request<VerifyVyperStandardJsonRequest>,
     ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
-        Err(tonic::Status::unimplemented(
-            "Vyper standard-json verification is not implemented yet",
-        ))
+        let request = request.into_inner();
+
+        let bytecode_type = request.bytecode_type();
+        let verification_request = VerificationRequest {
+            bytecode: request.bytecode,
+            bytecode_type: BytecodeTypeWrapper::from_inner(bytecode_type).try_into()?,
+            compiler_version: request.compiler_version,
+            content: vyper_standard_json::StandardJson {
+                input: request.input,
+            },
+            metadata: request
+                .metadata
+                .map(|metadata| VerificationMetadataWrapper::from_inner(metadata).try_into())
+                .transpose()?,
+        };
+        let result = vyper_standard_json::verify(self.client.clone(), verification_request).await;
+
+        verifier_base::process_verification_result(result)
     }
 
     async fn list_compiler_versions(

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
@@ -37,6 +37,7 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
             compiler_version: request.compiler_version,
             content: vyper_multi_part::MultiPartFiles {
                 source_files: request.source_files,
+                interfaces: request.interfaces,
                 evm_version: request.evm_version,
                 optimizations: request.optimizations,
             },

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/verification_test_helpers/smart_contract_verifer_mock.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/verification_test_helpers/smart_contract_verifer_mock.rs
@@ -7,7 +7,7 @@ use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
     vyper_verifier_server::{VyperVerifier, VyperVerifierServer},
     ListCompilerVersionsRequest, ListCompilerVersionsResponse, VerifyResponse,
     VerifySolidityMultiPartRequest, VerifySolidityStandardJsonRequest, VerifySourcifyRequest,
-    VerifyVyperMultiPartRequest,
+    VerifyVyperMultiPartRequest, VerifyVyperStandardJsonRequest,
 };
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
@@ -33,6 +33,8 @@ mock! {
     #[async_trait::async_trait]
     impl VyperVerifier for VyperVerifierService {
         async fn verify_multi_part(&self, request: tonic::Request<VerifyVyperMultiPartRequest>) -> Result<tonic::Response<VerifyResponse>, tonic::Status>;
+
+        async fn verify_standard_json(&self, request: tonic::Request<VerifyVyperStandardJsonRequest>) -> Result<tonic::Response<VerifyResponse>, tonic::Status>;
 
         async fn list_compiler_versions(&self, request: tonic::Request<ListCompilerVersionsRequest>) -> Result<tonic::Response<ListCompilerVersionsResponse>, tonic::Status>;
     }

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_standard_json.rs
@@ -1,0 +1,126 @@
+mod verification_test_helpers;
+
+use async_trait::async_trait;
+use eth_bytecode_db::verification;
+use eth_bytecode_db_proto::blockscout::eth_bytecode_db::v2::{
+    BytecodeType, VerifyVyperStandardJsonRequest,
+};
+use rstest::{fixture, rstest};
+use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2 as smart_contract_verifier_v2;
+use tonic::Response;
+use verification_test_helpers::{
+    smart_contract_verifer_mock::{MockVyperVerifierService, SmartContractVerifierServer},
+    test_cases, VerifierService,
+};
+
+const TEST_SUITE_NAME: &str = "vyper_standard_json";
+
+const ROUTE: &str = "/api/v2/verifier/vyper/sources:verify-standard-json";
+
+#[async_trait]
+impl VerifierService<smart_contract_verifier_v2::VerifyResponse> for MockVyperVerifierService {
+    fn add_into_service(&mut self, response: smart_contract_verifier_v2::VerifyResponse) {
+        self.expect_verify_standard_json()
+            .returning(move |_| Ok(Response::new(response.clone())));
+    }
+
+    fn build_server(self) -> SmartContractVerifierServer {
+        SmartContractVerifierServer::new().vyper_service(self)
+    }
+}
+
+#[fixture]
+fn service() -> MockVyperVerifierService {
+    MockVyperVerifierService::new()
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_returns_valid_source(service: MockVyperVerifierService) {
+    let default_request = VerifyVyperStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_returns_valid_source(
+        TEST_SUITE_NAME,
+        service,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_verify_then_search(service: MockVyperVerifierService) {
+    let default_request = VerifyVyperStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_verify_then_search(
+        TEST_SUITE_NAME,
+        service,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_verify_same_source_twice(service: MockVyperVerifierService) {
+    let default_request = VerifyVyperStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_verify_same_source_twice(
+        TEST_SUITE_NAME,
+        service,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_search_returns_full_matches_only_if_any() {
+    let default_request = VerifyVyperStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_search_returns_full_matches_only_if_any::<MockVyperVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -27,7 +27,7 @@ prometheus = "0.13"
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "95e4f0b7" }
+smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "d393fa3" }
 solidity-metadata = "1.0"
 thiserror = "1.0"
 tokio = "1.22"

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
@@ -3,6 +3,7 @@ pub mod solidity_multi_part;
 pub mod solidity_standard_json;
 pub mod sourcify;
 pub mod vyper_multi_part;
+pub mod vyper_standard_json;
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -15,6 +15,7 @@ pub struct MultiPartFiles {
     pub evm_version: Option<String>,
     pub optimizations: Option<bool>,
     pub source_files: BTreeMap<String, String>,
+    pub interfaces: BTreeMap<String, String>,
 }
 
 impl From<VerificationRequest<MultiPartFiles>> for VerifyVyperMultiPartRequest {
@@ -24,6 +25,7 @@ impl From<VerificationRequest<MultiPartFiles>> for VerifyVyperMultiPartRequest {
             bytecode_type: BytecodeType::from(request.bytecode_type).into(),
             compiler_version: request.compiler_version,
             source_files: request.content.source_files,
+            interfaces: request.content.interfaces,
             evm_version: request.content.evm_version,
             optimizations: request.content.optimizations,
             metadata: request.metadata.map(|metadata| metadata.into()),
@@ -84,6 +86,10 @@ mod tests {
                     ("source_file1".into(), "content1".into()),
                     ("source_file2".into(), "content2".into()),
                 ]),
+                interfaces: BTreeMap::from([
+                    ("interface1".into(), "interface_content1".into()),
+                    ("interface2".into(), "interface_content2".into()),
+                ]),
             },
             metadata: Some(types::VerificationMetadata {
                 chain_id: 1,
@@ -97,6 +103,10 @@ mod tests {
             source_files: BTreeMap::from([
                 ("source_file1".into(), "content1".into()),
                 ("source_file2".into(), "content2".into()),
+            ]),
+            interfaces: BTreeMap::from([
+                ("interface1".into(), "interface_content1".into()),
+                ("interface2".into(), "interface_content2".into()),
             ]),
             evm_version: Some("istanbul".to_string()),
             optimizations: Some(true),
@@ -125,6 +135,10 @@ mod tests {
                     ("source_file1".into(), "content1".into()),
                     ("source_file2".into(), "content2".into()),
                 ]),
+                interfaces: BTreeMap::from([
+                    ("interface1".into(), "interface_content1".into()),
+                    ("interface2".into(), "interface_content2".into()),
+                ]),
             },
             metadata: Some(types::VerificationMetadata {
                 chain_id: 1,
@@ -138,6 +152,10 @@ mod tests {
             source_files: BTreeMap::from([
                 ("source_file1".into(), "content1".into()),
                 ("source_file2".into(), "content2".into()),
+            ]),
+            interfaces: BTreeMap::from([
+                ("interface1".into(), "interface_content1".into()),
+                ("interface2".into(), "interface_content2".into()),
             ]),
             evm_version: Some("istanbul".to_string()),
             optimizations: Some(true),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
@@ -50,7 +50,7 @@ pub async fn verify(
             bytecode_type,
             raw_request_bytecode,
             verification_settings,
-            verification_type: VerificationType::MultiPartFiles,
+            verification_type: VerificationType::StandardJson,
             verification_metadata,
         },
     )

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
@@ -1,0 +1,129 @@
+use super::{
+    super::{
+        client::Client,
+        errors::Error,
+        smart_contract_verifier::{BytecodeType, VerifyVyperStandardJsonRequest},
+        types::{Source, VerificationRequest, VerificationType},
+    },
+    process_verify_response, ProcessResponseAction,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StandardJson {
+    pub input: String,
+}
+impl From<VerificationRequest<StandardJson>> for VerifyVyperStandardJsonRequest {
+    fn from(request: VerificationRequest<StandardJson>) -> Self {
+        Self {
+            bytecode: request.bytecode,
+            bytecode_type: BytecodeType::from(request.bytecode_type).into(),
+            compiler_version: request.compiler_version,
+            input: request.content.input,
+            metadata: request.metadata.map(|metadata| metadata.into()),
+        }
+    }
+}
+
+pub async fn verify(
+    mut client: Client,
+    request: VerificationRequest<StandardJson>,
+) -> Result<Source, Error> {
+    let bytecode_type = request.bytecode_type;
+    let raw_request_bytecode = hex::decode(request.bytecode.clone().trim_start_matches("0x"))
+        .map_err(|err| Error::InvalidArgument(format!("invalid bytecode: {err}")))?;
+    let verification_settings = serde_json::json!(&request);
+    let verification_metadata = request.metadata.clone();
+
+    let request: VerifyVyperStandardJsonRequest = request.into();
+    let response = client
+        .vyper_client
+        .verify_standard_json(request)
+        .await
+        .map_err(Error::from)?
+        .into_inner();
+
+    process_verify_response(
+        &client.db_client,
+        response,
+        ProcessResponseAction::SaveData {
+            bytecode_type,
+            raw_request_bytecode,
+            verification_settings,
+            verification_type: VerificationType::MultiPartFiles,
+            verification_metadata,
+        },
+    )
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        super::super::{smart_contract_verifier, types},
+        *,
+    };
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn from_verification_request_creation_input() {
+        let request = VerificationRequest {
+            bytecode: "0x1234".to_string(),
+            bytecode_type: types::BytecodeType::CreationInput,
+            compiler_version: "compiler_version".to_string(),
+            content: StandardJson {
+                input: "standard_json_input".to_string(),
+            },
+            metadata: Some(types::VerificationMetadata {
+                chain_id: 1,
+                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+            }),
+        };
+        let expected = VerifyVyperStandardJsonRequest {
+            bytecode: "0x1234".to_string(),
+            bytecode_type: BytecodeType::CreationInput.into(),
+            compiler_version: "compiler_version".to_string(),
+            input: "standard_json_input".to_string(),
+            metadata: Some(smart_contract_verifier::VerificationMetadata {
+                chain_id: "1".to_string(),
+                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+            }),
+        };
+        assert_eq!(
+            expected,
+            VerifyVyperStandardJsonRequest::from(request),
+            "Invalid conversion"
+        );
+    }
+
+    #[test]
+    fn from_verification_request_deployed_bytecode() {
+        let request = VerificationRequest {
+            bytecode: "0x1234".to_string(),
+            bytecode_type: types::BytecodeType::DeployedBytecode,
+            compiler_version: "compiler_version".to_string(),
+            content: StandardJson {
+                input: "standard_json_input".to_string(),
+            },
+            metadata: Some(types::VerificationMetadata {
+                chain_id: 1,
+                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+            }),
+        };
+        let expected = VerifyVyperStandardJsonRequest {
+            bytecode: "0x1234".to_string(),
+            bytecode_type: BytecodeType::DeployedBytecode.into(),
+            compiler_version: "compiler_version".to_string(),
+            input: "standard_json_input".to_string(),
+            metadata: Some(smart_contract_verifier::VerificationMetadata {
+                chain_id: "1".to_string(),
+                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+            }),
+        };
+        assert_eq!(
+            expected,
+            VerifyVyperStandardJsonRequest::from(request),
+            "Invalid conversion"
+        );
+    }
+}

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/mod.rs
@@ -9,6 +9,7 @@ pub use client::Client;
 pub use errors::Error;
 pub use handlers::{
     compiler_versions, solidity_multi_part, solidity_standard_json, sourcify, vyper_multi_part,
+    vyper_standard_json,
 };
 pub use types::{
     BytecodePart, BytecodeType, MatchType, Source, SourceType, VerificationMetadata,

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/smart_contract_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/smart_contract_verifier.rs
@@ -6,4 +6,5 @@ pub use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::
     vyper_verifier_client, BytecodeType, ListCompilerVersionsRequest, ListCompilerVersionsResponse,
     VerificationMetadata, VerifyResponse, VerifySolidityMultiPartRequest,
     VerifySolidityStandardJsonRequest, VerifySourcifyRequest, VerifyVyperMultiPartRequest,
+    VerifyVyperStandardJsonRequest,
 };

--- a/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/smart_contract_veriifer_mock.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/smart_contract_veriifer_mock.rs
@@ -7,7 +7,7 @@ use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
     vyper_verifier_server::{VyperVerifier, VyperVerifierServer},
     ListCompilerVersionsRequest, ListCompilerVersionsResponse, VerifyResponse,
     VerifySolidityMultiPartRequest, VerifySolidityStandardJsonRequest, VerifySourcifyRequest,
-    VerifyVyperMultiPartRequest,
+    VerifyVyperMultiPartRequest, VerifyVyperStandardJsonRequest,
 };
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
@@ -33,6 +33,8 @@ mock! {
     #[async_trait::async_trait]
     impl VyperVerifier for VyperVerifierService {
         async fn verify_multi_part(&self, request: tonic::Request<VerifyVyperMultiPartRequest>) -> Result<tonic::Response<VerifyResponse>, tonic::Status>;
+
+        async fn verify_standard_json(&self, request: tonic::Request<VerifyVyperStandardJsonRequest>) -> Result<tonic::Response<VerifyResponse>, tonic::Status>;
 
         async fn list_compiler_versions(&self, request: tonic::Request<ListCompilerVersionsRequest>) -> Result<tonic::Response<ListCompilerVersionsResponse>, tonic::Status>;
     }

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -91,7 +91,8 @@ async fn test_historical_data_is_added_into_database(service: MockVyperVerifierS
         "compiler_version": "compiler_version",
         "evm_version": "london",
         "optimizations": false,
-        "source_files": {}
+        "source_files": {},
+        "interfaces": {}
     });
     let verification_type = sea_orm_active_enums::VerificationType::MultiPartFiles;
     verification_test_helpers::test_historical_data_is_added_into_database(

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -22,6 +22,7 @@ const DB_PREFIX: &str = "vyper_multi_part";
 fn default_request_content() -> MultiPartFiles {
     MultiPartFiles {
         source_files: Default::default(),
+        interfaces: Default::default(),
         evm_version: Some("london".to_string()),
         optimizations: Some(false),
     }

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_standard_json.rs
@@ -1,0 +1,125 @@
+mod verification_test_helpers;
+
+use async_trait::async_trait;
+use entity::sea_orm_active_enums;
+use eth_bytecode_db::verification::{
+    vyper_standard_json, vyper_standard_json::StandardJson, Client, Error, Source, SourceType,
+    VerificationMetadata, VerificationRequest,
+};
+use rstest::{fixture, rstest};
+use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
+    VerifyResponse, VerifyVyperStandardJsonRequest,
+};
+use tonic::Response;
+use verification_test_helpers::{
+    generate_verification_request,
+    smart_contract_veriifer_mock::{MockVyperVerifierService, SmartContractVerifierServer},
+    VerifierService,
+};
+
+const DB_PREFIX: &str = "vyper_standard_json";
+
+fn default_request_content() -> StandardJson {
+    StandardJson {
+        input: "".to_string(),
+    }
+}
+
+#[async_trait]
+impl VerifierService<VerificationRequest<StandardJson>> for MockVyperVerifierService {
+    type GrpcT = VerifyVyperStandardJsonRequest;
+
+    fn add_into_service(
+        &mut self,
+        request: VerifyVyperStandardJsonRequest,
+        response: VerifyResponse,
+    ) {
+        self.expect_verify_standard_json()
+            .withf(move |arg| arg.get_ref() == &request)
+            .returning(move |_| Ok(Response::new(response.clone())));
+    }
+
+    fn build_server(self) -> SmartContractVerifierServer {
+        SmartContractVerifierServer::new().vyper_service(self)
+    }
+
+    fn generate_request(
+        &self,
+        id: u8,
+        metadata: Option<VerificationMetadata>,
+    ) -> VerificationRequest<StandardJson> {
+        generate_verification_request(id, default_request_content(), metadata)
+    }
+
+    fn source_type(&self) -> SourceType {
+        SourceType::Vyper
+    }
+
+    async fn verify(
+        client: Client,
+        request: VerificationRequest<StandardJson>,
+    ) -> Result<Source, Error> {
+        vyper_standard_json::verify(client, request).await
+    }
+}
+
+#[fixture]
+fn service() -> MockVyperVerifierService {
+    MockVyperVerifierService::new()
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_returns_valid_source(service: MockVyperVerifierService) {
+    verification_test_helpers::test_returns_valid_source(DB_PREFIX, service).await
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_data_is_added_into_database(service: MockVyperVerifierService) {
+    verification_test_helpers::test_data_is_added_into_database(DB_PREFIX, service).await
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_historical_data_is_added_into_database(service: MockVyperVerifierService) {
+    let verification_settings = serde_json::json!({
+        "bytecode": "0x01",
+        "bytecode_type": "CreationInput",
+        "compiler_version": "compiler_version",
+        "input": ""
+    });
+    let verification_type = sea_orm_active_enums::VerificationType::StandardJson;
+    verification_test_helpers::test_historical_data_is_added_into_database(
+        DB_PREFIX,
+        service,
+        verification_settings,
+        verification_type,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_historical_data_saves_chain_id_and_contract_address(
+    service: MockVyperVerifierService,
+) {
+    verification_test_helpers::test_historical_data_saves_chain_id_and_contract_address(
+        DB_PREFIX, service,
+    )
+    .await;
+}
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_same_source_results_stored_once(service: MockVyperVerifierService) {
+    verification_test_helpers::test_verification_of_same_source_results_stored_once(
+        DB_PREFIX, service,
+    )
+    .await;
+}


### PR DESCRIPTION
Update requests eth-bytecode-db sends to verification service. Make use of `interfaces` for multi-part verification. Add implementation for standard-json verification