### PR TITLE
verifier: fix standard-json failures and errors

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier-server/src/services/solidity_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/services/solidity_verifier.rs
@@ -127,10 +127,10 @@ impl SolidityVerifier for SolidityVerifierService {
             if let Err(err) = request {
                 match err {
                     StandardJsonParseError::InvalidContent(_) => {
-                        return Err(Status::invalid_argument(err.to_string()))
+                        return Ok(Response::new(VerifyResponseWrapper::err(err).into_inner()))
                     }
                     StandardJsonParseError::BadRequest(_) => {
-                        return Ok(Response::new(VerifyResponseWrapper::err(err).into_inner()))
+                        return Err(Status::invalid_argument(err.to_string()))
                     }
                 }
             }

--- a/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
@@ -114,10 +114,10 @@ impl VyperVerifier for VyperVerifierService {
             if let Err(err) = request {
                 match err {
                     StandardJsonParseError::InvalidContent(_) => {
-                        return Err(Status::invalid_argument(err.to_string()))
+                        return Ok(Response::new(VerifyResponseWrapper::err(err).into_inner()))
                     }
                     StandardJsonParseError::BadRequest(_) => {
-                        return Ok(Response::new(VerifyResponseWrapper::err(err).into_inner()))
+                        return Err(Status::invalid_argument(err.to_string()))
                     }
                 }
             }

--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/errors.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/errors.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum StandardJsonParseError {
-    #[error("content is not valid standard json: {0}")]
+    #[error("content is not a valid standard json: {0}")]
     InvalidContent(#[from] serde_json::Error),
     #[error("{0}")]
     BadRequest(#[from] anyhow::Error),

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json.rs
@@ -3,6 +3,7 @@ mod standard_json_types;
 use crate::standard_json_types::TestInput;
 use actix_web::{
     dev::ServiceResponse,
+    http::StatusCode,
     test,
     test::{read_body, read_body_json, TestRequest},
     App,
@@ -212,6 +213,68 @@ async fn test_success(dir: &'static str, mut input: TestInput) -> VerifyResponse
     verification_response_clone
 }
 
+/// Test verification failures (note: do not handle 400 BadRequest responses)
+async fn test_failure(dir: &str, mut input: TestInput, expected_message: &str) {
+    let (response, _expected_constructor_argument) = test_setup(dir, &mut input).await;
+
+    assert!(
+        response.status().is_success(),
+        "Invalid status code (success expected): {}",
+        response.status()
+    );
+
+    let verification_response: VerifyResponse = read_body_json(response).await;
+
+    assert_eq!(
+        verification_response.status().as_str_name(),
+        "FAILURE", // failure
+        "Invalid verification status. Response: {:?}",
+        verification_response
+    );
+
+    assert!(
+        verification_response.source.is_none(),
+        "In case of failure, source should be None"
+    );
+    assert!(
+        verification_response.extra_data.is_none(),
+        "In case of failure, extra data should be None"
+    );
+
+    assert!(
+        verification_response.message.contains(expected_message),
+        "Invalid message: {}",
+        verification_response.message
+    );
+}
+
+/// Test errors codes (handle 400 BadRequest, 500 InternalServerError and similar responses)
+async fn test_error(
+    dir: &str,
+    mut input: TestInput,
+    expected_status: StatusCode,
+    expected_message: Option<&str>,
+) {
+    let (response, _expected_constructor_argument) = test_setup(dir, &mut input).await;
+
+    let status = response.status();
+
+    let body = read_body(response).await;
+    let message = from_utf8(&body).expect("Read body as UTF-8");
+
+    assert_eq!(
+        status, expected_status,
+        "Invalid status code. Message: {}",
+        message
+    );
+
+    if let Some(expected_message) = expected_message {
+        assert!(
+            message.contains(expected_message),
+            "Invalid message: {message}"
+        );
+    }
+}
 mod success_tests {
     use super::*;
 
@@ -291,5 +354,40 @@ mod match_types_tests {
         let test_input = TestInput::new("Storage", "v0.8.7+commit.e28d00a7");
         let response = test_success(contract_dir, test_input).await;
         check_match_type(response, MatchType::Full);
+    }
+}
+
+mod failure_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn invalid_input() {
+        let contract_dir = "solidity_0.4.18";
+        let test_input = TestInput::new("Main", "v0.4.18+commit.9cf6e910")
+            // The outer bracket is not closed
+            .with_standard_json_input("{ \"language\": \"Solidity\" ".to_string());
+        test_failure(
+            contract_dir,
+            test_input,
+            "content is not a valid standard json",
+        )
+        .await;
+    }
+}
+
+mod error_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bad_request() {
+        let contract_dir = "solidity_0.4.18";
+        let test_input = TestInput::new("Main", "invalid_compiler_version");
+        test_error(
+            contract_dir,
+            test_input,
+            StatusCode::BAD_REQUEST,
+            Some("Invalid compiler version"),
+        )
+        .await;
     }
 }

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/vyper.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/vyper.rs
@@ -203,6 +203,7 @@ async fn test_error(test_case: impl TestCase, expected_status: StatusCode, expec
         "Invalid message: {message}"
     );
 }
+
 mod flattened {
     use super::{test_error, test_failure, test_success, vyper_types};
     use actix_web::http::StatusCode;

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/vyper.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/vyper.rs
@@ -269,6 +269,8 @@ mod multi_part {
 
 mod standard_json {
     use super::{test_success, vyper_types};
+    use crate::{test_error, test_failure};
+    use actix_web::http::StatusCode;
     use vyper_types::StandardJson;
 
     #[tokio::test]
@@ -277,5 +279,34 @@ mod standard_json {
             let test_case = vyper_types::from_file::<StandardJson>(test_case_name);
             test_success(test_case).await;
         }
+    }
+
+    #[tokio::test]
+    async fn verify_invalid_input() {
+        let test_case = {
+            let mut test_case =
+                vyper_types::from_file::<StandardJson>("standard_json_with_interfaces");
+            // Remove the latest "}" bracket to make the input json invalid
+            test_case.input.remove(test_case.input.len() - 1);
+            test_case
+        };
+        test_failure(test_case, "content is not a valid standard json").await;
+    }
+
+    #[tokio::test]
+    async fn verify_bad_request() {
+        let test_case = {
+            let mut test_case =
+                vyper_types::from_file::<StandardJson>("standard_json_with_interfaces");
+            // Remove the latest "}" bracket to make the input json invalid
+            test_case.compiler_version = "invalid_compiler_version".to_string();
+            test_case
+        };
+        test_error(
+            test_case,
+            StatusCode::BAD_REQUEST,
+            "Invalid compiler version",
+        )
+        .await;
     }
 }


### PR DESCRIPTION
Bad request error has been returned for invalid standard json input, and 200 Success with a failure status has been returned for actually bad requests. This PR fixes that swapping the results