### PR TITLE
verifier: fix non-full abi into responses

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/source.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/source.rs
@@ -131,7 +131,7 @@ mod tests {
             compiler_version: Version::from_str("v0.8.17+commit.8df45f5f").unwrap(),
             file_path: "file_name".to_string(),
             contract_name: "contract_name".to_string(),
-            abi: Some(Default::default()),
+            abi: Some(serde_json::Value::Object(Default::default())),
             constructor_args: Some(DisplayBytes::from_str("0x123456").unwrap()),
             local_bytecode_parts: Default::default(),
             match_type: MatchType::Partial,
@@ -147,7 +147,7 @@ mod tests {
             source_type: source::SourceType::Solidity.into(),
             source_files: BTreeMap::from([("file_name".into(), "content".into())]),
             constructor_arguments: Some("0x123456".into()),
-            abi: Some(serde_json::to_string(&ethabi::Contract::default()).unwrap()),
+            abi: Some("{}".to_string()),
             match_type: source::MatchType::Partial.into(),
         };
 
@@ -176,7 +176,7 @@ mod tests {
             compiler_version: Version::from_str("v0.3.9+commit.66b96705").unwrap(),
             file_path: "file_name".to_string(),
             contract_name: "contract_name".to_string(),
-            abi: Some(Default::default()),
+            abi: Some(serde_json::Value::Object(Default::default())),
             constructor_args: Some(DisplayBytes::from_str("0x123456").unwrap()),
             local_bytecode_parts: Default::default(),
             match_type: MatchType::Partial,
@@ -195,7 +195,7 @@ mod tests {
                 ("interface_name.vy".into(), "interface_content".into()),
             ]),
             constructor_arguments: Some("0x123456".into()),
-            abi: Some(serde_json::to_string(&ethabi::Contract::default()).unwrap()),
+            abi: Some("{}".to_string()),
             match_type: source::MatchType::Partial.into(),
         };
 

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/ERC677/abi.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/ERC677/abi.json
@@ -1,0 +1,873 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_bridge",
+        "type": "address"
+      }
+    ],
+    "name": "removeBridge",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "approve",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferDistribution",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transferFrom",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "PERMIT_TYPEHASH",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "DOMAIN_SEPARATOR",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "distributionAddress",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "addedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "increaseAllowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      },
+      {
+        "name": "_data",
+        "type": "bytes"
+      }
+    ],
+    "name": "transferAndCall",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_account",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "mint",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "bridgePointers",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      }
+    ],
+    "name": "claimTokens",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "advisorsRewardDistributionAddress",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "balanceOf",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "_address",
+        "type": "address"
+      }
+    ],
+    "name": "isBridge",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "privateOfferingDistributionAddress",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "nonces",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "isOwner",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_holder",
+        "type": "address"
+      },
+      {
+        "name": "_spender",
+        "type": "address"
+      },
+      {
+        "name": "_nonce",
+        "type": "uint256"
+      },
+      {
+        "name": "_expiry",
+        "type": "uint256"
+      },
+      {
+        "name": "_allowed",
+        "type": "bool"
+      },
+      {
+        "name": "_v",
+        "type": "uint8"
+      },
+      {
+        "name": "_r",
+        "type": "bytes32"
+      },
+      {
+        "name": "_s",
+        "type": "bytes32"
+      }
+    ],
+    "name": "permit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [
+      {
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_bridge",
+        "type": "address"
+      }
+    ],
+    "name": "addBridge",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "bridgeList",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "name": "subtractedValue",
+        "type": "uint256"
+      }
+    ],
+    "name": "decreaseAllowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_value",
+        "type": "uint256"
+      }
+    ],
+    "name": "transfer",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "push",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_to",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "move",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "F_ADDR",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "name": "spender",
+        "type": "address"
+      }
+    ],
+    "name": "allowance",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_from",
+        "type": "address"
+      },
+      {
+        "name": "_amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "pull",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "bridgeCount",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      {
+        "name": "",
+        "type": "address"
+      },
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "expirations",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "name": "_symbol",
+        "type": "string"
+      },
+      {
+        "name": "_distributionAddress",
+        "type": "address"
+      },
+      {
+        "name": "_privateOfferingDistributionAddress",
+        "type": "address"
+      },
+      {
+        "name": "_advisorsRewardDistributionAddress",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "bridge",
+        "type": "address"
+      }
+    ],
+    "name": "BridgeAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "bridge",
+        "type": "address"
+      }
+    ],
+    "name": "BridgeRemoved",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "ContractFallbackCallFailed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "from",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Transfer",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "spender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "name": "Approval",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  }
+]

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/contract_from_factory/abi.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/contract_from_factory/abi.json
@@ -1,0 +1,27 @@
+[
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "Name",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "name": "name",
+        "type": "bytes32"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  }
+]

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/contract_with_lib/abi.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/contract_with_lib/abi.json
@@ -1,0 +1,47 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "x",
+        "type": "uint256"
+      }
+    ],
+    "name": "set",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "get",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "x",
+        "type": "uint256"
+      }
+    ],
+    "name": "increment",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/issue_5748/abi.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/issue_5748/abi.json
@@ -1,0 +1,21 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "input",
+        "type": "address"
+      }
+    ],
+    "name": "identity",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/simple_storage/abi.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/contracts/simple_storage/abi.json
@@ -1,0 +1,30 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "x",
+        "type": "uint256"
+      }
+    ],
+    "name": "set",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "get",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_multiple.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_multiple.rs
@@ -19,6 +19,7 @@ use solidity_multiple_types::TestInput;
 use std::{
     collections::BTreeMap,
     fs,
+    path::PathBuf,
     str::{from_utf8, FromStr},
     sync::Arc,
 };
@@ -45,7 +46,10 @@ async fn global_service() -> &'static Arc<SolidityVerifierService> {
         .await
 }
 
-async fn test_setup(dir: &str, input: &mut TestInput) -> (ServiceResponse, Option<String>) {
+async fn test_setup(
+    dir: &str,
+    input: &mut TestInput,
+) -> (ServiceResponse, Option<String>, Option<serde_json::Value>) {
     let service = global_service().await;
     let app = test::init_service(
         App::new().configure(|config| route_solidity_verifier(config, service.clone())),
@@ -75,6 +79,14 @@ async fn test_setup(dir: &str, input: &mut TestInput) -> (ServiceResponse, Optio
             .expect("Error while reading constructor_arguments")
     });
 
+    let abi = {
+        let path = PathBuf::from(format!("{prefix}/abi.json"));
+        path.is_file().then(|| {
+            let content = fs::read_to_string(path).expect("Error while reading abi");
+            serde_json::Value::from_str(&content).expect("Error while deserializing abi")
+        })
+    };
+
     let (bytecode, bytecode_type) = if !input.ignore_creation_tx_input {
         (input.creation_tx_input.as_ref().unwrap(), "CREATION_INPUT")
     } else {
@@ -99,11 +111,11 @@ async fn test_setup(dir: &str, input: &mut TestInput) -> (ServiceResponse, Optio
         .send_request(&app)
         .await;
 
-    (response, expected_constructor_argument)
+    (response, expected_constructor_argument, abi)
 }
 
 async fn test_success(dir: &'static str, mut input: TestInput) -> VerifyResponse {
-    let (response, expected_constructor_argument) = test_setup(dir, &mut input).await;
+    let (response, expected_constructor_argument, expected_abi) = test_setup(dir, &mut input).await;
 
     // Assert that status code is success
     if !response.status().is_success() {
@@ -133,7 +145,7 @@ async fn test_success(dir: &'static str, mut input: TestInput) -> VerifyResponse
     );
 
     let result_source = verification_response.source.expect("Checked above");
-    let abi: Option<Result<ethabi::Contract, _>> = result_source
+    let abi: Option<Result<serde_json::Value, _>> = result_source
         .abi
         .as_ref()
         .map(|abi| serde_json::from_str(abi));
@@ -148,6 +160,13 @@ async fn test_success(dir: &'static str, mut input: TestInput) -> VerifyResponse
             "Abi deserialization failed: {}",
             abi.unwrap().as_ref().unwrap_err()
         );
+        if let Some(expected_abi) = expected_abi {
+            assert_eq!(
+                &expected_abi,
+                abi.as_ref().unwrap().as_ref().unwrap(),
+                "Invalid abi"
+            )
+        }
         assert_eq!(
             result_source.source_type().as_str_name(),
             "SOLIDITY",
@@ -240,7 +259,7 @@ async fn test_success(dir: &'static str, mut input: TestInput) -> VerifyResponse
 
 /// Test verification failures (note: do not handle 400 BadRequest responses)
 async fn test_failure(dir: &str, mut input: TestInput, expected_message: &str) {
-    let (response, _expected_constructor_argument) = test_setup(dir, &mut input).await;
+    let (response, _expected_constructor_argument, _abi) = test_setup(dir, &mut input).await;
 
     assert!(
         response.status().is_success(),
@@ -280,7 +299,7 @@ async fn test_error(
     expected_status: StatusCode,
     expected_message: Option<&str>,
 ) {
-    let (response, _expected_constructor_argument) = test_setup(dir, &mut input).await;
+    let (response, _expected_constructor_argument, _abi) = test_setup(dir, &mut input).await;
 
     let status = response.status();
 

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_multiple_types.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_multiple_types.rs
@@ -11,6 +11,7 @@ pub struct TestInput {
     pub has_constructor_args: bool,
     pub is_yul: bool,
     pub ignore_creation_tx_input: bool,
+    pub abi: Option<serde_json::Value>,
 
     /// If None, the input would be read from the corresponding file
     pub source_code: Option<String>,
@@ -31,6 +32,7 @@ impl TestInput {
             has_constructor_args: false,
             is_yul: false,
             ignore_creation_tx_input: false,
+            abi: None,
 
             source_code: None,
             creation_tx_input: None,

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json.rs
@@ -238,7 +238,7 @@ async fn test_success(dir: &'static str, mut input: TestInput) -> VerifyResponse
 
 /// Test verification failures (note: do not handle 400 BadRequest responses)
 async fn test_failure(dir: &str, mut input: TestInput, expected_message: &str) {
-    let (response, _expected_constructor_argument) = test_setup(dir, &mut input).await;
+    let (response, _expected_constructor_argument, _abi) = test_setup(dir, &mut input).await;
 
     assert!(
         response.status().is_success(),
@@ -278,7 +278,7 @@ async fn test_error(
     expected_status: StatusCode,
     expected_message: Option<&str>,
 ) {
-    let (response, _expected_constructor_argument) = test_setup(dir, &mut input).await;
+    let (response, _expected_constructor_argument, _abi) = test_setup(dir, &mut input).await;
 
     let status = response.status();
 

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json_types.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/standard_json_types.rs
@@ -6,6 +6,7 @@ pub struct TestInput {
     pub has_constructor_args: bool,
     pub is_yul: bool,
     pub ignore_creation_tx_input: bool,
+    pub abi: Option<serde_json::Value>,
 
     /// If None, the input would be read from the corresponding file
     pub standard_input: Option<String>,
@@ -23,6 +24,7 @@ impl TestInput {
             has_constructor_args: false,
             is_yul: false,
             ignore_creation_tx_input: false,
+            abi: None,
 
             standard_input: None,
             creation_tx_input: None,

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/types.rs
@@ -13,7 +13,7 @@ pub struct Success {
     pub compiler_version: compiler::Version,
     pub file_path: String,
     pub contract_name: String,
-    pub abi: Option<ethabi::Contract>,
+    pub abi: Option<serde_json::Value>,
     pub constructor_args: Option<DisplayBytes>,
     pub local_bytecode_parts: LocalBytecodeParts,
     pub match_type: MatchType,

--- a/smart-contract-verifier/smart-contract-verifier/src/verifier/all_metadata_extracting_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/verifier/all_metadata_extracting_verifier.rs
@@ -190,7 +190,7 @@ impl<T: Source> Verifier<T> {
         )?;
 
         Ok(ComparisonSuccess {
-            abi,
+            abi: contract.abi.clone().map(|abi| abi.abi_value),
             constructor_args,
             local_bytecode,
             match_type,
@@ -359,7 +359,7 @@ impl<T: Source> Verifier<T> {
 }
 
 struct ComparisonSuccess<T> {
-    pub abi: Option<ethabi::Contract>,
+    pub abi: Option<serde_json::Value>,
     pub constructor_args: Option<Bytes>,
     pub local_bytecode: LocalBytecode<T>,
     pub match_type: MatchType,

--- a/smart-contract-verifier/smart-contract-verifier/src/verifier/base.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/verifier/base.rs
@@ -25,7 +25,7 @@ impl<T> From<LocalBytecode<T>> for LocalBytecodeParts {
 pub struct VerificationSuccess {
     pub file_path: String,
     pub contract_name: String,
-    pub abi: Option<ethabi::Contract>,
+    pub abi: Option<serde_json::Value>,
     pub constructor_args: Option<DisplayBytes>,
 
     pub local_bytecode_parts: LocalBytecodeParts,

--- a/smart-contract-verifier/smart-contract-verifier/src/verifier/contract_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/verifier/contract_verifier.rs
@@ -56,7 +56,7 @@ pub struct Success {
     pub compiler_version: compiler::Version,
     pub file_path: String,
     pub contract_name: String,
-    pub abi: Option<ethabi::Contract>,
+    pub abi: Option<serde_json::Value>,
     pub constructor_args: Option<DisplayBytes>,
     pub local_bytecode_parts: LocalBytecodeParts,
     pub match_type: MatchType,

--- a/smart-contract-verifier/smart-contract-verifier/src/vyper/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/vyper/types.rs
@@ -14,7 +14,7 @@ pub struct Success {
     pub compiler_version: compiler::Version,
     pub file_path: String,
     pub contract_name: String,
-    pub abi: Option<ethabi::Contract>,
+    pub abi: Option<serde_json::Value>,
     pub constructor_args: Option<DisplayBytes>,
     pub local_bytecode_parts: LocalBytecodeParts,
     pub match_type: MatchType,


### PR DESCRIPTION
Make use of the raw abi stored as `serde_json::Value` to return as the verification result.

Closes https://github.com/blockscout/blockscout-rs/issues/389