### PR TITLE
eth-bytecode-db: remove optimizations from VerifyVyperMultiPartRequest

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -3902,7 +3902,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "smart-contract-verifier-proto"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=d393fa3#d393fa3e84d01eecd5143cb1f2cda999a4c4f00b"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=ee52afad#ee52afad47b5032c79492f4bef20f99d999c50bb"
 dependencies = [
  "actix-prost",
  "actix-prost-build",

--- a/eth-bytecode-db/eth-bytecode-db-proto/proto/v2/eth-bytecode-db.proto
+++ b/eth-bytecode-db/eth-bytecode-db-proto/proto/v2/eth-bytecode-db.proto
@@ -128,8 +128,6 @@ message VerifyVyperMultiPartRequest {
   string compiler_version = 3;
   /// Version of the EVM to compile for. If absent results in default EVM version
   optional string evm_version = 4;
-  /// Flag enabling optimizations. If absent, default value is `true`
-  optional bool optimizations = 5;
   /// Map from a source file name to the actual source code
   map<string, string> source_files = 6;
   /// Map from an interface names to the actual interfaces.
@@ -138,6 +136,9 @@ message VerifyVyperMultiPartRequest {
 
   /// An optional field to be filled by explorers
   optional VerificationMetadata metadata = 7;
+
+  reserved 5;
+  reserved "optimizations";
 }
 
 message VerifyVyperStandardJsonRequest {

--- a/eth-bytecode-db/eth-bytecode-db-proto/swagger/v2/eth-bytecode-db.swagger.yaml
+++ b/eth-bytecode-db/eth-bytecode-db-proto/swagger/v2/eth-bytecode-db.swagger.yaml
@@ -424,9 +424,6 @@ definitions:
       metadata:
         $ref: '#/definitions/v2VerificationMetadata'
         title: / An optional field to be filled by explorers
-      optimizations:
-        type: boolean
-        title: / Flag enabling optimizations. If absent, default value is `true`
       sourceFiles:
         type: object
         additionalProperties:

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 
 [dev-dependencies]
-smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "d393fa3" }
+smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "ee52afad" }
 
 hex = "0.4.3"
 mockall = "0.11"

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
@@ -39,7 +39,6 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
                 source_files: request.source_files,
                 interfaces: request.interfaces,
                 evm_version: request.evm_version,
-                optimizations: request.optimizations,
             },
             metadata: request
                 .metadata

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
@@ -46,7 +46,6 @@ async fn test_returns_valid_source(service: MockVyperVerifierService) {
         evm_version: None,
         source_files: Default::default(),
         interfaces: Default::default(),
-        optimizations: None,
         metadata: None,
     };
     let source_type = verification::SourceType::Vyper;
@@ -72,7 +71,6 @@ async fn test_verify_then_search(service: MockVyperVerifierService) {
         evm_version: None,
         source_files: Default::default(),
         interfaces: Default::default(),
-        optimizations: None,
         metadata: None,
     };
     let source_type = verification::SourceType::Vyper;
@@ -98,7 +96,6 @@ async fn test_verify_same_source_twice(service: MockVyperVerifierService) {
         evm_version: None,
         source_files: Default::default(),
         interfaces: Default::default(),
-        optimizations: None,
         metadata: None,
     };
     let source_type = verification::SourceType::Vyper;
@@ -124,7 +121,6 @@ async fn test_search_returns_full_matches_only_if_any() {
         evm_version: None,
         source_files: Default::default(),
         interfaces: Default::default(),
-        optimizations: None,
         metadata: None,
     };
     let source_type = verification::SourceType::Vyper;

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -27,7 +27,7 @@ prometheus = "0.13"
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "d393fa3" }
+smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "ee52afad" }
 solidity-metadata = "1.0"
 thiserror = "1.0"
 tokio = "1.22"

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -13,7 +13,6 @@ use std::collections::BTreeMap;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MultiPartFiles {
     pub evm_version: Option<String>,
-    pub optimizations: Option<bool>,
     pub source_files: BTreeMap<String, String>,
     pub interfaces: BTreeMap<String, String>,
 }
@@ -80,7 +79,6 @@ mod tests {
             compiler_version: "compiler_version".to_string(),
             content: MultiPartFiles {
                 evm_version: Some("istanbul".to_string()),
-                optimizations: Some(true),
                 source_files: BTreeMap::from([
                     ("source_file1".into(), "content1".into()),
                     ("source_file2".into(), "content2".into()),
@@ -128,7 +126,6 @@ mod tests {
             compiler_version: "compiler_version".to_string(),
             content: MultiPartFiles {
                 evm_version: Some("istanbul".to_string()),
-                optimizations: Some(true),
                 source_files: BTreeMap::from([
                     ("source_file1".into(), "content1".into()),
                     ("source_file2".into(), "content2".into()),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -27,7 +27,6 @@ impl From<VerificationRequest<MultiPartFiles>> for VerifyVyperMultiPartRequest {
             source_files: request.content.source_files,
             interfaces: request.content.interfaces,
             evm_version: request.content.evm_version,
-            optimizations: request.content.optimizations,
             metadata: request.metadata.map(|metadata| metadata.into()),
         }
     }
@@ -109,7 +108,6 @@ mod tests {
                 ("interface2".into(), "interface_content2".into()),
             ]),
             evm_version: Some("istanbul".to_string()),
-            optimizations: Some(true),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
                 chain_id: "1".to_string(),
                 contract_address: "0x0101010101010101010101010101010101010101".to_string(),
@@ -158,7 +156,6 @@ mod tests {
                 ("interface2".into(), "interface_content2".into()),
             ]),
             evm_version: Some("istanbul".to_string()),
-            optimizations: Some(true),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
                 chain_id: "1".to_string(),
                 contract_address: "0x0101010101010101010101010101010101010101".to_string(),

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -24,7 +24,6 @@ fn default_request_content() -> MultiPartFiles {
         source_files: Default::default(),
         interfaces: Default::default(),
         evm_version: Some("london".to_string()),
-        optimizations: Some(false),
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -89,7 +89,6 @@ async fn test_historical_data_is_added_into_database(service: MockVyperVerifierS
         "bytecode_type": "CreationInput",
         "compiler_version": "compiler_version",
         "evm_version": "london",
-        "optimizations": false,
         "source_files": {},
         "interfaces": {}
     });


### PR DESCRIPTION
Remove optimizations field from VerifyVyperMultiPartRequest as it is not used. optimize setting could be set with standard-json verification if required.

Bump smart-contract-verifier-proto to the version with optimizations removed