### PR TITLE
Update sig-provider workflow to use a github registry for the docker cache

### DIFF
--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -137,5 +137,5 @@ jobs:
           push: ${{ steps.tags_extractor.outputs.tags != '' }}
           tags: ${{ steps.tags_extractor.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-cache
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-cache,mode=max' || '' }}


### PR DESCRIPTION
Just some experiments.

That should reduce the amount of caches stored via github actions cache, and decrease the rate of cache evictions.