### PR TITLE
Add json+env chart configuration

### DIFF
--- a/stats/Cargo.lock
+++ b/stats/Cargo.lock
@@ -857,6 +857,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,7 +1083,7 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
+ "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
@@ -3290,6 +3299,7 @@ dependencies = [
  "bytes",
  "chrono",
  "config",
+ "convert_case 0.6.0",
  "cron",
  "futures",
  "pretty_assertions",

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -1,32 +1,32 @@
 {
     "counters": {
         "total_blocks": {
-            "title": "Total Blocks",
+            "title": "Total blocks",
             "update_schedule": "0 0 */3 * * * *"
         },
         "average_block_time": {
-            "title": "Average Block Time",
+            "title": "Average block time",
             "units": "s",
             "update_schedule": "0 0 15 * * * *"
         },
         "completed_txns": {
-            "title": "Completed Txns",
+            "title": "Completed txns",
             "update_schedule": "0 5 */3 * * * *"
         },
         "total_accounts": {
-            "title": "Total Accounts",
+            "title": "Total accounts",
             "update_schedule": "0 0 16 * * * *"
         },
         "total_native_coin_transfers": {
-            "title": "Total Native Coin Transfers",
+            "title": "Total native coin transfers",
             "update_schedule": "0 0 13 * * * *"
         },
         "total_tokens": {
-            "title": "Total Tokens",
+            "title": "Total tokens",
             "update_schedule": "0 0 18 * * * *"
         },
         "total_txns": {
-            "title": "Total Txns",
+            "title": "Total txns",
             "update_schedule": "0 10 */3 * * * *"
         },
         "last_new_contracts": {

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -47,135 +47,133 @@
         }
     },
     "lines": {
-        "sections": {
-            "accounts": {
-                "title": "Accounts",
-                "charts": {
-                    "active_accounts": {
-                        "title": "Active accounts",
-                        "description": "Active accounts number per period",
-                        "update_schedule": "0 0 4 * * * *"
-                    },
-                    "accounts_growth": {
-                        "title": "Accounts growth",
-                        "description": "Cumulative accounts number per period",
-                        "update_schedule": "0 0 5 * * * *"
-                    },
-                    "new_accounts": {
-                        "title": "New accounts",
-                        "description": "New accounts number per day",
-                        "update_schedule": "0 0 21 * * * *"
-                    }
+        "accounts": {
+            "title": "Accounts",
+            "charts": {
+                "active_accounts": {
+                    "title": "Active accounts",
+                    "description": "Active accounts number per period",
+                    "update_schedule": "0 0 4 * * * *"
+                },
+                "accounts_growth": {
+                    "title": "Accounts growth",
+                    "description": "Cumulative accounts number per period",
+                    "update_schedule": "0 0 5 * * * *"
+                },
+                "new_accounts": {
+                    "title": "New accounts",
+                    "description": "New accounts number per day",
+                    "update_schedule": "0 0 21 * * * *"
                 }
-            },
-            "transactions": {
-                "title": "Transactions",
-                "charts": {
-                    "average_txn_fee": {
-                        "title": "Average transaction fee",
-                        "description": "The average amount in ETH spent per transaction",
-                        "units": "ETH",
-                        "update_schedule": "0 0 6 * * * *"
-                    },
-                    "txns_fee": {
-                        "title": "Transactions fees",
-                        "description": "Amount of tokens paid as fees",
-                        "units": "ETH",
-                        "update_schedule": "0 0 7 * * * *"
-                    },
-                    "new_txns": {
-                        "title": "New transactions",
-                        "description": "New transactions number",
-                        "update_schedule": "0 0 1 * * * *"
-                    },
-                    "txns_growth": {
-                        "title": "Transactions growth",
-                        "description": "Cumulative transactions number",
-                        "update_schedule": "0 0 2 * * * *"
-                    },
-                    "txns_success_rate": {
-                        "title": "Transactions success rate",
-                        "description": "Successful transactions rate per day",
-                        "update_schedule": "0 0 19 * * * *"
-                    }
+            }
+        },
+        "transactions": {
+            "title": "Transactions",
+            "charts": {
+                "average_txn_fee": {
+                    "title": "Average transaction fee",
+                    "description": "The average amount in ETH spent per transaction",
+                    "units": "ETH",
+                    "update_schedule": "0 0 6 * * * *"
+                },
+                "txns_fee": {
+                    "title": "Transactions fees",
+                    "description": "Amount of tokens paid as fees",
+                    "units": "ETH",
+                    "update_schedule": "0 0 7 * * * *"
+                },
+                "new_txns": {
+                    "title": "New transactions",
+                    "description": "New transactions number",
+                    "update_schedule": "0 0 1 * * * *"
+                },
+                "txns_growth": {
+                    "title": "Transactions growth",
+                    "description": "Cumulative transactions number",
+                    "update_schedule": "0 0 2 * * * *"
+                },
+                "txns_success_rate": {
+                    "title": "Transactions success rate",
+                    "description": "Successful transactions rate per day",
+                    "update_schedule": "0 0 19 * * * *"
                 }
-            },
-            "blocks": {
-                "title": "Blocks",
-                "charts": {
-                    "new_blocks": {
-                        "title": "New blocks",
-                        "description": "New blocks number",
-                        "update_schedule": "0 0 8 * * * *"
-                    },
-                    "average_block_size": {
-                        "title": "Average block size",
-                        "description": "Average size of blocks in bytes",
-                        "units": "Bytes",
-                        "update_schedule": "0 0 9 * * * *"
-                    },
-                    "average_block_rewards": {
-                        "title": "Average block rewards",
-                        "description": "Average amount of distributed reward in tokens per day",
-                        "units": "ETH",
-                        "update_schedule": "0 0 20 * * * *"
-                    }
+            }
+        },
+        "blocks": {
+            "title": "Blocks",
+            "charts": {
+                "new_blocks": {
+                    "title": "New blocks",
+                    "description": "New blocks number",
+                    "update_schedule": "0 0 8 * * * *"
+                },
+                "average_block_size": {
+                    "title": "Average block size",
+                    "description": "Average size of blocks in bytes",
+                    "units": "Bytes",
+                    "update_schedule": "0 0 9 * * * *"
+                },
+                "average_block_rewards": {
+                    "title": "Average block rewards",
+                    "description": "Average amount of distributed reward in tokens per day",
+                    "units": "ETH",
+                    "update_schedule": "0 0 20 * * * *"
                 }
-            },
-            "tokens": {
-                "title": "Tokens",
-                "charts": {
-                    "new_native_coin_transfers": {
-                        "title": "New native coins transfers",
-                        "description": "New token transfers number for the period",
-                        "update_schedule": "0 0 3 * * * *"
-                    }
+            }
+        },
+        "tokens": {
+            "title": "Tokens",
+            "charts": {
+                "new_native_coin_transfers": {
+                    "title": "New native coins transfers",
+                    "description": "New token transfers number for the period",
+                    "update_schedule": "0 0 3 * * * *"
                 }
-            },
-            "gas": {
-                "title": "Gas",
-                "charts": {
-                    "average_gas_limit": {
-                        "title": "Average gas limit",
-                        "description": "Average gas limit per block for the period",
-                        "update_schedule": "0 0 12 * * * *"
-                    },
-                    "gas_used_growth": {
-                        "title": "Gas used growth",
-                        "description": "Cumulative gas used for the period",
-                        "update_schedule": "0 0 13 * * * *"
-                    },
-                    "average_gas_price": {
-                        "title": "Average gas price",
-                        "description": "Average gas price for the period (Gwei)",
-                        "units": "Gwei",
-                        "update_schedule": "0 0 14 * * * *"
-                    }
+            }
+        },
+        "gas": {
+            "title": "Gas",
+            "charts": {
+                "average_gas_limit": {
+                    "title": "Average gas limit",
+                    "description": "Average gas limit per block for the period",
+                    "update_schedule": "0 0 12 * * * *"
+                },
+                "gas_used_growth": {
+                    "title": "Gas used growth",
+                    "description": "Cumulative gas used for the period",
+                    "update_schedule": "0 0 13 * * * *"
+                },
+                "average_gas_price": {
+                    "title": "Average gas price",
+                    "description": "Average gas price for the period (Gwei)",
+                    "units": "Gwei",
+                    "update_schedule": "0 0 14 * * * *"
                 }
-            },
-            "contracts": {
-                "title": "Contracts",
-                "charts": {
-                    "new_verified_contracts": {
-                        "title": "New verified contracts",
-                        "description": "New verified contracts number for the period",
-                        "update_schedule": "0 0 15 * * * *"
-                    },
-                    "verified_contracts_growth": {
-                        "title": "Verified contracts growth",
-                        "description": "Cumulative number verified contracts for the period",
-                        "update_schedule": "0 0 7 * * * *"
-                    },
-                    "new_contracts": {
-                        "title": "New contracts",
-                        "description": "New contracts number for the period",
-                        "update_schedule": "0 0 16 * * * *"
-                    },
-                    "contracts_growth": {
-                        "title": "Contracts growth",
-                        "description": "Cumulative number of contracts for the period",
-                        "update_schedule": "0 0 8 * * * *"
-                    }
+            }
+        },
+        "contracts": {
+            "title": "Contracts",
+            "charts": {
+                "new_verified_contracts": {
+                    "title": "New verified contracts",
+                    "description": "New verified contracts number for the period",
+                    "update_schedule": "0 0 15 * * * *"
+                },
+                "verified_contracts_growth": {
+                    "title": "Verified contracts growth",
+                    "description": "Cumulative number verified contracts for the period",
+                    "update_schedule": "0 0 7 * * * *"
+                },
+                "new_contracts": {
+                    "title": "New contracts",
+                    "description": "New contracts number for the period",
+                    "update_schedule": "0 0 16 * * * *"
+                },
+                "contracts_growth": {
+                    "title": "Contracts growth",
+                    "description": "Cumulative number of contracts for the period",
+                    "update_schedule": "0 0 8 * * * *"
                 }
             }
         }

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -47,133 +47,135 @@
         }
     },
     "lines": {
-        "accounts": {
-            "title": "Accounts",
-            "charts": {
-                "active_accounts": {
-                    "title": "Active accounts",
-                    "description": "Active accounts number per period",
-                    "update_schedule": "0 0 4 * * * *"
-                },
-                "accounts_growth": {
-                    "title": "Accounts growth",
-                    "description": "Cumulative accounts number per period",
-                    "update_schedule": "0 0 5 * * * *"
-                },
-                "new_accounts": {
-                    "title": "New accounts",
-                    "description": "New accounts number per day",
-                    "update_schedule": "0 0 21 * * * *"
+        "sections": {
+            "accounts": {
+                "title": "Accounts",
+                "charts": {
+                    "active_accounts": {
+                        "title": "Active accounts",
+                        "description": "Active accounts number per period",
+                        "update_schedule": "0 0 4 * * * *"
+                    },
+                    "accounts_growth": {
+                        "title": "Accounts growth",
+                        "description": "Cumulative accounts number per period",
+                        "update_schedule": "0 0 5 * * * *"
+                    },
+                    "new_accounts": {
+                        "title": "New accounts",
+                        "description": "New accounts number per day",
+                        "update_schedule": "0 0 21 * * * *"
+                    }
                 }
-            }
-        },
-        "transactions": {
-            "title": "Transactions",
-            "charts": {
-                "average_txn_fee": {
-                    "title": "Average transaction fee",
-                    "description": "The average amount in ETH spent per transaction",
-                    "units": "ETH",
-                    "update_schedule": "0 0 6 * * * *"
-                },
-                "txns_fee": {
-                    "title": "Transactions fees",
-                    "description": "Amount of tokens paid as fees",
-                    "units": "ETH",
-                    "update_schedule": "0 0 7 * * * *"
-                },
-                "new_txns": {
-                    "title": "New transactions",
-                    "description": "New transactions number",
-                    "update_schedule": "0 0 1 * * * *"
-                },
-                "txns_growth": {
-                    "title": "Transactions growth",
-                    "description": "Cumulative transactions number",
-                    "update_schedule": "0 0 2 * * * *"
-                },
-                "txns_success_rate": {
-                    "title": "Transactions success rate",
-                    "description": "Successful transactions rate per day",
-                    "update_schedule": "0 0 19 * * * *"
+            },
+            "transactions": {
+                "title": "Transactions",
+                "charts": {
+                    "average_txn_fee": {
+                        "title": "Average transaction fee",
+                        "description": "The average amount in ETH spent per transaction",
+                        "units": "ETH",
+                        "update_schedule": "0 0 6 * * * *"
+                    },
+                    "txns_fee": {
+                        "title": "Transactions fees",
+                        "description": "Amount of tokens paid as fees",
+                        "units": "ETH",
+                        "update_schedule": "0 0 7 * * * *"
+                    },
+                    "new_txns": {
+                        "title": "New transactions",
+                        "description": "New transactions number",
+                        "update_schedule": "0 0 1 * * * *"
+                    },
+                    "txns_growth": {
+                        "title": "Transactions growth",
+                        "description": "Cumulative transactions number",
+                        "update_schedule": "0 0 2 * * * *"
+                    },
+                    "txns_success_rate": {
+                        "title": "Transactions success rate",
+                        "description": "Successful transactions rate per day",
+                        "update_schedule": "0 0 19 * * * *"
+                    }
                 }
-            }
-        },
-        "blocks": {
-            "title": "Blocks",
-            "charts": {
-                "new_blocks": {
-                    "title": "New blocks",
-                    "description": "New blocks number",
-                    "update_schedule": "0 0 8 * * * *"
-                },
-                "average_block_size": {
-                    "title": "Average block size",
-                    "description": "Average size of blocks in bytes",
-                    "units": "Bytes",
-                    "update_schedule": "0 0 9 * * * *"
-                },
-                "average_block_rewards": {
-                    "title": "Average block rewards",
-                    "description": "Average amount of distributed reward in tokens per day",
-                    "units": "ETH",
-                    "update_schedule": "0 0 20 * * * *"
+            },
+            "blocks": {
+                "title": "Blocks",
+                "charts": {
+                    "new_blocks": {
+                        "title": "New blocks",
+                        "description": "New blocks number",
+                        "update_schedule": "0 0 8 * * * *"
+                    },
+                    "average_block_size": {
+                        "title": "Average block size",
+                        "description": "Average size of blocks in bytes",
+                        "units": "Bytes",
+                        "update_schedule": "0 0 9 * * * *"
+                    },
+                    "average_block_rewards": {
+                        "title": "Average block rewards",
+                        "description": "Average amount of distributed reward in tokens per day",
+                        "units": "ETH",
+                        "update_schedule": "0 0 20 * * * *"
+                    }
                 }
-            }
-        },
-        "tokens": {
-            "title": "Tokens",
-            "charts": {
-                "new_native_coin_transfers": {
-                    "title": "New native coins transfers",
-                    "description": "New token transfers number for the period",
-                    "update_schedule": "0 0 3 * * * *"
+            },
+            "tokens": {
+                "title": "Tokens",
+                "charts": {
+                    "new_native_coin_transfers": {
+                        "title": "New native coins transfers",
+                        "description": "New token transfers number for the period",
+                        "update_schedule": "0 0 3 * * * *"
+                    }
                 }
-            }
-        },
-        "gas": {
-            "title": "Gas",
-            "charts": {
-                "average_gas_limit": {
-                    "title": "Average gas limit",
-                    "description": "Average gas limit per block for the period",
-                    "update_schedule": "0 0 12 * * * *"
-                },
-                "gas_used_growth": {
-                    "title": "Gas used growth",
-                    "description": "Cumulative gas used for the period",
-                    "update_schedule": "0 0 13 * * * *"
-                },
-                "average_gas_price": {
-                    "title": "Average gas price",
-                    "description": "Average gas price for the period (Gwei)",
-                    "units": "Gwei",
-                    "update_schedule": "0 0 14 * * * *"
+            },
+            "gas": {
+                "title": "Gas",
+                "charts": {
+                    "average_gas_limit": {
+                        "title": "Average gas limit",
+                        "description": "Average gas limit per block for the period",
+                        "update_schedule": "0 0 12 * * * *"
+                    },
+                    "gas_used_growth": {
+                        "title": "Gas used growth",
+                        "description": "Cumulative gas used for the period",
+                        "update_schedule": "0 0 13 * * * *"
+                    },
+                    "average_gas_price": {
+                        "title": "Average gas price",
+                        "description": "Average gas price for the period (Gwei)",
+                        "units": "Gwei",
+                        "update_schedule": "0 0 14 * * * *"
+                    }
                 }
-            }
-        },
-        "contracts": {
-            "title": "Contracts",
-            "charts": {
-                "new_verified_contracts": {
-                    "title": "New verified contracts",
-                    "description": "New verified contracts number for the period",
-                    "update_schedule": "0 0 15 * * * *"
-                },
-                "verified_contracts_growth": {
-                    "title": "Verified contracts growth",
-                    "description": "Cumulative number verified contracts for the period",
-                    "update_schedule": "0 0 7 * * * *"
-                },
-                "new_contracts": {
-                    "title": "New contracts",
-                    "description": "New contracts number for the period",
-                    "update_schedule": "0 0 16 * * * *"
-                },
-                "contracts_growth": {
-                    "title": "Contracts growth",
-                    "description": "Cumulative number of contracts for the period",
-                    "update_schedule": "0 0 8 * * * *"
+            },
+            "contracts": {
+                "title": "Contracts",
+                "charts": {
+                    "new_verified_contracts": {
+                        "title": "New verified contracts",
+                        "description": "New verified contracts number for the period",
+                        "update_schedule": "0 0 15 * * * *"
+                    },
+                    "verified_contracts_growth": {
+                        "title": "Verified contracts growth",
+                        "description": "Cumulative number verified contracts for the period",
+                        "update_schedule": "0 0 7 * * * *"
+                    },
+                    "new_contracts": {
+                        "title": "New contracts",
+                        "description": "New contracts number for the period",
+                        "update_schedule": "0 0 16 * * * *"
+                    },
+                    "contracts_growth": {
+                        "title": "Contracts growth",
+                        "description": "Cumulative number of contracts for the period",
+                        "update_schedule": "0 0 8 * * * *"
+                    }
                 }
             }
         }

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -1,0 +1,181 @@
+{
+    "counters": {
+        "total_blocks": {
+            "title": "Total Blocks",
+            "update_schedule": "0 0 */3 * * * *"
+        },
+        "average_block_time": {
+            "title": "Average Block Time",
+            "units": "s",
+            "update_schedule": "0 0 15 * * * *"
+        },
+        "completed_txns": {
+            "title": "Completed Txns",
+            "update_schedule": "0 5 */3 * * * *"
+        },
+        "total_accounts": {
+            "title": "Total Accounts",
+            "update_schedule": "0 0 16 * * * *"
+        },
+        "total_native_coin_transfers": {
+            "title": "Total Native Coin Transfers",
+            "update_schedule": "0 0 13 * * * *"
+        },
+        "total_tokens": {
+            "title": "Total Tokens",
+            "update_schedule": "0 0 18 * * * *"
+        },
+        "total_txns": {
+            "title": "Total Txns",
+            "update_schedule": "0 10 */3 * * * *"
+        },
+        "last_new_contracts": {
+            "title": "Number of deployed contracts today",
+            "update_schedule": "0 15 */3 * * * *"
+        },
+        "total_contracts": {
+            "title": "Total contracts",
+            "update_schedule": "0 20 */3 * * * *"
+        },
+        "last_new_verified_contracts": {
+            "title": "Number of verified contracts today",
+            "update_schedule": "0 25 */3 * * * *"
+        },
+        "total_verified_contracts": {
+            "title": "Total verified contracts",
+            "update_schedule": "0 30 */3 * * * *"
+        }
+    },
+    "lines": {
+        "accounts": {
+            "title": "Accounts",
+            "charts": {
+                "active_accounts": {
+                    "title": "Active accounts",
+                    "description": "Active accounts number per period",
+                    "update_schedule": "0 0 4 * * * *"
+                },
+                "accounts_growth": {
+                    "title": "Accounts growth",
+                    "description": "Cumulative accounts number per period",
+                    "update_schedule": "0 0 5 * * * *"
+                },
+                "new_accounts": {
+                    "title": "New accounts",
+                    "description": "New accounts number per day",
+                    "update_schedule": "0 0 21 * * * *"
+                }
+            }
+        },
+        "transactions": {
+            "title": "Transactions",
+            "charts": {
+                "average_txn_fee": {
+                    "title": "Average transaction fee",
+                    "description": "The average amount in ETH spent per transaction",
+                    "units": "ETH",
+                    "update_schedule": "0 0 6 * * * *"
+                },
+                "txns_fee": {
+                    "title": "Transactions fees",
+                    "description": "Amount of tokens paid as fees",
+                    "units": "ETH",
+                    "update_schedule": "0 0 7 * * * *"
+                },
+                "new_txns": {
+                    "title": "New transactions",
+                    "description": "New transactions number",
+                    "update_schedule": "0 0 1 * * * *"
+                },
+                "txns_growth": {
+                    "title": "Transactions growth",
+                    "description": "Cumulative transactions number",
+                    "update_schedule": "0 0 2 * * * *"
+                },
+                "txns_success_rate": {
+                    "title": "Transactions success rate",
+                    "description": "Successful transactions rate per day",
+                    "update_schedule": "0 0 19 * * * *"
+                }
+            }
+        },
+        "blocks": {
+            "title": "Blocks",
+            "charts": {
+                "new_blocks": {
+                    "title": "New blocks",
+                    "description": "New blocks number",
+                    "update_schedule": "0 0 8 * * * *"
+                },
+                "average_block_size": {
+                    "title": "Average block size",
+                    "description": "Average size of blocks in bytes",
+                    "units": "Bytes",
+                    "update_schedule": "0 0 9 * * * *"
+                },
+                "average_block_rewards": {
+                    "title": "Average block rewards",
+                    "description": "Average amount of distributed reward in tokens per day",
+                    "units": "ETH",
+                    "update_schedule": "0 0 20 * * * *"
+                }
+            }
+        },
+        "tokens": {
+            "title": "Tokens",
+            "charts": {
+                "new_native_coin_transfers": {
+                    "title": "New native coins transfers",
+                    "description": "New token transfers number for the period",
+                    "update_schedule": "0 0 3 * * * *"
+                }
+            }
+        },
+        "gas": {
+            "title": "Gas",
+            "charts": {
+                "average_gas_limit": {
+                    "title": "Average gas limit",
+                    "description": "Average gas limit per block for the period",
+                    "update_schedule": "0 0 12 * * * *"
+                },
+                "gas_used_growth": {
+                    "title": "Gas used growth",
+                    "description": "Cumulative gas used for the period",
+                    "update_schedule": "0 0 13 * * * *"
+                },
+                "average_gas_price": {
+                    "title": "Average gas price",
+                    "description": "Average gas price for the period (Gwei)",
+                    "units": "Gwei",
+                    "update_schedule": "0 0 14 * * * *"
+                }
+            }
+        },
+        "contracts": {
+            "title": "Contracts",
+            "charts": {
+                "new_verified_contracts": {
+                    "title": "New verified contracts",
+                    "description": "New verified contracts number for the period",
+                    "update_schedule": "0 0 15 * * * *"
+                },
+                "verified_contracts_growth": {
+                    "title": "Verified contracts growth",
+                    "description": "Cumulative number verified contracts for the period",
+                    "update_schedule": "0 0 7 * * * *"
+                },
+                "new_contracts": {
+                    "title": "New contracts",
+                    "description": "New contracts number for the period",
+                    "update_schedule": "0 0 16 * * * *"
+                },
+                "contracts_growth": {
+                    "title": "Contracts growth",
+                    "description": "Cumulative number of contracts for the period",
+                    "update_schedule": "0 0 8 * * * *"
+                }
+            }
+        }
+    }
+}

--- a/stats/config/charts.toml
+++ b/stats/config/charts.toml
@@ -1,22 +1,22 @@
 [[counters]]
 id = "totalBlocks"
-title = "Total Blocks"
+title = "Total blocks"
 update_schedule = "0 0 */3 * * * *"
 
 [[counters]]
 id = "averageBlockTime"
-title = "Average Block Time"
+title = "Average block time"
 units = "s"
 update_schedule = "0 0 15 * * * *"
 
 [[counters]]
 id = "completedTxns"
-title = "Completed Txns"
+title = "Completed txns"
 update_schedule = "0 5 */3 * * * *"
 
 [[counters]]
 id = "totalAccounts"
-title = "Total Accounts"
+title = "Total accounts"
 update_schedule = "0 0 16 * * * *"
 
 # [[counters]]
@@ -26,17 +26,17 @@ update_schedule = "0 0 16 * * * *"
 
 [[counters]]
 id = "totalNativeCoinTransfers"
-title = "Total Native Coin Transfers"
+title = "Total native coin transfers"
 update_schedule = "0 0 13 * * * *"
 
 [[counters]]
 id = "totalTokens"
-title = "Total Tokens"
+title = "Total tokens"
 update_schedule = "0 0 18 * * * *"
 
 [[counters]]
 id = "totalTxns"
-title = "Total Txns"
+title = "Total txns"
 update_schedule = "0 10 */3 * * * *"
 
 [[counters]]

--- a/stats/stats-server/Cargo.toml
+++ b/stats/stats-server/Cargo.toml
@@ -26,7 +26,7 @@ sea-orm = { version = "0.10", features = [
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 blockscout-service-launcher = { version = "0.7.1", features = [ "database-0_10" ] }
 cron = "0.12"
-
+convert_case = "0.6.0"
 
 [dev-dependencies]
 reqwest-middleware = "0.2"

--- a/stats/stats-server/src/config/chart_info.rs
+++ b/stats/stats-server/src/config/chart_info.rs
@@ -1,0 +1,35 @@
+use cron::Schedule;
+use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
+
+#[serde_as]
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ChartSettings {
+    #[serde(default = "enabled_default")]
+    pub enabled: bool,
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub update_schedule: Option<Schedule>,
+    pub units: Option<String>,
+}
+
+fn enabled_default() -> bool {
+    true
+}
+
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CounterInfo {
+    pub title: String,
+    #[serde(flatten)]
+    pub settings: ChartSettings,
+}
+
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LineChartInfo {
+    pub title: String,
+    pub description: String,
+    #[serde(flatten)]
+    pub settings: ChartSettings,
+}

--- a/stats/stats-server/src/config/json_config.rs
+++ b/stats/stats-server/src/config/json_config.rs
@@ -1,0 +1,87 @@
+use super::{
+    chart_info::{CounterInfo, LineChartInfo},
+    toml_config,
+};
+use convert_case::{Case, Casing};
+use serde::Deserialize;
+use std::collections::BTreeMap;
+
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LineChartSection {
+    pub title: String,
+    pub charts: BTreeMap<String, LineChartInfo>,
+}
+
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct LineCharts {
+    pub sections: BTreeMap<String, LineChartSection>,
+}
+
+#[derive(Default, Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct Config {
+    pub counters: BTreeMap<String, CounterInfo>,
+    pub lines: LineCharts,
+}
+
+impl From<Config> for toml_config::Config {
+    fn from(value: Config) -> Self {
+        Self {
+            counters: value
+                .counters
+                .into_iter()
+                .map(toml_config::CounterInfo::from)
+                .collect(),
+            lines: value.lines.into(),
+        }
+    }
+}
+
+impl From<LineCharts> for toml_config::LineCharts {
+    fn from(value: LineCharts) -> Self {
+        Self {
+            sections: value
+                .sections
+                .into_iter()
+                .map(toml_config::LineChartSection::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<(String, LineChartSection)> for toml_config::LineChartSection {
+    fn from((id, section): (String, LineChartSection)) -> Self {
+        Self {
+            id,
+            title: section.title,
+            charts: section
+                .charts
+                .into_iter()
+                .map(toml_config::LineChartInfo::from)
+                .collect(),
+        }
+    }
+}
+
+impl From<(String, LineChartInfo)> for toml_config::LineChartInfo {
+    fn from((id, info): (String, LineChartInfo)) -> Self {
+        Self {
+            id: id.to_case(Case::Camel),
+            title: info.title,
+            description: info.description,
+            settings: info.settings,
+        }
+    }
+}
+
+impl From<(String, CounterInfo)> for toml_config::CounterInfo {
+    fn from((id, info): (String, CounterInfo)) -> Self {
+        Self {
+            id: id.to_case(Case::Camel),
+            title: info.title,
+            settings: info.settings,
+        }
+    }
+}

--- a/stats/stats-server/src/config/json_config.rs
+++ b/stats/stats-server/src/config/json_config.rs
@@ -61,7 +61,7 @@ impl From<(String, LineChartSection)> for toml_config::LineChartSection {
 impl From<(String, LineChartInfo)> for toml_config::LineChartInfo {
     fn from((id, info): (String, LineChartInfo)) -> Self {
         Self {
-            id: id.to_case(Case::Camel),
+            id: id.from_case(Case::Snake).to_case(Case::Camel),
             title: info.title,
             description: info.description,
             settings: info.settings,
@@ -72,7 +72,7 @@ impl From<(String, LineChartInfo)> for toml_config::LineChartInfo {
 impl From<(String, CounterInfo)> for toml_config::CounterInfo {
     fn from((id, info): (String, CounterInfo)) -> Self {
         Self {
-            id: id.to_case(Case::Camel),
+            id: id.from_case(Case::Snake).to_case(Case::Camel),
             title: info.title,
             settings: info.settings,
         }

--- a/stats/stats-server/src/config/json_config.rs
+++ b/stats/stats-server/src/config/json_config.rs
@@ -15,15 +15,9 @@ pub struct LineChartSection {
 
 #[derive(Default, Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
-pub struct LineCharts {
-    pub sections: BTreeMap<String, LineChartSection>,
-}
-
-#[derive(Default, Debug, Clone, Deserialize)]
-#[serde(default, deny_unknown_fields)]
 pub struct Config {
     pub counters: BTreeMap<String, CounterInfo>,
-    pub lines: LineCharts,
+    pub lines: BTreeMap<String, LineChartSection>,
 }
 
 impl From<Config> for toml_config::Config {
@@ -34,20 +28,19 @@ impl From<Config> for toml_config::Config {
                 .into_iter()
                 .map(toml_config::CounterInfo::from)
                 .collect(),
-            lines: value.lines.into(),
+            lines: value
+                .lines
+                .into_iter()
+                .map(toml_config::LineChartSection::from)
+                .collect::<Vec<_>>()
+                .into(),
         }
     }
 }
 
-impl From<LineCharts> for toml_config::LineCharts {
-    fn from(value: LineCharts) -> Self {
-        Self {
-            sections: value
-                .sections
-                .into_iter()
-                .map(toml_config::LineChartSection::from)
-                .collect(),
-        }
+impl From<Vec<toml_config::LineChartSection>> for toml_config::LineCharts {
+    fn from(sections: Vec<toml_config::LineChartSection>) -> Self {
+        Self { sections }
     }
 }
 

--- a/stats/stats-server/src/config/mod.rs
+++ b/stats/stats-server/src/config/mod.rs
@@ -1,0 +1,31 @@
+mod chart_info;
+pub mod json_config;
+pub mod toml_config;
+
+pub use chart_info::ChartSettings;
+use std::path::PathBuf;
+
+pub fn read_charts_config(path: PathBuf) -> Result<toml_config::Config, anyhow::Error> {
+    let extension = path.extension();
+    if extension == Some(std::ffi::OsStr::new("json")) {
+        let json_config: json_config::Config = config::Config::builder()
+            .add_source(config::File::from(path))
+            .add_source(
+                config::Environment::with_prefix("STATS_CFG")
+                    .separator("__")
+                    .try_parsing(true),
+            )
+            .build()?
+            .try_deserialize()?;
+        Ok(json_config.into())
+    } else if extension == Some(std::ffi::OsStr::new("toml")) {
+        let toml_config = std::fs::read(path)?;
+        let toml_config: toml_config::Config = toml::from_slice(&toml_config)?;
+
+        Ok(toml_config)
+    } else {
+        Err(anyhow::anyhow!(
+            "invalid chart config extension: {extension:?}"
+        ))
+    }
+}

--- a/stats/stats-server/src/config/mod.rs
+++ b/stats/stats-server/src/config/mod.rs
@@ -1,31 +1,8 @@
 mod chart_info;
+mod read;
+
 pub mod json_config;
 pub mod toml_config;
 
 pub use chart_info::ChartSettings;
-use std::path::PathBuf;
-
-pub fn read_charts_config(path: PathBuf) -> Result<toml_config::Config, anyhow::Error> {
-    let extension = path.extension();
-    if extension == Some(std::ffi::OsStr::new("json")) {
-        let json_config: json_config::Config = config::Config::builder()
-            .add_source(config::File::from(path))
-            .add_source(
-                config::Environment::with_prefix("STATS_CFG")
-                    .separator("__")
-                    .try_parsing(true),
-            )
-            .build()?
-            .try_deserialize()?;
-        Ok(json_config.into())
-    } else if extension == Some(std::ffi::OsStr::new("toml")) {
-        let toml_config = std::fs::read(path)?;
-        let toml_config: toml_config::Config = toml::from_slice(&toml_config)?;
-
-        Ok(toml_config)
-    } else {
-        Err(anyhow::anyhow!(
-            "invalid chart config extension: {extension:?}"
-        ))
-    }
-}
+pub use read::read_charts_config;

--- a/stats/stats-server/src/config/read.rs
+++ b/stats/stats-server/src/config/read.rs
@@ -7,7 +7,7 @@ pub fn read_charts_config(path: PathBuf) -> Result<toml_config::Config, anyhow::
         let json_config: json_config::Config = config::Config::builder()
             .add_source(config::File::from(path))
             .add_source(
-                config::Environment::with_prefix("STATS_CFG")
+                config::Environment::with_prefix("STATS_CHARTS")
                     .separator("__")
                     .try_parsing(true),
             )

--- a/stats/stats-server/src/config/read.rs
+++ b/stats/stats-server/src/config/read.rs
@@ -1,0 +1,26 @@
+use super::{json_config, toml_config};
+use std::path::PathBuf;
+
+pub fn read_charts_config(path: PathBuf) -> Result<toml_config::Config, anyhow::Error> {
+    let extension = path.extension();
+    if extension == Some(std::ffi::OsStr::new("json")) {
+        let json_config: json_config::Config = config::Config::builder()
+            .add_source(config::File::from(path))
+            .add_source(
+                config::Environment::with_prefix("STATS_CFG")
+                    .separator("__")
+                    .try_parsing(true),
+            )
+            .build()?
+            .try_deserialize()?;
+        Ok(json_config.into())
+    } else if extension == Some(std::ffi::OsStr::new("toml")) {
+        let toml_config = std::fs::read(path)?;
+        let toml_config: toml_config::Config = toml::from_slice(&toml_config)?;
+        Ok(toml_config)
+    } else {
+        Err(anyhow::anyhow!(
+            "invalid chart config extension: {extension:?}"
+        ))
+    }
+}

--- a/stats/stats-server/src/config/read.rs
+++ b/stats/stats-server/src/config/read.rs
@@ -1,7 +1,7 @@
 use super::{json_config, toml_config};
-use std::path::PathBuf;
+use std::path::Path;
 
-pub fn read_charts_config(path: PathBuf) -> Result<toml_config::Config, anyhow::Error> {
+pub fn read_charts_config(path: &Path) -> Result<toml_config::Config, anyhow::Error> {
     let extension = path.extension();
     if extension == Some(std::ffi::OsStr::new("json")) {
         let json_config: json_config::Config = config::Config::builder()

--- a/stats/stats-server/src/config/toml_config.rs
+++ b/stats/stats-server/src/config/toml_config.rs
@@ -1,15 +1,7 @@
-use cron::Schedule;
 use serde::Deserialize;
-use serde_with::{serde_as, DisplayFromStr};
 use stats_proto::blockscout::stats::v1 as proto;
 
-#[serde_as]
-#[derive(Debug, Clone, Deserialize)]
-pub struct ChartSettings {
-    #[serde_as(as = "Option<DisplayFromStr>")]
-    pub update_schedule: Option<Schedule>,
-    pub units: Option<String>,
-}
+use super::chart_info::ChartSettings;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct CounterInfo {

--- a/stats/stats-server/src/lib.rs
+++ b/stats/stats-server/src/lib.rs
@@ -1,5 +1,5 @@
 mod charts;
-mod charts_config;
+mod config;
 mod health;
 mod read_service;
 mod serializers;

--- a/stats/stats-server/src/server.rs
+++ b/stats/stats-server/src/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    charts::Charts, charts_config, health::HealthService, read_service::ReadService,
+    charts::Charts, config::read_charts_config, health::HealthService, read_service::ReadService,
     settings::Settings, update_service::UpdateService,
 };
 use blockscout_service_launcher::LaunchSettings;
@@ -40,9 +40,7 @@ fn grpc_router<S: StatsService>(
 pub async fn stats(settings: Settings) -> Result<(), anyhow::Error> {
     blockscout_service_launcher::init_logs(SERVICE_NAME, &settings.tracing, &settings.jaeger)?;
 
-    let charts_config = std::fs::read(settings.charts_config)?;
-    let charts_config: charts_config::Config = toml::from_slice(&charts_config)?;
-
+    let charts_config = read_charts_config(settings.charts_config.clone())?;
     let mut opt = ConnectOptions::new(settings.db_url.clone());
     opt.sqlx_logging_level(tracing::log::LevelFilter::Debug);
     blockscout_service_launcher::database::initialize_postgres::<stats::migration::Migrator>(

--- a/stats/stats-server/src/server.rs
+++ b/stats/stats-server/src/server.rs
@@ -40,7 +40,7 @@ fn grpc_router<S: StatsService>(
 pub async fn stats(settings: Settings) -> Result<(), anyhow::Error> {
     blockscout_service_launcher::init_logs(SERVICE_NAME, &settings.tracing, &settings.jaeger)?;
 
-    let charts_config = read_charts_config(settings.charts_config.clone())?;
+    let charts_config = read_charts_config(&settings.charts_config)?;
     let mut opt = ConnectOptions::new(settings.db_url.clone());
     opt.sqlx_logging_level(tracing::log::LevelFilter::Debug);
     blockscout_service_launcher::database::initialize_postgres::<stats::migration::Migrator>(

--- a/stats/stats-server/src/settings.rs
+++ b/stats/stats-server/src/settings.rs
@@ -66,7 +66,7 @@ impl Default for Settings {
             default_schedule: Schedule::from_str("0 0 1 * * * *").unwrap(),
             force_update_on_start: Some(false),
             concurrent_start_updates: 3,
-            charts_config: PathBuf::from_str("config/charts.toml").unwrap(),
+            charts_config: PathBuf::from_str("config/charts.json").unwrap(),
             blockscout_db_url: Default::default(),
             create_database: Default::default(),
             run_migrations: Default::default(),


### PR DESCRIPTION
solves #546 

Added JSON option for chart configuration

Also we added ENV support for configuring charts, for example, disabling `totalBlocks` and `activeAccounts` can be done with
```bash
STATS_CHARTS__LINES__ACCOUNTS__CHARTS__ACTIVE_ACCOUNTS__ENABLED=false
#                    ^section name     ^line name
STATS_CHARTS__COUNTERS__TOTAL_BLOCKS__ENABLED=false
#                       ^counter name
```