### PR TITLE
Fix sourcify verification

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier/src/sourcify/api.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/sourcify/api.rs
@@ -20,7 +20,7 @@ impl From<VerificationRequest> for ApiRequest {
             address: value.address,
             chain: value.chain,
             files: Files(value.files),
-            chosen_contract: value.chosen_contract,
+            chosen_contract: value.chosen_contract.map(|v| v.to_string()),
         }
     }
 }

--- a/smart-contract-verifier/smart-contract-verifier/src/sourcify/api_client.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/sourcify/api_client.rs
@@ -62,20 +62,14 @@ impl SourcifyApiClient {
         &self,
         params: &ApiRequest,
     ) -> Result<ApiVerificationResponse, anyhow::Error> {
-        let response = self
-            .reqwest_client
+        self.reqwest_client
             .post(self.host.as_str())
             .json(&params)
             .send()
-            .await?;
-        if !response.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "response status code is not success: {} - {}",
-                response.status(),
-                response.text().await?
-            ));
-        }
-        response.json().await.map_err(anyhow::Error::msg)
+            .await?
+            .json()
+            .await
+            .map_err(anyhow::Error::msg)
     }
 
     pub(super) async fn source_files_request(
@@ -86,14 +80,12 @@ impl SourcifyApiClient {
             .host
             .join(format!("files/any/{}/{}", &params.chain, &params.address).as_str())
             .expect("should be valid url");
-        let response = self.reqwest_client.get(url).send().await?;
-        if !response.status().is_success() {
-            return Err(anyhow::anyhow!(
-                "response status code is not success: {} - {}",
-                response.status(),
-                response.text().await?
-            ));
-        }
-        response.json().await.map_err(anyhow::Error::msg)
+        self.reqwest_client
+            .get(url)
+            .send()
+            .await?
+            .json()
+            .await
+            .map_err(anyhow::Error::msg)
     }
 }

--- a/smart-contract-verifier/smart-contract-verifier/src/sourcify/api_client.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/sourcify/api_client.rs
@@ -70,8 +70,9 @@ impl SourcifyApiClient {
             .await?;
         if !response.status().is_success() {
             return Err(anyhow::anyhow!(
-                "response status code is not success: {}",
-                response.status()
+                "response status code is not success: {} - {}",
+                response.status(),
+                response.text().await?
             ));
         }
         response.json().await.map_err(anyhow::Error::msg)
@@ -88,8 +89,9 @@ impl SourcifyApiClient {
         let response = self.reqwest_client.get(url).send().await?;
         if !response.status().is_success() {
             return Err(anyhow::anyhow!(
-                "response status code is not success: {}",
-                response.status()
+                "response status code is not success: {} - {}",
+                response.status(),
+                response.text().await?
             ));
         }
         response.json().await.map_err(anyhow::Error::msg)

--- a/smart-contract-verifier/smart-contract-verifier/src/sourcify/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/sourcify/types.rs
@@ -12,7 +12,8 @@ pub struct ApiRequest {
     pub address: String,
     pub chain: String,
     pub files: Files,
-    pub chosen_contract: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chosen_contract: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -158,7 +159,7 @@ mod tests {
                         ("source.sol".to_string(), "pragma ...".to_string()),
                         ("metadata.json".to_string(), "{ metadata: ... }".to_string()),
                     ])),
-                    chosen_contract: Some(1),
+                    chosen_contract: Some("1".into()),
                 },
             ),
         ]);

--- a/smart-contract-verifier/smart-contract-verifier/src/sourcify/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/sourcify/types.rs
@@ -150,7 +150,7 @@ mod tests {
                         "source.sol": "pragma ...",
                         "metadata.json": "{ metadata: ... }"
                     },
-                    "chosenContract": 1
+                    "chosenContract": "1"
                 }"#,
                 ApiRequest {
                     address: "0xcafecafecafecafecafecafecafecafecafecafe".to_string(),


### PR DESCRIPTION
Currently verification requests to Sourcify fails, due to an invalid type of `chosenContract` field. Previously the null option was considered valid for that argument, but due to some latest Sourcify API changes now it returns an error saying that it expected "String". This PR fixes that by omitting `chosenContract` in case if it is empty