### PR TITLE
Fix missing zeros bug

### DIFF
--- a/stats/stats-server/src/serializers.rs
+++ b/stats/stats-server/src/serializers.rs
@@ -2,25 +2,16 @@ use chrono::{Duration, NaiveDate};
 use stats::{DateValue, MissingDatePolicy};
 use stats_proto::blockscout::stats::v1::Point;
 
-pub fn serialize_line_points(
-    data: Vec<DateValue>,
-    missing_date_policy: MissingDatePolicy,
-    from: Option<NaiveDate>,
-    to: Option<NaiveDate>,
-) -> Vec<Point> {
-    let data = fill_missing_points(data, missing_date_policy, from, to);
-    let serialized_chart: Vec<_> = data
-        .into_iter()
+pub fn serialize_line_points(data: Vec<DateValue>) -> Vec<Point> {
+    data.into_iter()
         .map(|point| Point {
             date: point.date.to_string(),
             value: point.value,
         })
-        .collect();
-
-    serialized_chart
+        .collect()
 }
 
-fn fill_missing_points(
+pub fn fill_missing_points(
     data: Vec<DateValue>,
     policy: MissingDatePolicy,
     from: Option<NaiveDate>,


### PR DESCRIPTION
Currently, we fill missing dates with zeros after removing last partial points. this isnt correct

<img width="526" alt="image" src="https://github.com/blockscout/blockscout-rs/assets/41516657/3ff8ff64-73ad-4fc9-ae1c-0477f5bb331a">
