### PR TITLE
Fix settings bug

### DIFF
--- a/stats/stats-server/src/charts_config.rs
+++ b/stats/stats-server/src/charts_config.rs
@@ -9,10 +9,6 @@ pub struct ChartSettings {
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub update_schedule: Option<Schedule>,
     pub units: Option<String>,
-    #[serde(default)]
-    pub drop_last_point: bool,
-    #[serde(default)]
-    pub relevant_or_zero: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]


### PR DESCRIPTION
in https://github.com/blockscout/blockscout-rs/pull/548/ we added new source of settings for charts: using `Chart` trait. This PR removes previous configuration and uses new settings from this trait