### PR TITLE
Eth-bytecode-db: allow partial values for the verification metadata

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -3902,7 +3902,7 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 [[package]]
 name = "smart-contract-verifier-proto"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=ee52afad#ee52afad47b5032c79492f4bef20f99d999c50bb"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=52c41ec#52c41ecdf4dca82580893cd4dd026079f784d560"
 dependencies = [
  "actix-prost",
  "actix-prost-build",

--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -1387,6 +1387,7 @@ dependencies = [
  "rstest",
  "sea-orm",
  "serde",
+ "serde_json",
  "serde_with",
  "smart-contract-verifier-proto",
  "tokio",

--- a/eth-bytecode-db/eth-bytecode-db-proto/proto/v2/eth-bytecode-db.proto
+++ b/eth-bytecode-db/eth-bytecode-db-proto/proto/v2/eth-bytecode-db.proto
@@ -79,9 +79,9 @@ enum BytecodeType {
 
 message VerificationMetadata {
   /// Id of the chain the contract is verified on
-  string chain_id = 1;
+  optional string chain_id = 1;
   /// The address of the contract to be verified
-  string contract_address = 2;
+  optional string contract_address = 2;
 }
 
 message VerifySolidityMultiPartRequest {

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -33,5 +33,6 @@ reqwest = { version = "0.11", features = ["json"]}
 rand = "0.8"
 rstest = "0.16"
 sea-orm = { version = "*", features = [ "sqlx-sqlite" ]}
+serde_json = "1.0.96"
 tokio-stream = { version = "0.1", features = ["net"] }
 tracing = "0.1"

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 
 [dev-dependencies]
-smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "ee52afad" }
+smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "52c41ec" }
 
 hex = "0.4.3"
 mockall = "0.11"

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
@@ -136,3 +136,28 @@ async fn test_search_returns_full_matches_only_if_any() {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_accepts_partial_verification_metadata_in_input() {
+    let default_request = VerifySolidityMultiPartRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        evm_version: None,
+        optimization_runs: None,
+        source_files: Default::default(),
+        libraries: Default::default(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Solidity;
+    test_cases::test_accepts_partial_verification_metadata_in_input::<MockSolidityVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+        .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
@@ -124,3 +124,25 @@ async fn test_search_returns_full_matches_only_if_any() {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_accepts_partial_verification_metadata_in_input() {
+    let default_request = VerifySolidityStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Solidity;
+    test_cases::test_accepts_partial_verification_metadata_in_input::<MockSolidityVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+        .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
@@ -132,3 +132,27 @@ async fn test_search_returns_full_matches_only_if_any() {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_accepts_partial_verification_metadata_in_input() {
+    let default_request = VerifyVyperMultiPartRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        evm_version: None,
+        source_files: Default::default(),
+        interfaces: Default::default(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_accepts_partial_verification_metadata_in_input::<MockVyperVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_standard_json.rs
@@ -124,3 +124,25 @@ async fn test_search_returns_full_matches_only_if_any() {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_accepts_partial_verification_metadata_in_input() {
+    let default_request = VerifyVyperStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_accepts_partial_verification_metadata_in_input::<MockVyperVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -27,7 +27,7 @@ prometheus = "0.13"
 semver = "1.0"
 serde = "1.0"
 serde_json = "1.0"
-smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "ee52afad" }
+smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "52c41ec" }
 solidity-metadata = "1.0"
 thiserror = "1.0"
 tokio = "1.22"

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/db.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/db.rs
@@ -118,8 +118,8 @@ pub(crate) async fn insert_verified_contract_data(
     let (chain_id, contract_address) = match verification_metadata {
         None => (None, None),
         Some(metadata) => (
-            Some(metadata.chain_id),
-            Some(metadata.contract_address.to_vec()),
+            metadata.chain_id,
+            metadata.contract_address.map(|address| address.to_vec()),
         ),
     };
     verified_contracts::ActiveModel {

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
@@ -105,8 +105,8 @@ mod tests {
             optimization_runs: Some(200),
             libraries: BTreeMap::from([("lib1".into(), "0xcafe".into())]),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(
@@ -148,8 +148,8 @@ mod tests {
             optimization_runs: Some(200),
             libraries: BTreeMap::from([("lib1".into(), "0xcafe".into())]),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
@@ -89,8 +89,8 @@ mod tests {
                 libraries: BTreeMap::from([("lib1".into(), "0xcafe".into())]),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifySolidityMultiPartRequest {
@@ -132,8 +132,8 @@ mod tests {
                 libraries: BTreeMap::from([("lib1".into(), "0xcafe".into())]),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifySolidityMultiPartRequest {

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
@@ -86,8 +86,8 @@ mod tests {
             compiler_version: "compiler_version".to_string(),
             input: "standard_json_input".to_string(),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(
@@ -117,8 +117,8 @@ mod tests {
             compiler_version: "compiler_version".to_string(),
             input: "standard_json_input".to_string(),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
@@ -76,8 +76,8 @@ mod tests {
                 input: "standard_json_input".to_string(),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifySolidityStandardJsonRequest {
@@ -107,8 +107,8 @@ mod tests {
                 input: "standard_json_input".to_string(),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifySolidityStandardJsonRequest {

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -89,8 +89,8 @@ mod tests {
                 ]),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifyVyperMultiPartRequest {
@@ -136,8 +136,8 @@ mod tests {
                 ]),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifyVyperMultiPartRequest {

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -107,8 +107,8 @@ mod tests {
             ]),
             evm_version: Some("istanbul".to_string()),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(
@@ -154,8 +154,8 @@ mod tests {
             ]),
             evm_version: Some("istanbul".to_string()),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
@@ -75,8 +75,8 @@ mod tests {
                 input: "standard_json_input".to_string(),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifyVyperStandardJsonRequest {
@@ -106,8 +106,8 @@ mod tests {
                 input: "standard_json_input".to_string(),
             },
             metadata: Some(types::VerificationMetadata {
-                chain_id: 1,
-                contract_address: bytes::Bytes::from_static(&[1u8; 20]),
+                chain_id: Some(1),
+                contract_address: Some(bytes::Bytes::from_static(&[1u8; 20])),
             }),
         };
         let expected = VerifyVyperStandardJsonRequest {

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
@@ -85,8 +85,8 @@ mod tests {
             compiler_version: "compiler_version".to_string(),
             input: "standard_json_input".to_string(),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(
@@ -116,8 +116,8 @@ mod tests {
             compiler_version: "compiler_version".to_string(),
             input: "standard_json_input".to_string(),
             metadata: Some(smart_contract_verifier::VerificationMetadata {
-                chain_id: "1".to_string(),
-                contract_address: "0x0101010101010101010101010101010101010101".to_string(),
+                chain_id: Some("1".to_string()),
+                contract_address: Some("0x0101010101010101010101010101010101010101".to_string()),
             }),
         };
         assert_eq!(

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/types.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/types.rs
@@ -181,9 +181,10 @@ pub struct VerificationMetadata {
 impl From<VerificationMetadata> for smart_contract_verifier::VerificationMetadata {
     fn from(value: VerificationMetadata) -> Self {
         Self {
-            chain_id: format!("{}", value.chain_id),
-            contract_address: blockscout_display_bytes::Bytes::from(value.contract_address)
-                .to_string(),
+            chain_id: Some(format!("{}", value.chain_id)),
+            contract_address: Some(
+                blockscout_display_bytes::Bytes::from(value.contract_address).to_string(),
+            ),
         }
     }
 }

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/types.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/types.rs
@@ -174,17 +174,19 @@ pub struct Source {
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct VerificationMetadata {
-    pub chain_id: i64,
-    pub contract_address: bytes::Bytes,
+    pub chain_id: Option<i64>,
+    pub contract_address: Option<bytes::Bytes>,
 }
 
 impl From<VerificationMetadata> for smart_contract_verifier::VerificationMetadata {
     fn from(value: VerificationMetadata) -> Self {
+        let chain_id = value.chain_id.map(|id| format!("{}", id));
+        let contract_address = value
+            .contract_address
+            .map(|address| blockscout_display_bytes::Bytes::from(address).to_string());
         Self {
-            chain_id: Some(format!("{}", value.chain_id)),
-            contract_address: Some(
-                blockscout_display_bytes::Bytes::from(value.contract_address).to_string(),
-            ),
+            chain_id,
+            contract_address,
         }
     }
 }

--- a/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/mod.rs
@@ -467,8 +467,8 @@ pub async fn test_historical_data_saves_chain_id_and_contract_address<Service, R
         service.generate_request(
             1,
             Some(VerificationMetadata {
-                chain_id,
-                contract_address: contract_address.clone(),
+                chain_id: Some(chain_id),
+                contract_address: Some(contract_address.clone()),
             }),
         ),
         source_type,


### PR DESCRIPTION
Continues #565 for eth-bytecode-db service. Allows the verification metadata with only one of the `chain_id` or `contract_address` value provided. That information is optional, and the service should not reject the whole input just because one of those values is not provided.

