### PR TITLE
Fix sections order

### DIFF
--- a/stats/Cargo.lock
+++ b/stats/Cargo.lock
@@ -1638,6 +1638,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,7 +2395,7 @@ checksum = "1d8b442418ea0822409d9e7d047cbf1e7e9e1760b172bf9982cf29d517c93511"
 dependencies = [
  "bytes",
  "heck 0.4.0",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -2407,7 +2416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "164ae68b6587001ca506d3bf7f1000bfa248d0e1217b618108fba4ec1d0cc306"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn",
@@ -3145,7 +3154,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87e292b4291f154971a43c3774364e2cbcaec599d3f5bf6fa9d122885dbc38a"
 dependencies = [
- "itertools",
+ "itertools 0.10.5",
  "nom",
  "unicode_categories",
 ]
@@ -3302,6 +3311,7 @@ dependencies = [
  "convert_case 0.6.0",
  "cron",
  "futures",
+ "itertools 0.11.0",
  "pretty_assertions",
  "reqwest",
  "reqwest-middleware",

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -54,6 +54,7 @@
     "lines": {
         "accounts": {
             "title": "Accounts",
+            "order": 1,
             "charts": {
                 "active_accounts": {
                     "title": "Active accounts",
@@ -74,6 +75,7 @@
         },
         "transactions": {
             "title": "Transactions",
+            "order": 2,
             "charts": {
                 "average_txn_fee": {
                     "title": "Average transaction fee",
@@ -106,6 +108,7 @@
         },
         "blocks": {
             "title": "Blocks",
+            "order": 3,
             "charts": {
                 "new_blocks": {
                     "title": "New blocks",
@@ -128,6 +131,7 @@
         },
         "tokens": {
             "title": "Tokens",
+            "order": 4,
             "charts": {
                 "new_native_coin_transfers": {
                     "title": "New native coins transfers",
@@ -157,6 +161,7 @@
         },
         "gas": {
             "title": "Gas",
+            "order": 5,
             "charts": {
                 "average_gas_limit": {
                     "title": "Average gas limit",
@@ -178,6 +183,7 @@
         },
         "contracts": {
             "title": "Contracts",
+            "order": 6,
             "charts": {
                 "new_verified_contracts": {
                     "title": "New verified contracts",

--- a/stats/stats-server/Cargo.toml
+++ b/stats/stats-server/Cargo.toml
@@ -27,6 +27,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 blockscout-service-launcher = { version = "0.7.1", features = [ "database-0_10" ] }
 cron = "0.12"
 convert_case = "0.6.0"
+itertools = "0.11.0"
 
 [dev-dependencies]
 reqwest-middleware = "0.2"

--- a/stats/stats-server/src/config/json_config.rs
+++ b/stats/stats-server/src/config/json_config.rs
@@ -3,6 +3,7 @@ use super::{
     toml_config,
 };
 use convert_case::{Case, Casing};
+use itertools::Itertools;
 use serde::Deserialize;
 use std::collections::BTreeMap;
 
@@ -10,6 +11,7 @@ use std::collections::BTreeMap;
 #[serde(default, deny_unknown_fields)]
 pub struct LineChartSection {
     pub title: String,
+    pub order: Option<i64>,
     pub charts: BTreeMap<String, LineChartInfo>,
 }
 
@@ -31,6 +33,7 @@ impl From<Config> for toml_config::Config {
             lines: value
                 .lines
                 .into_iter()
+                .sorted_by_key(|(_, section)| section.order)
                 .map(toml_config::LineChartSection::from)
                 .collect::<Vec<_>>()
                 .into(),

--- a/stats/stats-server/tests/lines.rs
+++ b/stats/stats-server/tests/lines.rs
@@ -40,6 +40,30 @@ async fn test_lines_ok() {
 
     let client = client();
 
+    let resp = client
+        .get(format!("{base}/api/v1/lines"))
+        .send()
+        .await
+        .expect("failed to connect to server");
+    let s = resp.status();
+    assert_eq!(s, 200, "invalid status for charts info: {s:?}");
+    let line_charts: stats_proto::blockscout::stats::v1::LineCharts =
+        resp.json().await.expect("failed to parse response");
+    let sections: Vec<&str> = line_charts
+        .sections
+        .iter()
+        .map(|sec| sec.id.as_str())
+        .collect();
+    let expected_sections = [
+        "accounts",
+        "transactions",
+        "blocks",
+        "tokens",
+        "gas",
+        "contracts",
+    ];
+    assert_eq!(sections, expected_sections, "wrong sections response");
+
     for line_name in [
         "accountsGrowth",
         "activeAccounts",


### PR DESCRIPTION
There is a problem that json doesn't support order of keys and previously we changed config structure of sections from `array` to `map`.

Therefore, we either need to change sections to `array` (breaking change) or add `Option<i64>` field `order` to sort sections using that field. I decided to choose 2nd way. 
Also, now we can change order of sections using ENV variables

