### PR TITLE
sourcify: set max-retries

### DIFF
--- a/libs/sourcify/Cargo.toml
+++ b/libs/sourcify/Cargo.toml
@@ -19,8 +19,11 @@ tracing = { version = "0.1.37", optional = true }
 url = "2.4.0"
 
 [dev-dependencies]
+governor = "0.5.1"
+once_cell = "1.18.0"
 pretty_assertions = "1.3.0"
-tokio = { version = "1.28.2", features = ["macros"] }
+reqwest-rate-limiter = { git = "https://github.com/blockscout/blockscout-rs", rev = "13ef4e8" }
+tokio = { version = "1.28.2", features = ["macros"]}
 
 [features]
 default = ["tracing"]

--- a/libs/sourcify/src/client.rs
+++ b/libs/sourcify/src/client.rs
@@ -8,23 +8,26 @@ use crate::{
 use blockscout_display_bytes::Bytes as DisplayBytes;
 use bytes::Bytes;
 use reqwest::{Response, StatusCode};
-use reqwest_middleware::ClientWithMiddleware;
+use reqwest_middleware::{ClientWithMiddleware, Middleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use serde::{Deserialize, Serialize};
-use std::{str::FromStr, time::Duration};
+use std::{str::FromStr};
+use std::sync::Arc;
 use url::Url;
 
 #[derive(Clone)]
 pub struct ClientBuilder {
     base_url: Url,
-    total_duration: Duration,
+    max_retries: u32,
+    middleware_stack: Vec<Arc<dyn Middleware>>,
 }
 
 impl Default for ClientBuilder {
     fn default() -> Self {
         Self {
             base_url: Url::from_str("https://sourcify.dev/server/").unwrap(),
-            total_duration: Duration::from_secs(180),
+            max_retries: 3,
+            middleware_stack: vec![],
         }
     }
 }
@@ -37,17 +40,28 @@ impl ClientBuilder {
         Ok(self)
     }
 
-    pub fn total_duration(mut self, total_duration: Duration) -> Self {
-        self.total_duration = total_duration;
+    pub fn max_retries(mut self, max_retries: u32) -> Self {
+        self.max_retries = max_retries;
+        self
+    }
+
+    pub fn with_middleware<M: Middleware>(self, middleware: M) -> Self {
+        self.with_arc_middleware(Arc::new(middleware))
+    }
+
+    pub fn with_arc_middleware<M: Middleware>(mut self, middleware: Arc<M>) -> Self {
+        self.middleware_stack.push(middleware);
         self
     }
 
     pub fn build(self) -> Client {
-        let retry_policy =
-            ExponentialBackoff::builder().build_with_total_retry_duration(self.total_duration);
-        let client = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
-            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
-            .build();
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(self.max_retries);
+        let mut client_builder = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy));
+        for middleware in self.middleware_stack {
+            client_builder = client_builder.with_arc(middleware);
+        }
+        let client = client_builder.build();
 
         Client {
             base_url: self.base_url,
@@ -190,231 +204,252 @@ impl Client {
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-//     use serde_json::json;
-//
-//     fn parse_contract_address(contract_address: &str) -> Bytes {
-//         DisplayBytes::from_str(contract_address).unwrap().0
-//     }
-//
-//     mod success {
-//         use super::*;
-//         use pretty_assertions::assert_eq;
-//
-//         #[tokio::test]
-//         async fn get_source_files_any() {
-//             let expected: GetSourceFilesResponse = serde_json::from_value(json!({
-//             "status": "full",
-//             "files": [
-//                 {
-//                     "name": "library-map.json",
-//                     "path": "/home/data/repository/contracts/full_match/5/0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52/library-map.json",
-//                     "content": "{\"__$54103d3e1543ebb87230c9454f838057a5$__\":\"6b88c55cfbd4eda1320f802b724193cab062ccce\"}"
-//                 },
-//                 {
-//                     "name": "metadata.json",
-//                     "path": "/home/data/repository/contracts/full_match/5/0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52/metadata.json",
-//                     "content": "{\"compiler\":{\"version\":\"0.6.8+commit.0bbfe453\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[],\"name\":\"SourcifySolidity14\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"input\",\"type\":\"address\"}],\"name\":\"identity\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"contracts/project:/ExternalTestMultiple.sol\":\"ExternalTestMultiple\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":300},\"remappings\":[]},\"sources\":{\"contracts/project:/ExternalTestMultiple.sol\":{\"keccak256\":\"0xc40380283b7d4a97da5e247fbb7b795f6241cfe3d86e34493d87528dfcb4d56b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://86ec578963cb912c4b912f066390e564c54ea1bc5fb1a55aa4e4c77bb92b07ba\",\"dweb:/ipfs/QmeqihJa8kUjbNHNCpFRHkq1scCbjjFvaUN2gWEJCNEx1Q\"]},\"contracts/project_/ExternalTestMultiple.sol\":{\"keccak256\":\"0xff9e0ddd21b0579491371fe8d4f7e09254ffc7af9382ba287ef8d2a2fd1ce8e2\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1f516a34091c829a18a8c5dd13fbd82f44b532e7dea6fed9f60ae731c9042d74\",\"dweb:/ipfs/QmZqm6CLGUKQ3RJCLAZy5CWo2ScLzV2r5JXWNWfBwbGCsK\"]}},\"version\":1}"
-//                 },
-//                 {
-//                     "name": "ExternalTestMultiple.sol",
-//                     "path": "/home/data/repository/contracts/full_match/5/0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52/sources/contracts/project_/ExternalTestMultiple.sol",
-//                     "content": "//SPDX-License-Identifier: MIT\r\npragma solidity ^0.6.8;\r\n\r\nlibrary ExternalTestLibraryMultiple {\r\n  function pop(address[] storage list) external returns (address out) {\r\n    out = list[list.length - 1];\r\n    list.pop();\r\n  }\r\n}\r\n"
-//                 }
-//             ]
-//         })).unwrap();
-//
-//             let chain_id = "5";
-//             let contract_address =
-//                 parse_contract_address("0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52");
-//
-//             let result = Client::default()
-//                 .get_source_files_any(chain_id, contract_address)
-//                 .await
-//                 .expect("success expected");
-//             assert_eq!(expected, result);
-//         }
-//
-//         #[tokio::test]
-//         async fn verify_from_etherscan() {
-//             let expected: VerifyFromEtherscanResponse = serde_json::from_value(json!({
-//             "result": [
-//                 {
-//                     "address": "0x831b003398106153eD89a758bEC9734667D18AeC",
-//                     "chainId": "10",
-//                     "status": "partial",
-//                     "libraryMap": {
-//                         "__$5762d9689e001ee319dd424b89cc702f5c$__": "9224ee604e9b62f8e0a0e5824fee2e0df2ca902f"
-//                     },
-//                     "immutableReferences": {"2155":[{"length":32,"start":4157},{"length":32,"start":4712}],"2157":[{"length":32,"start":1172},{"length":32,"start":1221},{"length":32,"start":1289},{"length":32,"start":2077},{"length":32,"start":4218},{"length":32,"start":5837}],"2159":[{"length":32,"start":742},{"length":32,"start":4943}],"2161":[{"length":32,"start":402},{"length":32,"start":3247},{"length":32,"start":5564}]}
-//                 }
-//             ]
-//         })).unwrap();
-//
-//             let chain_id = "10";
-//             let contract_address =
-//                 parse_contract_address("0x831b003398106153eD89a758bEC9734667D18AeC");
-//
-//             let result = Client::default()
-//                 .verify_from_etherscan(chain_id, contract_address)
-//                 .await
-//                 .expect("success expected");
-//             assert_eq!(expected, result);
-//         }
-//     }
-//
-//     mod not_found {
-//         use super::*;
-//
-//         #[tokio::test]
-//         async fn get_source_files_any() {
-//             let chain_id = "5";
-//             let contract_address =
-//                 parse_contract_address("0x847F2d0c193E90963aAD7B2791aAE8d7310dFF6A");
-//
-//             let result = Client::default()
-//                 .get_source_files_any(chain_id, contract_address)
-//                 .await
-//                 .expect_err("error expected");
-//             assert!(
-//                 matches!(result, Error::Sourcify(SourcifyError::NotFound(_))),
-//                 "expected: 'SourcifyError::NotFound', got: {result:?}"
-//             );
-//         }
-//
-//         /*
-//         * Not implemented, as custom error that 'contract is not verified on Etherscan' is returned instead.
-//
-//         * async fn verify_from_etherscan() {}
-//         */
-//     }
-//
-//     mod bad_request {
-//         use super::*;
-//
-//         #[tokio::test]
-//         async fn get_source_files_any_invalid_argument() {
-//             let chain_id = "5";
-//             let contract_address = parse_contract_address("0xcafecafecafecafe");
-//
-//             let result = Client::default()
-//                 .get_source_files_any(chain_id, contract_address)
-//                 .await
-//                 .expect_err("error expected");
-//             assert!(
-//                 matches!(result, Error::Sourcify(SourcifyError::BadRequest(_))),
-//                 "expected: 'SourcifyError::BadRequest', got: {result:?}"
-//             );
-//         }
-//
-//         #[tokio::test]
-//         async fn verify_from_etherscan_invalid_argument() {
-//             let chain_id = "5";
-//             let contract_address = parse_contract_address("0xcafecafecafecafe");
-//
-//             let result = Client::default()
-//                 .verify_from_etherscan(chain_id, contract_address)
-//                 .await
-//                 .expect_err("error expected");
-//             assert!(
-//                 matches!(result, Error::Sourcify(SourcifyError::BadRequest(_))),
-//                 "expected: 'SourcifyError::BadRequest', got: {result:?}"
-//             );
-//         }
-//     }
-//
-//     mod chain_not_supported {
-//         use super::*;
-//
-//         #[tokio::test]
-//         async fn get_source_files_any() {
-//             let chain_id = "12345";
-//             let contract_address =
-//                 parse_contract_address("0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52");
-//
-//             let result = Client::default()
-//                 .get_source_files_any(chain_id, contract_address)
-//                 .await
-//                 .expect_err("error expected");
-//             assert!(
-//                 matches!(result, Error::Sourcify(SourcifyError::ChainNotSupported(_))),
-//                 "expected: 'SourcifyError::BadRequest', got: {result:?}"
-//             );
-//         }
-//
-//         /*
-//         * Not implemented, as custom error that 'chain is not supported for verification on Etherscan' is returned instead.
-//
-//         * async fn verify_from_etherscan() {}
-//         */
-//     }
-//
-//     mod custom_errors {
-//         use super::*;
-//
-//         #[tokio::test]
-//         async fn verify_from_etherscan_chain_is_not_supported() {
-//             let chain_id = "2221";
-//             let contract_address =
-//                 parse_contract_address("0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa");
-//
-//             let result = Client::default()
-//                 .verify_from_etherscan(chain_id, contract_address)
-//                 .await
-//                 .expect_err("error expected");
-//             assert!(matches!(
-//                 result,
-//                 Error::Sourcify(SourcifyError::Custom(
-//                     VerifyFromEtherscanError::ChainNotSupported(_)
-//                 ))
-//             ));
-//         }
-//
-//         #[tokio::test]
-//         async fn verify_from_etherscan_contract_not_verified() {
-//             let chain_id = "5";
-//             let contract_address =
-//                 parse_contract_address("0x847F2d0c193E90963aAD7B2791aAE8d7310dFF6A");
-//
-//             let result = Client::default()
-//                 .verify_from_etherscan(chain_id, contract_address)
-//                 .await
-//                 .expect_err("error expected");
-//             assert!(matches!(
-//                 result,
-//                 Error::Sourcify(SourcifyError::Custom(
-//                     VerifyFromEtherscanError::ContractNotVerified(_)
-//                 ))
-//             ));
-//         }
-//
-//         /*
-//         * Not implemented to avoid unnecessary burden on the Sourcify server.
-//
-//         * async fn verify_from_etherscan_too_many_request() {}
-//         */
-//
-//         /*
-//         * Not implemented as could not find any contract for which the error is returned.
-//         * We need to add the implementation when such contract is found.
-//
-//         * async fn verify_from_etherscan_api_response_error() {}
-//         */
-//
-//         /*
-//         * Not implemented as could not find any contract for which the error is returned.
-//         * We need to add the implementation when such contract is found.
-//
-//         * async fn verify_from_etherscan_cannot_generate_solc_json_input() {}
-//         */
-//
-//         /*
-//         * Not implemented as could not find any contract for which the error is returned.
-//         * We need to add the implementation when such contract is found.
-//
-//         * async fn verify_from_etherscan_verified_with_errors() {}
-//         */
-//     }
-// }
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU32;
+    use super::*;
+    use serde_json::json;
+    use reqwest_rate_limiter::RateLimiterMiddleware;
+    use governor::{RateLimiter, Quota};
+    use governor::clock::DefaultClock;
+    use governor::middleware::NoOpMiddleware;
+    use governor::state::{InMemoryState, NotKeyed};
+    use once_cell::sync::OnceCell;
+
+    fn parse_contract_address(contract_address: &str) -> Bytes {
+        DisplayBytes::from_str(contract_address).unwrap().0
+    }
+
+    static RATE_LIMITER_MIDDLEWARE: OnceCell<Arc<RateLimiterMiddleware<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>>> = OnceCell::new();
+    fn rate_limiter_middleware() -> &'static Arc<RateLimiterMiddleware<NotKeyed, InMemoryState, DefaultClock, NoOpMiddleware>> {
+        RATE_LIMITER_MIDDLEWARE
+            .get_or_init(|| {
+                let max_burst = NonZeroU32::new(1).unwrap();
+                Arc::new(RateLimiterMiddleware::new(RateLimiter::direct(Quota::per_second(max_burst))))
+            })
+    }
+
+    fn client() -> Client {
+        let rate_limiter = rate_limiter_middleware().clone();
+        ClientBuilder::default().max_retries(1).with_arc_middleware(rate_limiter).build()
+    }
+
+    mod success {
+        use super::*;
+        use pretty_assertions::assert_eq;
+
+        #[tokio::test]
+        async fn get_source_files_any() {
+            let expected: GetSourceFilesResponse = serde_json::from_value(json!({
+            "status": "full",
+            "files": [
+                {
+                    "name": "library-map.json",
+                    "path": "/home/data/repository/contracts/full_match/5/0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52/library-map.json",
+                    "content": "{\"__$54103d3e1543ebb87230c9454f838057a5$__\":\"6b88c55cfbd4eda1320f802b724193cab062ccce\"}"
+                },
+                {
+                    "name": "metadata.json",
+                    "path": "/home/data/repository/contracts/full_match/5/0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52/metadata.json",
+                    "content": "{\"compiler\":{\"version\":\"0.6.8+commit.0bbfe453\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[],\"name\":\"SourcifySolidity14\",\"type\":\"event\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"input\",\"type\":\"address\"}],\"name\":\"identity\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"methods\":{}},\"userdoc\":{\"methods\":{}}},\"settings\":{\"compilationTarget\":{\"contracts/project:/ExternalTestMultiple.sol\":\"ExternalTestMultiple\"},\"evmVersion\":\"istanbul\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":300},\"remappings\":[]},\"sources\":{\"contracts/project:/ExternalTestMultiple.sol\":{\"keccak256\":\"0xc40380283b7d4a97da5e247fbb7b795f6241cfe3d86e34493d87528dfcb4d56b\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://86ec578963cb912c4b912f066390e564c54ea1bc5fb1a55aa4e4c77bb92b07ba\",\"dweb:/ipfs/QmeqihJa8kUjbNHNCpFRHkq1scCbjjFvaUN2gWEJCNEx1Q\"]},\"contracts/project_/ExternalTestMultiple.sol\":{\"keccak256\":\"0xff9e0ddd21b0579491371fe8d4f7e09254ffc7af9382ba287ef8d2a2fd1ce8e2\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1f516a34091c829a18a8c5dd13fbd82f44b532e7dea6fed9f60ae731c9042d74\",\"dweb:/ipfs/QmZqm6CLGUKQ3RJCLAZy5CWo2ScLzV2r5JXWNWfBwbGCsK\"]}},\"version\":1}"
+                },
+                {
+                    "name": "ExternalTestMultiple.sol",
+                    "path": "/home/data/repository/contracts/full_match/5/0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52/sources/contracts/project_/ExternalTestMultiple.sol",
+                    "content": "//SPDX-License-Identifier: MIT\r\npragma solidity ^0.6.8;\r\n\r\nlibrary ExternalTestLibraryMultiple {\r\n  function pop(address[] storage list) external returns (address out) {\r\n    out = list[list.length - 1];\r\n    list.pop();\r\n  }\r\n}\r\n"
+                }
+            ]
+        })).unwrap();
+
+            let chain_id = "5";
+            let contract_address =
+                parse_contract_address("0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52");
+
+            let result = client()
+                .get_source_files_any(chain_id, contract_address)
+                .await
+                .expect("success expected");
+            assert_eq!(expected, result);
+        }
+
+        #[tokio::test]
+        async fn verify_from_etherscan() {
+            let expected: VerifyFromEtherscanResponse = serde_json::from_value(json!({
+            "result": [
+                {
+                    "address": "0x831b003398106153eD89a758bEC9734667D18AeC",
+                    "chainId": "10",
+                    "status": "partial",
+                    "libraryMap": {
+                        "__$5762d9689e001ee319dd424b89cc702f5c$__": "9224ee604e9b62f8e0a0e5824fee2e0df2ca902f"
+                    },
+                    "immutableReferences": {"2155":[{"length":32,"start":4157},{"length":32,"start":4712}],"2157":[{"length":32,"start":1172},{"length":32,"start":1221},{"length":32,"start":1289},{"length":32,"start":2077},{"length":32,"start":4218},{"length":32,"start":5837}],"2159":[{"length":32,"start":742},{"length":32,"start":4943}],"2161":[{"length":32,"start":402},{"length":32,"start":3247},{"length":32,"start":5564}]}
+                }
+            ]
+        })).unwrap();
+
+            let chain_id = "10";
+            let contract_address =
+                parse_contract_address("0x831b003398106153eD89a758bEC9734667D18AeC");
+
+            let result = client()
+                .verify_from_etherscan(chain_id, contract_address)
+                .await
+                .expect("success expected");
+            assert_eq!(expected, result);
+        }
+    }
+
+    mod not_found {
+        use super::*;
+
+        #[tokio::test]
+        async fn get_source_files_any() {
+            let chain_id = "5";
+            let contract_address =
+                parse_contract_address("0x847F2d0c193E90963aAD7B2791aAE8d7310dFF6A");
+
+            let result = client()
+                .get_source_files_any(chain_id, contract_address)
+                .await
+                .expect_err("error expected");
+            assert!(
+                matches!(result, Error::Sourcify(SourcifyError::NotFound(_))),
+                "expected: 'SourcifyError::NotFound', got: {result:?}"
+            );
+        }
+
+        /*
+        * Not implemented, as custom error that 'contract is not verified on Etherscan' is returned instead.
+
+        * async fn verify_from_etherscan() {}
+        */
+    }
+
+    mod bad_request {
+        use super::*;
+
+        #[tokio::test]
+        async fn get_source_files_any_invalid_argument() {
+            let chain_id = "5";
+            let contract_address = parse_contract_address("0xcafecafecafecafe");
+
+            let result = client()
+                .get_source_files_any(chain_id, contract_address)
+                .await
+                .expect_err("error expected");
+            assert!(
+                matches!(result, Error::Sourcify(SourcifyError::BadRequest(_))),
+                "expected: 'SourcifyError::BadRequest', got: {result:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn verify_from_etherscan_invalid_argument() {
+            let chain_id = "5";
+            let contract_address = parse_contract_address("0xcafecafecafecafe");
+
+            let result = client()
+                .verify_from_etherscan(chain_id, contract_address)
+                .await
+                .expect_err("error expected");
+            assert!(
+                matches!(result, Error::Sourcify(SourcifyError::BadRequest(_))),
+                "expected: 'SourcifyError::BadRequest', got: {result:?}"
+            );
+        }
+    }
+
+    mod chain_not_supported {
+        use super::*;
+
+        #[tokio::test]
+        async fn get_source_files_any() {
+            let chain_id = "12345";
+            let contract_address =
+                parse_contract_address("0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52");
+
+            let result = client()
+                .get_source_files_any(chain_id, contract_address)
+                .await
+                .expect_err("error expected");
+            assert!(
+                matches!(result, Error::Sourcify(SourcifyError::ChainNotSupported(_))),
+                "expected: 'SourcifyError::BadRequest', got: {result:?}"
+            );
+        }
+
+        /*
+        * Not implemented, as custom error that 'chain is not supported for verification on Etherscan' is returned instead.
+
+        * async fn verify_from_etherscan() {}
+        */
+    }
+
+    mod custom_errors {
+        use super::*;
+
+        #[tokio::test]
+        async fn verify_from_etherscan_chain_is_not_supported() {
+            let chain_id = "2221";
+            let contract_address =
+                parse_contract_address("0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa");
+
+            let result = client()
+                .verify_from_etherscan(chain_id, contract_address)
+                .await
+                .expect_err("error expected");
+            assert!(matches!(
+                result,
+                Error::Sourcify(SourcifyError::Custom(
+                    VerifyFromEtherscanError::ChainNotSupported(_)
+                ))
+            ));
+        }
+
+        #[tokio::test]
+        async fn verify_from_etherscan_contract_not_verified() {
+            let chain_id = "5";
+            let contract_address =
+                parse_contract_address("0x847F2d0c193E90963aAD7B2791aAE8d7310dFF6A");
+
+            let result = client()
+                .verify_from_etherscan(chain_id, contract_address)
+                .await
+                .expect_err("error expected");
+            assert!(matches!(
+                result,
+                Error::Sourcify(SourcifyError::Custom(
+                    VerifyFromEtherscanError::ContractNotVerified(_)
+                ))
+            ));
+        }
+
+        /*
+        * Not implemented to avoid unnecessary burden on the Sourcify server.
+
+        * async fn verify_from_etherscan_too_many_request() {}
+        */
+
+        /*
+        * Not implemented as could not find any contract for which the error is returned.
+        * We need to add the implementation when such contract is found.
+
+        * async fn verify_from_etherscan_api_response_error() {}
+        */
+
+        /*
+        * Not implemented as could not find any contract for which the error is returned.
+        * We need to add the implementation when such contract is found.
+
+        * async fn verify_from_etherscan_cannot_generate_solc_json_input() {}
+        */
+
+        /*
+        * Not implemented as could not find any contract for which the error is returned.
+        * We need to add the implementation when such contract is found.
+
+        * async fn verify_from_etherscan_verified_with_errors() {}
+        */
+    }
+}

--- a/libs/sourcify/src/lib.rs
+++ b/libs/sourcify/src/lib.rs
@@ -17,6 +17,8 @@ pub enum SourcifyError<E: std::error::Error> {
     NotFound(String),
     #[error("'Bad Request': {0}")]
     BadRequest(String),
+    #[error("'Bad Gateway': {0}")]
+    BadGateway(String),
     #[error("unexpected status code: {status_code} - {msg}")]
     UnexpectedStatusCode {
         status_code: reqwest::StatusCode,

--- a/libs/sourcify/src/types.rs
+++ b/libs/sourcify/src/types.rs
@@ -16,6 +16,10 @@ mod custom_error {
             None
         }
 
+        fn handle_bad_gateway(_message: &str) -> Option<Self> {
+            None
+        }
+
         fn handle_internal_server_error(_message: &str) -> Option<Self> {
             None
         }
@@ -285,18 +289,6 @@ mod verify_from_etherscan {
                 ));
             }
 
-            if message.contains("Error in Etherscan API response") {
-                return Some(VerifyFromEtherscanError::ApiResponseError(
-                    message.to_string(),
-                ));
-            }
-
-            if message.contains("contract is not verified on Etherscan") {
-                return Some(VerifyFromEtherscanError::ContractNotVerified(
-                    message.to_string(),
-                ));
-            }
-
             if message.contains("cannot generate the solcJsonInput") {
                 return Some(VerifyFromEtherscanError::CannotGenerateSolcJsonInput(
                     message.to_string(),
@@ -305,6 +297,24 @@ mod verify_from_etherscan {
 
             if message.contains("contract was verified with errors") {
                 return Some(VerifyFromEtherscanError::VerifiedWithErrors(
+                    message.to_string(),
+                ));
+            }
+
+            None
+        }
+
+        fn handle_bad_gateway(message: &str) -> Option<Self> {
+            if (message.contains("Request to") && message.contains("apiKey=XXX failed with code"))
+                || message.contains("Error in Etherscan API response")
+            {
+                return Some(VerifyFromEtherscanError::ApiResponseError(
+                    message.to_string(),
+                ));
+            }
+
+            if message.contains("contract is not verified on Etherscan") {
+                return Some(VerifyFromEtherscanError::ContractNotVerified(
                     message.to_string(),
                 ));
             }


### PR DESCRIPTION
Currently we use `total_duration` as the parameter of how much requests should be made to sourcify via `reqwest-retry` middleware. This PR changes it to use `max-retries` parameter instead, as otherwise we may make too many requests and even crash the Sourcify down