### PR TITLE
Disable new sourcify tests

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-server/tests/sourcify.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/sourcify.rs
@@ -1,55 +1,55 @@
-mod verification_test_helpers;
-
-use async_trait::async_trait;
-use eth_bytecode_db::verification;
-use eth_bytecode_db_proto::blockscout::eth_bytecode_db::v2::VerifySourcifyRequest;
-use rstest::{fixture, rstest};
-use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2 as smart_contract_verifier_v2;
-use tonic::Response;
-use verification_test_helpers::{
-    smart_contract_verifer_mock::{MockSourcifyVerifierService, SmartContractVerifierServer},
-    test_cases, VerifierService,
-};
-
-const TEST_SUITE_NAME: &str = "sourcify";
-
-const ROUTE: &str = "/api/v2/verifier/sourcify/sources:verify";
-
-#[async_trait]
-impl VerifierService<smart_contract_verifier_v2::VerifyResponse> for MockSourcifyVerifierService {
-    fn add_into_service(&mut self, response: smart_contract_verifier_v2::VerifyResponse) {
-        self.expect_verify()
-            .returning(move |_| Ok(Response::new(response.clone())));
-    }
-
-    fn build_server(self) -> SmartContractVerifierServer {
-        SmartContractVerifierServer::new().sourcify_service(self)
-    }
-}
-
-#[fixture]
-fn service() -> MockSourcifyVerifierService {
-    MockSourcifyVerifierService::new()
-}
-
-#[rstest]
-#[tokio::test]
-#[timeout(std::time::Duration::from_secs(60))]
-#[ignore = "Needs database to run"]
-async fn test_returns_valid_source(service: MockSourcifyVerifierService) {
-    let default_request = VerifySourcifyRequest {
-        address: "".to_string(),
-        chain: "".to_string(),
-        files: Default::default(),
-        chosen_contract: None,
-    };
-    let source_type = verification::SourceType::Solidity;
-    test_cases::test_returns_valid_source(
-        TEST_SUITE_NAME,
-        service,
-        ROUTE,
-        default_request,
-        source_type,
-    )
-    .await;
-}
+// mod verification_test_helpers;
+//
+// use async_trait::async_trait;
+// use eth_bytecode_db::verification;
+// use eth_bytecode_db_proto::blockscout::eth_bytecode_db::v2::VerifySourcifyRequest;
+// use rstest::{fixture, rstest};
+// use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2 as smart_contract_verifier_v2;
+// use tonic::Response;
+// use verification_test_helpers::{
+//     smart_contract_verifer_mock::{MockSourcifyVerifierService, SmartContractVerifierServer},
+//     test_cases, VerifierService,
+// };
+//
+// const TEST_SUITE_NAME: &str = "sourcify";
+//
+// const ROUTE: &str = "/api/v2/verifier/sourcify/sources:verify";
+//
+// #[async_trait]
+// impl VerifierService<smart_contract_verifier_v2::VerifyResponse> for MockSourcifyVerifierService {
+//     fn add_into_service(&mut self, response: smart_contract_verifier_v2::VerifyResponse) {
+//         self.expect_verify()
+//             .returning(move |_| Ok(Response::new(response.clone())));
+//     }
+//
+//     fn build_server(self) -> SmartContractVerifierServer {
+//         SmartContractVerifierServer::new().sourcify_service(self)
+//     }
+// }
+//
+// #[fixture]
+// fn service() -> MockSourcifyVerifierService {
+//     MockSourcifyVerifierService::new()
+// }
+//
+// #[rstest]
+// #[tokio::test]
+// #[timeout(std::time::Duration::from_secs(60))]
+// #[ignore = "Needs database to run"]
+// async fn test_returns_valid_source(service: MockSourcifyVerifierService) {
+//     let default_request = VerifySourcifyRequest {
+//         address: "".to_string(),
+//         chain: "".to_string(),
+//         files: Default::default(),
+//         chosen_contract: None,
+//     };
+//     let source_type = verification::SourceType::Solidity;
+//     test_cases::test_returns_valid_source(
+//         TEST_SUITE_NAME,
+//         service,
+//         ROUTE,
+//         default_request,
+//         source_type,
+//     )
+//     .await;
+// }

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/sourcify_from_etherscan.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/sourcify_from_etherscan.rs
@@ -1,53 +1,53 @@
-mod verification_test_helpers;
-
-use async_trait::async_trait;
-use eth_bytecode_db::verification;
-use eth_bytecode_db_proto::blockscout::eth_bytecode_db::v2::VerifyFromEtherscanSourcifyRequest;
-use rstest::{fixture, rstest};
-use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2 as smart_contract_verifier_v2;
-use tonic::Response;
-use verification_test_helpers::{
-    smart_contract_verifer_mock::{MockSourcifyVerifierService, SmartContractVerifierServer},
-    test_cases, VerifierService,
-};
-
-const TEST_SUITE_NAME: &str = "sourcify_from_etherscan";
-
-const ROUTE: &str = "/api/v2/verifier/sourcify/sources:verify-from-etherscan";
-
-#[async_trait]
-impl VerifierService<smart_contract_verifier_v2::VerifyResponse> for MockSourcifyVerifierService {
-    fn add_into_service(&mut self, response: smart_contract_verifier_v2::VerifyResponse) {
-        self.expect_verify_from_etherscan()
-            .returning(move |_| Ok(Response::new(response.clone())));
-    }
-
-    fn build_server(self) -> SmartContractVerifierServer {
-        SmartContractVerifierServer::new().sourcify_service(self)
-    }
-}
-
-#[fixture]
-fn service() -> MockSourcifyVerifierService {
-    MockSourcifyVerifierService::new()
-}
-
-#[rstest]
-#[tokio::test]
-#[timeout(std::time::Duration::from_secs(60))]
-#[ignore = "Needs database to run"]
-async fn test_returns_valid_source(service: MockSourcifyVerifierService) {
-    let default_request = VerifyFromEtherscanSourcifyRequest {
-        address: "".to_string(),
-        chain: "".to_string(),
-    };
-    let source_type = verification::SourceType::Solidity;
-    test_cases::test_returns_valid_source(
-        TEST_SUITE_NAME,
-        service,
-        ROUTE,
-        default_request,
-        source_type,
-    )
-    .await;
-}
+// mod verification_test_helpers;
+//
+// use async_trait::async_trait;
+// use eth_bytecode_db::verification;
+// use eth_bytecode_db_proto::blockscout::eth_bytecode_db::v2::VerifyFromEtherscanSourcifyRequest;
+// use rstest::{fixture, rstest};
+// use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2 as smart_contract_verifier_v2;
+// use tonic::Response;
+// use verification_test_helpers::{
+//     smart_contract_verifer_mock::{MockSourcifyVerifierService, SmartContractVerifierServer},
+//     test_cases, VerifierService,
+// };
+//
+// const TEST_SUITE_NAME: &str = "sourcify_from_etherscan";
+//
+// const ROUTE: &str = "/api/v2/verifier/sourcify/sources:verify-from-etherscan";
+//
+// #[async_trait]
+// impl VerifierService<smart_contract_verifier_v2::VerifyResponse> for MockSourcifyVerifierService {
+//     fn add_into_service(&mut self, response: smart_contract_verifier_v2::VerifyResponse) {
+//         self.expect_verify_from_etherscan()
+//             .returning(move |_| Ok(Response::new(response.clone())));
+//     }
+//
+//     fn build_server(self) -> SmartContractVerifierServer {
+//         SmartContractVerifierServer::new().sourcify_service(self)
+//     }
+// }
+//
+// #[fixture]
+// fn service() -> MockSourcifyVerifierService {
+//     MockSourcifyVerifierService::new()
+// }
+//
+// #[rstest]
+// #[tokio::test]
+// #[timeout(std::time::Duration::from_secs(60))]
+// #[ignore = "Needs database to run"]
+// async fn test_returns_valid_source(service: MockSourcifyVerifierService) {
+//     let default_request = VerifyFromEtherscanSourcifyRequest {
+//         address: "".to_string(),
+//         chain: "".to_string(),
+//     };
+//     let source_type = verification::SourceType::Solidity;
+//     test_cases::test_returns_valid_source(
+//         TEST_SUITE_NAME,
+//         service,
+//         ROUTE,
+//         default_request,
+//         source_type,
+//     )
+//     .await;
+// }

--- a/smart-contract-verifier/smart-contract-verifier-http/tests/sourcify.rs
+++ b/smart-contract-verifier/smart-contract-verifier-http/tests/sourcify.rs
@@ -1,138 +1,138 @@
-use actix_web::{
-    test::{self, TestRequest},
-    App,
-};
-use pretty_assertions::assert_eq;
-use serde_json::json;
-use smart_contract_verifier_http::{
-    configure_router, AppRouter, Settings, VerificationResponse, VerificationStatus,
-};
-use std::sync::Arc;
-
-#[actix_rt::test]
-async fn should_return_200() {
-    let mut settings = Settings::default();
-    settings.solidity.enabled = false;
-    let app_router = Arc::new(
-        AppRouter::new(settings)
-            .await
-            .expect("couldn't initialize the app"),
-    );
-    let app = test::init_service(App::new().configure(configure_router(&*app_router))).await;
-
-    let metadata = include_str!("contracts/storage/metadata.json");
-    let source = include_str!("contracts/storage/source.sol");
-    let request_body = json!({
-        // relies on the fact that the Ethereum Testnet Goerli has this contract
-        // https://eth-goerli.blockscout.com/address/0x6da5E8Cd88641dd371F3ED7737664ea86B3C3ec8
-        "address": "0x6da5E8Cd88641dd371F3ED7737664ea86B3C3ec8",
-        "chain": "5",
-        "files": {
-            "source.sol": source,
-            "metadata.json": metadata,
-        }
-    });
-
-    let resp = TestRequest::post()
-        .uri("/api/v1/sourcify/verify")
-        .set_json(&request_body)
-        .send_request(&app)
-        .await;
-
-    assert!(
-        resp.status().is_success(),
-        "failed to verify contract, status is {}",
-        resp.status()
-    );
-
-    let body: serde_json::Value = test::read_body_json(resp).await;
-    assert_eq!(
-        body,
-        serde_json::json!({
-            "message": "OK",
-            "result": {
-                "file_name": "contracts/1_Storage.sol",
-                "contract_name": "Storage",
-                "compiler_version": "0.8.7+commit.e28d00a7",
-                "evm_version": "london",
-                "constructor_arguments": null,
-                "optimization": false,
-                "optimization_runs": 200,
-                "contract_libraries": {},
-                "abi": "[{\"inputs\":[],\"name\":\"retrieve\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"store\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
-                "sources": {
-                    "contracts/1_Storage.sol": "// SPDX-License-Identifier: GPL-3.0\n\npragma solidity >=0.7.0 <0.9.0;\n\n/**\n * @title Storage\n * @dev Store & retrieve value in a variable\n * @custom:dev-run-script ./scripts/deploy_with_ethers.ts\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retrieve() public view returns (uint256){\n        return number;\n    }\n}"
-                },
-                "compiler_settings": "{\"compilationTarget\":{\"contracts/1_Storage.sol\":\"Storage\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]}"
-            },
-            "status": "0"
-        }),
-    );
-}
-
-#[actix_rt::test]
-async fn invalid_contracts() {
-    let mut settings = Settings::default();
-    settings.solidity.enabled = false;
-    let app_router = Arc::new(
-        AppRouter::new(settings)
-            .await
-            .expect("couldn't initialize the app"),
-    );
-    let app = test::init_service(App::new().configure(configure_router(&*app_router))).await;
-
-    let metadata_content = include_str!("contracts/storage/metadata.json");
-    let source = include_str!("contracts/storage/source.sol");
-    for (request_body, error_message) in [
-        (
-            json!({
-                // relies on fact that the Ethereum Testnet Goerli HASN'T any contract with this address
-                "address": "0x1234567890123456789012345678901234567890",
-                "chain": "5",
-                "files": {
-                    "metadata.json": metadata_content,
-                    "contracts/1_Storage.sol": source,
-                },
-            }),
-            "does not have a contract",
-        ),
-        (
-            json!({
-                "address": "0x1234567890123456789012345678901234567890",
-                "chain": "5",
-                "files": {},
-            }),
-            "Metadata file not found",
-        ),
-        (
-            json!({
-                // relies on fact that Ethereum Testnet Goerli has some contract, but it is not verified in
-                // sourcify and `source` contains wrong source code
-                "address": "0xD3F4730068b57d11a5Cd4252D8a9012A188C5D3B",
-                "chain": "5",
-                "files": {
-                    "metadata.json": metadata_content,
-                    "contracts/1_Storage.sol": source,
-                },
-            }),
-            "deployed and recompiled bytecode don't match",
-        ),
-    ] {
-        let resp = TestRequest::post()
-            .uri("/api/v1/sourcify/verify")
-            .set_json(&request_body)
-            .send_request(&app)
-            .await;
-
-        let body: VerificationResponse = test::read_body_json(resp).await;
-
-        assert!(body.result.is_none());
-        assert_eq!(body.status, VerificationStatus::Failed);
-        assert!(
-            body.message.contains(error_message),
-            "body message: {}, expected message: {}",
-            body.message,
-            error_message
-        );
-    }
-}
+// use actix_web::{
+//     test::{self, TestRequest},
+//     App,
+// };
+// use pretty_assertions::assert_eq;
+// use serde_json::json;
+// use smart_contract_verifier_http::{
+//     configure_router, AppRouter, Settings, VerificationResponse, VerificationStatus,
+// };
+// use std::sync::Arc;
+//
+// #[actix_rt::test]
+// async fn should_return_200() {
+//     let mut settings = Settings::default();
+//     settings.solidity.enabled = false;
+//     let app_router = Arc::new(
+//         AppRouter::new(settings)
+//             .await
+//             .expect("couldn't initialize the app"),
+//     );
+//     let app = test::init_service(App::new().configure(configure_router(&*app_router))).await;
+//
+//     let metadata = include_str!("contracts/storage/metadata.json");
+//     let source = include_str!("contracts/storage/source.sol");
+//     let request_body = json!({
+//         // relies on the fact that the Ethereum Testnet Goerli has this contract
+//         // https://eth-goerli.blockscout.com/address/0x6da5E8Cd88641dd371F3ED7737664ea86B3C3ec8
+//         "address": "0x6da5E8Cd88641dd371F3ED7737664ea86B3C3ec8",
+//         "chain": "5",
+//         "files": {
+//             "source.sol": source,
+//             "metadata.json": metadata,
+//         }
+//     });
+//
+//     let resp = TestRequest::post()
+//         .uri("/api/v1/sourcify/verify")
+//         .set_json(&request_body)
+//         .send_request(&app)
+//         .await;
+//
+//     assert!(
+//         resp.status().is_success(),
+//         "failed to verify contract, status is {}",
+//         resp.status()
+//     );
+//
+//     let body: serde_json::Value = test::read_body_json(resp).await;
+//     assert_eq!(
+//         body,
+//         serde_json::json!({
+//             "message": "OK",
+//             "result": {
+//                 "file_name": "contracts/1_Storage.sol",
+//                 "contract_name": "Storage",
+//                 "compiler_version": "0.8.7+commit.e28d00a7",
+//                 "evm_version": "london",
+//                 "constructor_arguments": null,
+//                 "optimization": false,
+//                 "optimization_runs": 200,
+//                 "contract_libraries": {},
+//                 "abi": "[{\"inputs\":[],\"name\":\"retrieve\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"num\",\"type\":\"uint256\"}],\"name\":\"store\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+//                 "sources": {
+//                     "contracts/1_Storage.sol": "// SPDX-License-Identifier: GPL-3.0\n\npragma solidity >=0.7.0 <0.9.0;\n\n/**\n * @title Storage\n * @dev Store & retrieve value in a variable\n * @custom:dev-run-script ./scripts/deploy_with_ethers.ts\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retrieve() public view returns (uint256){\n        return number;\n    }\n}"
+//                 },
+//                 "compiler_settings": "{\"compilationTarget\":{\"contracts/1_Storage.sol\":\"Storage\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]}"
+//             },
+//             "status": "0"
+//         }),
+//     );
+// }
+//
+// #[actix_rt::test]
+// async fn invalid_contracts() {
+//     let mut settings = Settings::default();
+//     settings.solidity.enabled = false;
+//     let app_router = Arc::new(
+//         AppRouter::new(settings)
+//             .await
+//             .expect("couldn't initialize the app"),
+//     );
+//     let app = test::init_service(App::new().configure(configure_router(&*app_router))).await;
+//
+//     let metadata_content = include_str!("contracts/storage/metadata.json");
+//     let source = include_str!("contracts/storage/source.sol");
+//     for (request_body, error_message) in [
+//         (
+//             json!({
+//                 // relies on fact that the Ethereum Testnet Goerli HASN'T any contract with this address
+//                 "address": "0x1234567890123456789012345678901234567890",
+//                 "chain": "5",
+//                 "files": {
+//                     "metadata.json": metadata_content,
+//                     "contracts/1_Storage.sol": source,
+//                 },
+//             }),
+//             "does not have a contract",
+//         ),
+//         (
+//             json!({
+//                 "address": "0x1234567890123456789012345678901234567890",
+//                 "chain": "5",
+//                 "files": {},
+//             }),
+//             "Metadata file not found",
+//         ),
+//         (
+//             json!({
+//                 // relies on fact that Ethereum Testnet Goerli has some contract, but it is not verified in
+//                 // sourcify and `source` contains wrong source code
+//                 "address": "0xD3F4730068b57d11a5Cd4252D8a9012A188C5D3B",
+//                 "chain": "5",
+//                 "files": {
+//                     "metadata.json": metadata_content,
+//                     "contracts/1_Storage.sol": source,
+//                 },
+//             }),
+//             "deployed and recompiled bytecode don't match",
+//         ),
+//     ] {
+//         let resp = TestRequest::post()
+//             .uri("/api/v1/sourcify/verify")
+//             .set_json(&request_body)
+//             .send_request(&app)
+//             .await;
+//
+//         let body: VerificationResponse = test::read_body_json(resp).await;
+//
+//         assert!(body.result.is_none());
+//         assert_eq!(body.status, VerificationStatus::Failed);
+//         assert!(
+//             body.message.contains(error_message),
+//             "body message: {}, expected message: {}",
+//             body.message,
+//             error_message
+//         );
+//     }
+// }

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/sourcify_from_etherscan.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/sourcify_from_etherscan.rs
@@ -1,157 +1,157 @@
-use actix_web::{test, test::TestRequest, App};
-use pretty_assertions::assert_eq;
-use serde_json::json;
-use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
-    sourcify_verifier_actix::route_sourcify_verifier, VerifyResponse,
-};
-use smart_contract_verifier_server::{Settings, SourcifyVerifierService};
-use std::sync::Arc;
-
-const ROUTE: &str = "/api/v2/verifier/sourcify/sources:verify-from-etherscan";
-
-async fn init_service() -> Arc<SourcifyVerifierService> {
-    let settings = Settings::default();
-    let service = SourcifyVerifierService::new(settings.sourcify, settings.extensions.sourcify)
-        .await
-        .expect("couldn't initialize the service");
-    Arc::new(service)
-}
-
-#[tokio::test]
-async fn should_return_200() {
-    let address = "0x20f6a0edCE30681CDE6debAa58ed9768E42d1899";
-    let chain_id = "5";
-
-    let service = init_service().await;
-    let app = test::init_service(
-        App::new().configure(|config| route_sourcify_verifier(config, service.clone())),
-    )
-    .await;
-
-    let request_body = json!({
-        // relies on the fact that the Ethereum Testnet Goerli has this contract
-            // https://goerli.etherscan.io/address/0x20f6a0edCE30681CDE6debAa58ed9768E42d1899#code
-        "address": address,
-        "chain": chain_id,
-    });
-
-    let resp = TestRequest::post()
-        .uri(ROUTE)
-        .set_json(&request_body)
-        .send_request(&app)
-        .await;
-
-    assert!(
-        resp.status().is_success(),
-        "failed to verify contract, status is {}",
-        resp.status()
-    );
-
-    let body: serde_json::Value = test::read_body_json(resp).await;
-    assert_eq!(
-        body,
-        json!({
-            "message": "OK",
-            "status": "SUCCESS",
-            "source": {
-                "fileName": "C1.sol",
-                "contractName": "C1",
-                "compilerVersion": "0.8.7+commit.e28d00a7",
-                "constructorArguments": null,
-                "abi": "[{\"inputs\":[],\"name\":\"a\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"b\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"c\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"d\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
-                "sourceFiles": {
-                    "C1.sol": "// SPDX-License-Identifier: MIT\r\npragma solidity 0.8.7;\r\n\r\ncontract C1 {\r\n    uint256 immutable public a = 0;\r\n    uint256 public b = 1202;\r\n    address public c = 0x9563Fdb01BFbF3D6c548C2C64E446cb5900ACA88;\r\n    address public d = 0x9563Fdb01BFbF3D6c548C2C64E446cb5900ACA88;\r\n}"
-                },
-                "compilerSettings": "{\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]}",
-                "matchType": "PARTIAL",
-                "sourceType": "SOLIDITY",
-            },
-            "extraData": {
-                "localCreationInputParts": [],
-                "localDeployedBytecodeParts": [],
-            }
-        }),
-    );
-}
-
-#[tokio::test]
-async fn chain_not_supported_fail() {
-    let address = "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa";
-    let chain_id = "2221";
-
-    let service = init_service().await;
-    let app = test::init_service(
-        App::new().configure(|config| route_sourcify_verifier(config, service.clone())),
-    )
-    .await;
-
-    let request_body = json!({
-        "address": address,
-        "chain": chain_id,
-    });
-
-    let resp = TestRequest::post()
-        .uri(ROUTE)
-        .set_json(&request_body)
-        .send_request(&app)
-        .await;
-
-    assert!(
-        resp.status().is_success(),
-        "failed to verify contract, status is {}",
-        resp.status()
-    );
-
-    let body: VerifyResponse = test::read_body_json(resp).await;
-
-    assert_eq!(body.status().as_str_name(), "FAILURE");
-
-    let error_message = "is not supported for importing from Etherscan";
-    assert!(
-        body.message.contains(error_message),
-        "body message: {}, expected message: {}",
-        body.message,
-        error_message
-    );
-}
-
-#[tokio::test]
-async fn contract_not_verified_fail() {
-    let address = "0x847F2d0c193E90963aAD7B2791aAE8d7310dFF6A";
-    let chain_id = "5";
-
-    let service = init_service().await;
-    let app = test::init_service(
-        App::new().configure(|config| route_sourcify_verifier(config, service.clone())),
-    )
-    .await;
-
-    let request_body = json!({
-        "address": address,
-        "chain": chain_id,
-    });
-
-    let resp = TestRequest::post()
-        .uri(ROUTE)
-        .set_json(&request_body)
-        .send_request(&app)
-        .await;
-
-    assert!(
-        resp.status().is_success(),
-        "failed to verify contract, status is {}",
-        resp.status()
-    );
-
-    let body: VerifyResponse = test::read_body_json(resp).await;
-
-    assert_eq!(body.status().as_str_name(), "FAILURE");
-
-    let error_message = "contract is not verified on Etherscan";
-    assert!(
-        body.message.contains(error_message),
-        "body message: {}, expected message: {}",
-        body.message,
-        error_message
-    );
-}
+// use actix_web::{test, test::TestRequest, App};
+// use pretty_assertions::assert_eq;
+// use serde_json::json;
+// use smart_contract_verifier_proto::blockscout::smart_contract_verifier::v2::{
+//     sourcify_verifier_actix::route_sourcify_verifier, VerifyResponse,
+// };
+// use smart_contract_verifier_server::{Settings, SourcifyVerifierService};
+// use std::sync::Arc;
+//
+// const ROUTE: &str = "/api/v2/verifier/sourcify/sources:verify-from-etherscan";
+//
+// async fn init_service() -> Arc<SourcifyVerifierService> {
+//     let settings = Settings::default();
+//     let service = SourcifyVerifierService::new(settings.sourcify, settings.extensions.sourcify)
+//         .await
+//         .expect("couldn't initialize the service");
+//     Arc::new(service)
+// }
+//
+// #[tokio::test]
+// async fn should_return_200() {
+//     let address = "0x20f6a0edCE30681CDE6debAa58ed9768E42d1899";
+//     let chain_id = "5";
+//
+//     let service = init_service().await;
+//     let app = test::init_service(
+//         App::new().configure(|config| route_sourcify_verifier(config, service.clone())),
+//     )
+//     .await;
+//
+//     let request_body = json!({
+//         // relies on the fact that the Ethereum Testnet Goerli has this contract
+//             // https://goerli.etherscan.io/address/0x20f6a0edCE30681CDE6debAa58ed9768E42d1899#code
+//         "address": address,
+//         "chain": chain_id,
+//     });
+//
+//     let resp = TestRequest::post()
+//         .uri(ROUTE)
+//         .set_json(&request_body)
+//         .send_request(&app)
+//         .await;
+//
+//     assert!(
+//         resp.status().is_success(),
+//         "failed to verify contract, status is {}",
+//         resp.status()
+//     );
+//
+//     let body: serde_json::Value = test::read_body_json(resp).await;
+//     assert_eq!(
+//         body,
+//         json!({
+//             "message": "OK",
+//             "status": "SUCCESS",
+//             "source": {
+//                 "fileName": "C1.sol",
+//                 "contractName": "C1",
+//                 "compilerVersion": "0.8.7+commit.e28d00a7",
+//                 "constructorArguments": null,
+//                 "abi": "[{\"inputs\":[],\"name\":\"a\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"b\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"c\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"d\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+//                 "sourceFiles": {
+//                     "C1.sol": "// SPDX-License-Identifier: MIT\r\npragma solidity 0.8.7;\r\n\r\ncontract C1 {\r\n    uint256 immutable public a = 0;\r\n    uint256 public b = 1202;\r\n    address public c = 0x9563Fdb01BFbF3D6c548C2C64E446cb5900ACA88;\r\n    address public d = 0x9563Fdb01BFbF3D6c548C2C64E446cb5900ACA88;\r\n}"
+//                 },
+//                 "compilerSettings": "{\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]}",
+//                 "matchType": "PARTIAL",
+//                 "sourceType": "SOLIDITY",
+//             },
+//             "extraData": {
+//                 "localCreationInputParts": [],
+//                 "localDeployedBytecodeParts": [],
+//             }
+//         }),
+//     );
+// }
+//
+// #[tokio::test]
+// async fn chain_not_supported_fail() {
+//     let address = "0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa";
+//     let chain_id = "2221";
+//
+//     let service = init_service().await;
+//     let app = test::init_service(
+//         App::new().configure(|config| route_sourcify_verifier(config, service.clone())),
+//     )
+//     .await;
+//
+//     let request_body = json!({
+//         "address": address,
+//         "chain": chain_id,
+//     });
+//
+//     let resp = TestRequest::post()
+//         .uri(ROUTE)
+//         .set_json(&request_body)
+//         .send_request(&app)
+//         .await;
+//
+//     assert!(
+//         resp.status().is_success(),
+//         "failed to verify contract, status is {}",
+//         resp.status()
+//     );
+//
+//     let body: VerifyResponse = test::read_body_json(resp).await;
+//
+//     assert_eq!(body.status().as_str_name(), "FAILURE");
+//
+//     let error_message = "is not supported for importing from Etherscan";
+//     assert!(
+//         body.message.contains(error_message),
+//         "body message: {}, expected message: {}",
+//         body.message,
+//         error_message
+//     );
+// }
+//
+// #[tokio::test]
+// async fn contract_not_verified_fail() {
+//     let address = "0x847F2d0c193E90963aAD7B2791aAE8d7310dFF6A";
+//     let chain_id = "5";
+//
+//     let service = init_service().await;
+//     let app = test::init_service(
+//         App::new().configure(|config| route_sourcify_verifier(config, service.clone())),
+//     )
+//     .await;
+//
+//     let request_body = json!({
+//         "address": address,
+//         "chain": chain_id,
+//     });
+//
+//     let resp = TestRequest::post()
+//         .uri(ROUTE)
+//         .set_json(&request_body)
+//         .send_request(&app)
+//         .await;
+//
+//     assert!(
+//         resp.status().is_success(),
+//         "failed to verify contract, status is {}",
+//         resp.status()
+//     );
+//
+//     let body: VerifyResponse = test::read_body_json(resp).await;
+//
+//     assert_eq!(body.status().as_str_name(), "FAILURE");
+//
+//     let error_message = "contract is not verified on Etherscan";
+//     assert!(
+//         body.message.contains(error_message),
+//         "body message: {}, expected message: {}",
+//         body.message,
+//         error_message
+//     );
+// }

--- a/smart-contract-verifier/smart-contract-verifier/tests/middleware.rs
+++ b/smart-contract-verifier/smart-contract-verifier/tests/middleware.rs
@@ -164,39 +164,39 @@ mod vyper {
     }
 }
 
-mod sourcify {
-    use super::*;
-    use smart_contract_verifier::{
-        sourcify, sourcify::api::VerificationRequest, SourcifyApiClient, SourcifySuccess,
-        DEFAULT_SOURCIFY_HOST,
-    };
-    use std::{collections::BTreeMap, sync::Arc};
-    use url::Url;
-
-    fn default_request() -> VerificationRequest {
-        VerificationRequest {
-            address: "0x8a8FA3Da120534a4945666520112a2A0D0A3aC55".to_string(),
-            chain: "5".to_string(),
-            files: BTreeMap::from([
-                ("metadata.json".to_string(), r#"{"compiler":{"version":"0.8.7+commit.e28d00a7"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"contracts/Basic.sol":"Main"},"evmVersion":"london","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"contracts/Basic.sol":{"keccak256":"0x16b344408fcd46f38344e2192b7b82677bb29a8c5e822145e55d67d156fd02b5","urls":["bzz-raw://99f0cffe21a52b8f1d0a6d687f974173d6ed3ccfe4fa25af22bcb8b343372363","dweb:/ipfs/Qmc5BsPNZkDeooYWLxwq6HCNKmH6GzXLmQSJ3LmrnFrNzw"]}},"version":1}"#.to_string()),
-                ("contracts/Basic.sol".to_string(), "pragma solidity >0.4.5; contract Main {uint256 a; }".to_string())
-            ]),
-            chosen_contract: None
-        }
-    }
-
-    #[rstest::rstest]
-    #[tokio::test]
-    async fn verify(middleware: impl smart_contract_verifier::Middleware<SourcifySuccess>) {
-        let host = Url::try_from(DEFAULT_SOURCIFY_HOST).expect("Invalid Sourcify host Url");
-        let client = SourcifyApiClient::new(host, 10, 3.try_into().unwrap())
-            .expect("Sourcify client build failed")
-            .with_middleware(middleware);
-
-        let request = default_request();
-
-        sourcify::api::verify(Arc::new(client), request)
-            .await
-            .expect("Verification failed");
-    }
-}
+// mod sourcify {
+//     use super::*;
+//     use smart_contract_verifier::{
+//         sourcify, sourcify::api::VerificationRequest, SourcifyApiClient, SourcifySuccess,
+//         DEFAULT_SOURCIFY_HOST,
+//     };
+//     use std::{collections::BTreeMap, sync::Arc};
+//     use url::Url;
+//
+//     fn default_request() -> VerificationRequest {
+//         VerificationRequest {
+//             address: "0x8a8FA3Da120534a4945666520112a2A0D0A3aC55".to_string(),
+//             chain: "5".to_string(),
+//             files: BTreeMap::from([
+//                 ("metadata.json".to_string(), r#"{"compiler":{"version":"0.8.7+commit.e28d00a7"},"language":"Solidity","output":{"abi":[],"devdoc":{"kind":"dev","methods":{},"version":1},"userdoc":{"kind":"user","methods":{},"version":1}},"settings":{"compilationTarget":{"contracts/Basic.sol":"Main"},"evmVersion":"london","libraries":{},"metadata":{"bytecodeHash":"ipfs"},"optimizer":{"enabled":false,"runs":200},"remappings":[]},"sources":{"contracts/Basic.sol":{"keccak256":"0x16b344408fcd46f38344e2192b7b82677bb29a8c5e822145e55d67d156fd02b5","urls":["bzz-raw://99f0cffe21a52b8f1d0a6d687f974173d6ed3ccfe4fa25af22bcb8b343372363","dweb:/ipfs/Qmc5BsPNZkDeooYWLxwq6HCNKmH6GzXLmQSJ3LmrnFrNzw"]}},"version":1}"#.to_string()),
+//                 ("contracts/Basic.sol".to_string(), "pragma solidity >0.4.5; contract Main {uint256 a; }".to_string())
+//             ]),
+//             chosen_contract: None
+//         }
+//     }
+//
+//     #[rstest::rstest]
+//     #[tokio::test]
+//     async fn verify(middleware: impl smart_contract_verifier::Middleware<SourcifySuccess>) {
+//         let host = Url::try_from(DEFAULT_SOURCIFY_HOST).expect("Invalid Sourcify host Url");
+//         let client = SourcifyApiClient::new(host, 10, 3.try_into().unwrap())
+//             .expect("Sourcify client build failed")
+//             .with_middleware(middleware);
+//
+//         let request = default_request();
+//
+//         sourcify::api::verify(Arc::new(client), request)
+//             .await
+//             .expect("Verification failed");
+//     }
+// }


### PR DESCRIPTION
Temporary disable new sourcify tests as they are currently are not working due to Sourcify rate limits