### PR TITLE
Add cors settings

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 
 [dependencies]
 actix-web = { version = "4", optional = true }
-actix-cors = "0.6.4"
+actix-cors = { version = "0.6.4", optional = true }
 actix-web-prom = { version = "0.6", optional = true }
 anyhow = { version = "1.0", optional = true }
 config = { version = "0.13", optional = true }
@@ -47,6 +47,7 @@ default = ["launcher", "tracing"]
 launcher = [
     "dep:actix-web",
     "dep:actix-web-prom",
+    "dep:actix-cors",
     "dep:anyhow",
     "dep:config",
     "dep:futures",

--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [dependencies]
 actix-web = { version = "4", optional = true }
+actix-cors = "0.6.4"
 actix-web-prom = { version = "0.6", optional = true }
 anyhow = { version = "1.0", optional = true }
 config = { version = "0.13", optional = true }

--- a/libs/blockscout-service-launcher/src/launcher/settings.rs
+++ b/libs/blockscout-service-launcher/src/launcher/settings.rs
@@ -52,13 +52,24 @@ pub struct HttpServerSettings {
     pub cors: CorsSettings,
 }
 
+impl Default for HttpServerSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            addr: SocketAddr::from_str("0.0.0.0:8050").unwrap(),
+            max_body_size: 2 * 1024 * 1024, // 2 Mb - default Actix value
+            cors: Default::default(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct CorsSettings {
     pub enabled: bool,
-    pub allow_origin: String,
-    pub allow_methods: String,
-    pub allow_credentials: bool,
+    pub allowed_origin: String,
+    pub allowed_methods: String,
+    pub allowed_credentials: bool,
     pub max_age: usize,
     pub block_on_origin_mismatch: bool,
 }
@@ -67,9 +78,9 @@ impl Default for CorsSettings {
     fn default() -> Self {
         Self {
             enabled: false,
-            allow_origin: "".to_string(),
-            allow_methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH".to_string(),
-            allow_credentials: true,
+            allowed_origin: "".to_string(),
+            allowed_methods: "PUT, GET, POST, OPTIONS, DELETE, PATCH".to_string(),
+            allowed_credentials: true,
             max_age: 3600,
             block_on_origin_mismatch: false,
         }
@@ -80,27 +91,16 @@ impl CorsSettings {
     pub fn build(self) -> Cors {
         let mut cors = Cors::default()
             .allow_any_header()
-            .allowed_methods(self.allow_methods.split(", "))
+            .allowed_methods(self.allowed_methods.split(", "))
             .max_age(Some(self.max_age))
             .block_on_origin_mismatch(self.block_on_origin_mismatch);
-        if self.allow_credentials {
+        if self.allowed_credentials {
             cors = cors.supports_credentials()
         }
-        for origin in self.allow_origin.split(", ") {
+        for origin in self.allowed_origin.split(", ") {
             cors = cors.allowed_origin(origin)
         }
         cors
-    }
-}
-
-impl Default for HttpServerSettings {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            addr: SocketAddr::from_str("0.0.0.0:8050").unwrap(),
-            max_body_size: 2 * 1024 * 1024, // 2 Mb - default Actix value
-            cors: Default::default(),
-        }
     }
 }
 


### PR DESCRIPTION
Added actix-cors crate to handle cors headers in requests. Disabling cors middleware by default

Note that wildcarding in allowed_origin is not supported, so `http://*.blockscout.com` is not a valid origin