### PR TITLE
Change bens proto

### DIFF
--- a/blockscout-ens/bens-proto/build.rs
+++ b/blockscout-ens/bens-proto/build.rs
@@ -18,10 +18,30 @@ fn compile(
         .bytes(["."])
         .btree_map(["."])
         .type_attribute(".", "#[actix_prost_macros::serde]")
-        // .field_attribute(
-        //     ".blockscout.ethBytecodeDb.v2.VerifyVyperMultiPartRequest.interfaces",
-        //     "#[serde(default)]"
-        // )
+        .field_attribute(
+            ".blockscout.bens.v1.ListDomainEventsRequest.sort",
+            "#[serde(default)]"
+        )
+        .field_attribute(
+            ".blockscout.bens.v1.ListDomainEventsRequest.order",
+            "#[serde(default)]"
+        )
+        .field_attribute(
+            ".blockscout.bens.v1.LookupDomainNameRequest.sort",
+            "#[serde(default)]"
+        )
+        .field_attribute(
+            ".blockscout.bens.v1.LookupDomainNameRequest.order",
+            "#[serde(default)]"
+        )
+        .field_attribute(
+            ".blockscout.bens.v1.LookupAddressRequest.sort",
+            "#[serde(default)]"
+        )
+        .field_attribute(
+            ".blockscout.bens.v1.LookupAddressRequest.order",
+            "#[serde(default)]"
+        )
         ;
     config.compile_protos(protos, includes)?;
     Ok(())

--- a/blockscout-ens/bens-proto/proto/api_config_http.yaml
+++ b/blockscout-ens/bens-proto/proto/api_config_http.yaml
@@ -10,14 +10,16 @@ http:
     - selector: blockscout.bens.v1.DomainsExtractor.ListDomainEvents
       get: /api/v1/{chain_id}/domains/{name}/events
 
-    - selector: blockscout.bens.v1.DomainsExtractor.ResolveDomainName
-      get: /api/v1/{chain_id}/domains/{name}/resolve
+    - selector: blockscout.bens.v1.DomainsExtractor.LookupDomainName
+      post: /api/v1/{chain_id}/domains:lookup
+      body: "*"
 
-    - selector: blockscout.bens.v1.DomainsExtractor.ResolveAddress
-      get: /api/v1/{chain_id}/addresses/{address}/resolve
+    - selector: blockscout.bens.v1.DomainsExtractor.LookupAddress
+      post: /api/v1/{chain_id}/addresses:lookup
+      body: "*"
 
-    - selector: blockscout.bens.v1.DomainsExtractor.BatchSearchAddressNames
-      post: /api/v1/{chain_id}/address-names:batch-search
+    - selector: blockscout.bens.v1.DomainsExtractor.BatchResolveAddressNames
+      post: /api/v1/{chain_id}/addresses:batch-resolve-names
       body: "*"
 
     #################### Health ####################

--- a/blockscout-ens/bens-proto/proto/api_config_http.yaml
+++ b/blockscout-ens/bens-proto/proto/api_config_http.yaml
@@ -5,22 +5,16 @@ http:
   rules:
     #################### DomainsExtractor ####################
     - selector: blockscout.bens.v1.DomainsExtractor.GetDomain
-      get: /api/v1/{chain_id}/domains/{id}
+      get: /api/v1/{chain_id}/domains/{name}
 
     - selector: blockscout.bens.v1.DomainsExtractor.ListDomainEvents
-      get: /api/v1/{chain_id}/domains/{domain_id}/events
+      get: /api/v1/{chain_id}/domains/{name}/events
 
     - selector: blockscout.bens.v1.DomainsExtractor.ResolveDomainName
-      post: /api/v1/{chain_id}/domains:resolve
-      body: "*"
-
-    - selector: blockscout.bens.v1.DomainsExtractor.BatchResolveDomainNames
-      post: /api/v1/{chain_id}/domains:batch-resolve
-      body: "*"
+      get: /api/v1/{chain_id}/domains/{name}/resolve
 
     - selector: blockscout.bens.v1.DomainsExtractor.ResolveAddress
-      post: /api/v1/{chain_id}/addresses:resolve
-      body: "*"
+      get: /api/v1/{chain_id}/addresses/{address}/resolve
 
     - selector: blockscout.bens.v1.DomainsExtractor.BatchSearchAddressNames
       post: /api/v1/{chain_id}/address-names:batch-search

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -17,10 +17,6 @@ service DomainsExtractor {
   rpc BatchResolveAddressNames(BatchResolveAddressNamesRequest) returns (BatchResolveAddressNamesResponse) {}
 }
 
-message Address {
-  string hash = 1;
-}
-
 message Domain {
   // Unique id for the domain, also known as nodehash
   string id = 1;
@@ -69,10 +65,13 @@ message DomainEvent {
   optional string action = 4;
 }
 
-enum OrderDirection {
-    NOT_SET = 0;
-    ASC = 1;
-    DESC = 2;
+message Address {
+  string hash = 1;
+}
+
+enum Order {
+    ASC = 0;
+    DESC = 1;
 }
 
 message Pagination {
@@ -96,7 +95,7 @@ message ListDomainEventsRequest {
   // Sorting field. Default is `timestamp`
   string sort = 4;
   // Order direction. Default is ASC
-  OrderDirection order = 5;
+  Order order = 5;
 }
 
 message ListDomainEventsResponse {
@@ -114,7 +113,7 @@ message LookupDomainNameRequest {
   // Sorting field. Default is `registration_date`
   string sort = 4;
   // Order direction. Default is ASC
-  OrderDirection order = 5;
+  Order order = 5;
 }
 
 message LookupDomainNameResponse {
@@ -138,7 +137,7 @@ message LookupAddressRequest {
   // Sorting field. Default is `registration_date`
   string sort = 7;
   // Order direction. Defaut is ASC
-  OrderDirection order = 8;
+  Order order = 8;
 }
 
 message LookupAddressResponse {

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -31,9 +31,9 @@ message Domain {
   // The account that owns the domain
   Address owner = 4;
   // Optinal. Unix timestamp of expiry date. None means never expires
-  uint64 registration_date = 5;
+  int64 registration_date = 5;
   // Optinal. Unix timestamp of expiry date. None means never expires
-  optional uint64 expiry_date = 6; 
+  optional int64 expiry_date = 6;
 }
 
 message DetailedDomain {
@@ -41,8 +41,8 @@ message DetailedDomain {
   string id = 1;
   // The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
   string name = 2;
-  // Integer representation of labelhash
-  uint64 token_id = 3;
+  // Hex representation of labelhash
+  string token_id = 3;
   // The account that owns the domain
   Address owner = 4;
   // Optinal. Resolved address of this domain
@@ -50,9 +50,9 @@ message DetailedDomain {
   // Optinal. The account that owns the ERC721 NFT for the domain
   optional Address registrant = 6;
   // Optinal. Unix timestamp of expiry date. None means never expires
-  optional uint64 expiry_date = 7;
+  optional int64 expiry_date = 7;
   // Unix timestamp of regisration date
-  uint64 registration_date = 8;
+  int64 registration_date = 8;
   // Map chain -> resolved_address that contains other blockchain addresses.
   // This map will contain `current_chain_id` -> `resovled_address` if `resovled_address` is not None
   map<string, string> other_addresses = 9;
@@ -62,7 +62,7 @@ message DomainEvent {
   // Transaction hash where action occured
   string transaction_hash = 1;
   // Timestamp of this transaction
-  uint64 timestamp = 2;
+  string timestamp = 2;
   ///Sender of transaction
   Address from_address = 3;
   // Optinal. Action name
@@ -85,14 +85,14 @@ message GetDomainRequest {
   // Name of domain, for example vitalik.eth
   string name = 1;
   // The chain (network) where domain search should be done
-  uint64 chain_id = 2;
+  int64 chain_id = 2;
 }
 
 message ListDomainEventsRequest {
   // Name of domain, for example vitalik.eth
   string name = 1;
   // The chain (network) where domain search should be done
-  uint64 chain_id = 2;
+  int64 chain_id = 2;
   // Sorting field. Default is `timestamp`
   string sort = 4;
   // Order direction. Default is ASC
@@ -108,7 +108,7 @@ message LookupDomainNameRequest {
   // Name of domain, for example vitalik.eth
   string name = 1;
   // The chain (network) where domain search should be done
-  uint64 chain_id = 2;
+  int64 chain_id = 2;
   // Filtering field to remove expired domains
   bool only_active = 3;
   // Sorting field. Default is `registration_date`
@@ -128,7 +128,7 @@ message LookupAddressRequest {
   // Address of EOA or contract
   string address = 1;
   // The chain (network) where domain search should be done
-  uint64 chain_id = 2;
+  int64 chain_id = 2;
   // Include domains resolved to the address
   bool resolved_to = 4;
   // Include domains owned by the address
@@ -152,7 +152,7 @@ message BatchResolveAddressNamesRequest {
   // List of requested addresses
   repeated string addresses = 1;
   // The chain (network) where domain search should be done
-  string chain_id = 2;
+  int64 chain_id = 2;
 }
 
 message BatchResolveAddressNamesResponse {

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -27,11 +27,13 @@ message Domain {
   // The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
   string name = 2;
   // Optinal. Resolved address of this domain
-  optional string resolved_address = 3;
+  optional Address resolved_address = 3;
   // The account that owns the domain
   Address owner = 4;
   // Optinal. Unix timestamp of expiry date. None means never expires
-  optional uint64 expiry_date = 5; 
+  uint64 registration_date = 5;
+  // Optinal. Unix timestamp of expiry date. None means never expires
+  optional uint64 expiry_date = 6; 
 }
 
 message DetailedDomain {
@@ -67,6 +69,12 @@ message DomainEvent {
   optional string action = 4;
 }
 
+enum OrderDirection {
+    NOT_SET = 0;
+    ASC = 1;
+    DESC = 2;
+}
+
 message Pagination {
   uint32 total_records = 1;
 }
@@ -85,6 +93,10 @@ message ListDomainEventsRequest {
   string name = 1;
   // The chain (network) where domain search should be done
   uint64 chain_id = 2;
+  // Sorting field. Default is `timestamp`
+  string sort = 4;
+  // Order direction. Default is ASC
+  OrderDirection order = 5;
 }
 
 message ListDomainEventsResponse {
@@ -99,6 +111,10 @@ message LookupDomainNameRequest {
   uint64 chain_id = 2;
   // Filtering field to remove expired domains
   bool only_active = 3;
+  // Sorting field. Default is `registration_date`
+  string sort = 4;
+  // Order direction. Default is ASC
+  OrderDirection order = 5;
 }
 
 message LookupDomainNameResponse {
@@ -119,6 +135,10 @@ message LookupAddressRequest {
   bool owned_by = 5;
   // Filtering field to remove expired domains
   bool only_active = 6;
+  // Sorting field. Default is `registration_date`
+  string sort = 7;
+  // Order direction. Defaut is ASC
+  OrderDirection order = 8;
 }
 
 message LookupAddressResponse {

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -5,16 +5,32 @@ package blockscout.bens.v1;
 option go_package = "github.com/blockscout/blockscout-rs/bens";
 
 service DomainsExtractor {
-  rpc GetDomain(GetDomainRequest) returns (Domain) {}
+  // Get detailed information about domain for Detailed domain page
+  rpc GetDomain(GetDomainRequest) returns (DetailedDomain) {}
+  // Get list of events of domain for Detailed domain page
   rpc ListDomainEvents(ListDomainEventsRequest) returns (ListDomainEventsResponse) {}
-
-  rpc ResolveDomainName(ResolveDomainNameRequest) returns (ResolveDomainNameResponse) {}
+  // Get basic info about domain for ens-lookup and blockscout quick-search
+  rpc ResolveDomainName(ResolveDomainNameRequest) returns (Domain) {}
+  // Get basic info about address for ens-lookup and blockscout quick-search
   rpc ResolveAddress(ResolveAddressRequest) returns (ResolveAddressResponse) {}
-  
+  // Perform batch resolving of list of address for blockscout backend requests
   rpc BatchSearchAddressNames(BatchSearchAddressNamesRequest) returns (BatchSearchAddressNamesResponse) {}
 }
 
 message Domain {
+  // Unique id for the domain, also known as nodehash
+  string id = 1;
+  // The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
+  string name = 2;
+  // Optinal. Resolved address of this domain
+  optional string resolved_address = 3;
+  // The account that owns the domain
+  string owner = 4;
+  // Optinal. Unix timestamp of expiry date. None means never expires
+  optional uint64 expiry_date = 5; 
+}
+
+message DetailedDomain {
   // Unique id for the domain, also known as nodehash
   string id = 1;
   // The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
@@ -48,40 +64,24 @@ message DomainEvent {
 }
 
 
-enum DomainView {
-  // The default / unset value.
-  // The API will default to the BASIC view.
-  DOMAIN_VIEW_UNSPECIFIED = 0;
-
-  // Include basic metadata about the domain, but not the full contents.
-  // (id, name, resolved_address, expiry_date)
-  // This is the default value.
-  DOMAIN_VIEW_BASIC = 1;
-
-  // Include everything.
-  DOMAIN_VIEW_FULL = 2;
-}
-
 /************************************************/
 
 message GetDomainRequest {
-  // Unique id for the domain, also known as nodehash
-  string id = 1;
+  // Name of domain, for example vitalik.eth
+  string name = 1;
   // The chain (network) where domain search should be done
   uint64 chain_id = 2;
-  // Specifies how much information about domain should be returned.
-  DomainView view = 3;
 }
 
 message ListDomainEventsRequest {
-  // Unique id for the domain, also known as nodehash
-  string domain_id = 1;
+  // Name of domain, for example vitalik.eth
+  string name = 1;
   // The chain (network) where domain search should be done
   uint64 chain_id = 2;
 }
 
 message ListDomainEventsResponse {
-  repeated DomainEvent domain_events = 1;
+  repeated DomainEvent items = 1;
 }
 
 message ResolveDomainNameRequest {
@@ -89,19 +89,8 @@ message ResolveDomainNameRequest {
   string name = 1;
   // The chain (network) where domain search should be done
   uint64 chain_id = 2;
-  // Specifies how much information about domain should be returned.
-  DomainView view = 3;
   // Filtering field to remove expired domains
-  bool only_active = 4;
-}
-
-message ResolveDomainNameResponse {
-  // Basic domain info.
-  // May be empty in case if domain name haven't been resolved.
-  // The caller should check that `domain.id` is not zero.
-  Domain domain = 1;
-  // List of domain events. Is empty, if BASIC domain view have been requested.
-  repeated DomainEvent domain_events = 2;
+  bool only_active = 3;
 }
 
 
@@ -110,8 +99,6 @@ message ResolveAddressRequest {
   string address = 1;
   // The chain (network) where domain search should be done
   uint64 chain_id = 2;
-  // Specifies how much information about corresponding domain should be returned.
-  DomainView view = 3;
   // Include domains resolved to the address
   bool resolved_to = 4;
   // Include domains owned by the address
@@ -121,11 +108,9 @@ message ResolveAddressRequest {
 }
 
 message ResolveAddressResponse {
-  // List of domains that resolved to requested address
+  // List of domains that resolved to or owned by requested address
   // Sorted by relevance, so first address could be displayed as main resolved address
-  repeated Domain resolved = 1;
-  // List of domains owned by requested address
-  repeated Domain owned = 2;
+  repeated Domain items = 1;
 }
 
 message BatchSearchAddressNamesRequest {

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -69,13 +69,13 @@ message Address {
   string hash = 1;
 }
 
-enum Order {
-    ASC = 0;
-    DESC = 1;
-}
-
 message Pagination {
   uint32 total_records = 1;
+}
+
+enum Order {
+  ASC = 0;
+  DESC = 1;
 }
 
 /************************************************/

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -9,12 +9,16 @@ service DomainsExtractor {
   rpc GetDomain(GetDomainRequest) returns (DetailedDomain) {}
   // Get list of events of domain for Detailed domain page
   rpc ListDomainEvents(ListDomainEventsRequest) returns (ListDomainEventsResponse) {}
-  // Get basic info about domain for ens-lookup and blockscout quick-search
-  rpc ResolveDomainName(ResolveDomainNameRequest) returns (Domain) {}
-  // Get basic info about address for ens-lookup and blockscout quick-search
-  rpc ResolveAddress(ResolveAddressRequest) returns (ResolveAddressResponse) {}
+  // Get basic info about domain for ens-lookup and blockscout quick-search. Sorted by `registration_date`
+  rpc LookupDomainName(LookupDomainNameRequest) returns (LookupDomainNameResponse) {}
+  // Get basic info about address for ens-lookup and blockscout quick-search. Sorted by `registration_date`
+  rpc LookupAddress(LookupAddressRequest) returns (LookupAddressResponse) {}
   // Perform batch resolving of list of address for blockscout backend requests
-  rpc BatchSearchAddressNames(BatchSearchAddressNamesRequest) returns (BatchSearchAddressNamesResponse) {}
+  rpc BatchResolveAddressNames(BatchResolveAddressNamesRequest) returns (BatchResolveAddressNamesResponse) {}
+}
+
+message Address {
+  string hash = 1;
 }
 
 message Domain {
@@ -25,7 +29,7 @@ message Domain {
   // Optinal. Resolved address of this domain
   optional string resolved_address = 3;
   // The account that owns the domain
-  string owner = 4;
+  Address owner = 4;
   // Optinal. Unix timestamp of expiry date. None means never expires
   optional uint64 expiry_date = 5; 
 }
@@ -38,11 +42,11 @@ message DetailedDomain {
   // Integer representation of labelhash
   uint64 token_id = 3;
   // The account that owns the domain
-  string owner = 4;
+  Address owner = 4;
   // Optinal. Resolved address of this domain
-  optional string resolved_address = 5;
+  optional Address resolved_address = 5;
   // Optinal. The account that owns the ERC721 NFT for the domain
-  optional string registrant = 6;
+  optional Address registrant = 6;
   // Optinal. Unix timestamp of expiry date. None means never expires
   optional uint64 expiry_date = 7;
   // Unix timestamp of regisration date
@@ -58,11 +62,14 @@ message DomainEvent {
   // Timestamp of this transaction
   uint64 timestamp = 2;
   ///Sender of transaction
-  string from_address = 3;
+  Address from_address = 3;
   // Optinal. Action name
   optional string action = 4;
 }
 
+message Pagination {
+  uint32 total_records = 1;
+}
 
 /************************************************/
 
@@ -82,9 +89,10 @@ message ListDomainEventsRequest {
 
 message ListDomainEventsResponse {
   repeated DomainEvent items = 1;
+  Pagination pagination = 2;
 }
 
-message ResolveDomainNameRequest {
+message LookupDomainNameRequest {
   // Name of domain, for example vitalik.eth
   string name = 1;
   // The chain (network) where domain search should be done
@@ -93,8 +101,14 @@ message ResolveDomainNameRequest {
   bool only_active = 3;
 }
 
+message LookupDomainNameResponse {
+  // List of domains that resolved to or owned by requested address
+  // Sorted by relevance, so first address could be displayed as main resolved address
+  repeated Domain items = 1;
+  Pagination pagination = 2;
+}
 
-message ResolveAddressRequest {
+message LookupAddressRequest {
   // Address of EOA or contract
   string address = 1;
   // The chain (network) where domain search should be done
@@ -107,19 +121,20 @@ message ResolveAddressRequest {
   bool only_active = 6;
 }
 
-message ResolveAddressResponse {
+message LookupAddressResponse {
   // List of domains that resolved to or owned by requested address
   // Sorted by relevance, so first address could be displayed as main resolved address
   repeated Domain items = 1;
+  Pagination pagination = 2;
 }
 
-message BatchSearchAddressNamesRequest {
+message BatchResolveAddressNamesRequest {
   // List of requested addresses
   repeated string addresses = 1;
   // The chain (network) where domain search should be done
   string chain_id = 2;
 }
 
-message BatchSearchAddressNamesResponse {
+message BatchResolveAddressNamesResponse {
   map<string, string> names = 1;
 }

--- a/blockscout-ens/bens-proto/src/lib.rs
+++ b/blockscout-ens/bens-proto/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 pub mod blockscout {
-    pub mod eth_bytecode_db {
-        pub mod v2 {
+    pub mod bens {
+        pub mod v1 {
             include!(concat!(env!("OUT_DIR"), "/blockscout.bens.v1.rs"));
         }
     }

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -10,15 +10,15 @@ consumes:
 produces:
   - application/json
 paths:
-  /api/v1/{chainId}/address-names:batch-search:
+  /api/v1/{chainId}/addresses:batch-resolve-names:
     post:
       summary: Perform batch resolving of list of address for blockscout backend requests
-      operationId: DomainsExtractor_BatchSearchAddressNames
+      operationId: DomainsExtractor_BatchResolveAddressNames
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1BatchSearchAddressNamesResponse'
+            $ref: '#/definitions/v1BatchResolveAddressNamesResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -42,15 +42,15 @@ paths:
                 title: List of requested addresses
       tags:
         - DomainsExtractor
-  /api/v1/{chainId}/addresses/{address}/resolve:
-    get:
-      summary: Get basic info about address for ens-lookup and blockscout quick-search
-      operationId: DomainsExtractor_ResolveAddress
+  /api/v1/{chainId}/addresses:lookup:
+    post:
+      summary: Get basic info about address for ens-lookup and blockscout quick-search. Sorted by `registration_date`
+      operationId: DomainsExtractor_LookupAddress
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1ResolveAddressResponse'
+            $ref: '#/definitions/v1LookupAddressResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -62,26 +62,24 @@ paths:
           required: true
           type: string
           format: uint64
-        - name: address
-          description: Address of EOA or contract
-          in: path
+        - name: body
+          in: body
           required: true
-          type: string
-        - name: resolvedTo
-          description: Include domains resolved to the address
-          in: query
-          required: false
-          type: boolean
-        - name: ownedBy
-          description: Include domains owned by the address
-          in: query
-          required: false
-          type: boolean
-        - name: onlyActive
-          description: Filtering field to remove expired domains
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: object
+            properties:
+              address:
+                type: string
+                title: Address of EOA or contract
+              resolvedTo:
+                type: boolean
+                title: Include domains resolved to the address
+              ownedBy:
+                type: boolean
+                title: Include domains owned by the address
+              onlyActive:
+                type: boolean
+                title: Filtering field to remove expired domains
       tags:
         - DomainsExtractor
   /api/v1/{chainId}/domains/{name}:
@@ -138,15 +136,15 @@ paths:
           type: string
       tags:
         - DomainsExtractor
-  /api/v1/{chainId}/domains/{name}/resolve:
-    get:
-      summary: Get basic info about domain for ens-lookup and blockscout quick-search
-      operationId: DomainsExtractor_ResolveDomainName
+  /api/v1/{chainId}/domains:lookup:
+    post:
+      summary: Get basic info about domain for ens-lookup and blockscout quick-search. Sorted by `registration_date`
+      operationId: DomainsExtractor_LookupDomainName
       responses:
         "200":
           description: A successful response.
           schema:
-            $ref: '#/definitions/v1Domain'
+            $ref: '#/definitions/v1LookupDomainNameResponse'
         default:
           description: An unexpected error response.
           schema:
@@ -158,16 +156,18 @@ paths:
           required: true
           type: string
           format: uint64
-        - name: name
-          description: Name of domain, for example vitalik.eth
-          in: path
+        - name: body
+          in: body
           required: true
-          type: string
-        - name: onlyActive
-          description: Filtering field to remove expired domains
-          in: query
-          required: false
-          type: boolean
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                title: Name of domain, for example vitalik.eth
+              onlyActive:
+                type: boolean
+                title: Filtering field to remove expired domains
       tags:
         - DomainsExtractor
   /health:
@@ -221,7 +221,7 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/protobufAny'
-  v1BatchSearchAddressNamesResponse:
+  v1BatchResolveAddressNamesResponse:
     type: object
     properties:
       names:
@@ -313,7 +313,9 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/v1DomainEvent'
-  v1ResolveAddressResponse:
+      pagination:
+        $ref: '#/definitions/v1Pagination'
+  v1LookupAddressResponse:
     type: object
     properties:
       items:
@@ -324,3 +326,24 @@ definitions:
         title: |-
           List of domains that resolved to or owned by requested address
           Sorted by relevance, so first address could be displayed as main resolved address
+      pagination:
+        $ref: '#/definitions/v1Pagination'
+  v1LookupDomainNameResponse:
+    type: object
+    properties:
+      items:
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/v1Domain'
+        title: |-
+          List of domains that resolved to or owned by requested address
+          Sorted by relevance, so first address could be displayed as main resolved address
+      pagination:
+        $ref: '#/definitions/v1Pagination'
+  v1Pagination:
+    type: object
+    properties:
+      totalRecords:
+        type: integer
+        format: int64

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -29,6 +29,7 @@ paths:
           in: path
           required: true
           type: string
+          format: int64
         - name: body
           in: body
           required: true
@@ -61,7 +62,7 @@ paths:
           in: path
           required: true
           type: string
-          format: uint64
+          format: int64
         - name: body
           in: body
           required: true
@@ -107,7 +108,7 @@ paths:
           in: path
           required: true
           type: string
-          format: uint64
+          format: int64
         - name: name
           description: Name of domain, for example vitalik.eth
           in: path
@@ -134,7 +135,7 @@ paths:
           in: path
           required: true
           type: string
-          format: uint64
+          format: int64
         - name: name
           description: Name of domain, for example vitalik.eth
           in: path
@@ -176,7 +177,7 @@ paths:
           in: path
           required: true
           type: string
-          format: uint64
+          format: int64
         - name: body
           in: body
           required: true
@@ -271,8 +272,7 @@ definitions:
         title: The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
       tokenId:
         type: string
-        format: uint64
-        title: Integer representation of labelhash
+        title: Hex representation of labelhash
       owner:
         $ref: '#/definitions/v1Address'
         title: The account that owns the domain
@@ -284,11 +284,11 @@ definitions:
         title: Optinal. The account that owns the ERC721 NFT for the domain
       expiryDate:
         type: string
-        format: uint64
+        format: int64
         title: Optinal. Unix timestamp of expiry date. None means never expires
       registrationDate:
         type: string
-        format: uint64
+        format: int64
         title: Unix timestamp of regisration date
       otherAddresses:
         type: object
@@ -314,11 +314,11 @@ definitions:
         title: The account that owns the domain
       registrationDate:
         type: string
-        format: uint64
+        format: int64
         title: Optinal. Unix timestamp of expiry date. None means never expires
       expiryDate:
         type: string
-        format: uint64
+        format: int64
         title: Optinal. Unix timestamp of expiry date. None means never expires
   v1DomainEvent:
     type: object
@@ -328,7 +328,6 @@ definitions:
         title: Transaction hash where action occured
       timestamp:
         type: string
-        format: uint64
         title: Timestamp of this transaction
       fromAddress:
         $ref: '#/definitions/v1Address'

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -85,7 +85,7 @@ paths:
                 type: string
                 title: Sorting field. Default is `registration_date`
               order:
-                $ref: '#/definitions/v1OrderDirection'
+                $ref: '#/definitions/v1Order'
                 title: Order direction. Defaut is ASC
       tags:
         - DomainsExtractor
@@ -152,10 +152,9 @@ paths:
           required: false
           type: string
           enum:
-            - NOT_SET
             - ASC
             - DESC
-          default: NOT_SET
+          default: ASC
       tags:
         - DomainsExtractor
   /api/v1/{chainId}/domains:lookup:
@@ -194,7 +193,7 @@ paths:
                 type: string
                 title: Sorting field. Default is `registration_date`
               order:
-                $ref: '#/definitions/v1OrderDirection'
+                $ref: '#/definitions/v1Order'
                 title: Order direction. Default is ASC
       tags:
         - DomainsExtractor
@@ -376,13 +375,12 @@ definitions:
           Sorted by relevance, so first address could be displayed as main resolved address
       pagination:
         $ref: '#/definitions/v1Pagination'
-  v1OrderDirection:
+  v1Order:
     type: string
     enum:
-      - NOT_SET
       - ASC
       - DESC
-    default: NOT_SET
+    default: ASC
   v1Pagination:
     type: object
     properties:

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -12,6 +12,7 @@ produces:
 paths:
   /api/v1/{chainId}/address-names:batch-search:
     post:
+      summary: Perform batch resolving of list of address for blockscout backend requests
       operationId: DomainsExtractor_BatchSearchAddressNames
       responses:
         "200":
@@ -41,8 +42,9 @@ paths:
                 title: List of requested addresses
       tags:
         - DomainsExtractor
-  /api/v1/{chainId}/addresses:resolve:
-    post:
+  /api/v1/{chainId}/addresses/{address}/resolve:
+    get:
+      summary: Get basic info about address for ens-lookup and blockscout quick-search
       operationId: DomainsExtractor_ResolveAddress
       responses:
         "200":
@@ -60,31 +62,58 @@ paths:
           required: true
           type: string
           format: uint64
-        - name: body
-          in: body
+        - name: address
+          description: Address of EOA or contract
+          in: path
           required: true
-          schema:
-            type: object
-            properties:
-              address:
-                type: string
-                title: Address of EOA or contract
-              view:
-                $ref: '#/definitions/v1DomainView'
-                description: Specifies how much information about corresponding domain should be returned.
-              resolvedTo:
-                type: boolean
-                title: Include domains resolved to the address
-              ownedBy:
-                type: boolean
-                title: Include domains owned by the address
-              onlyActive:
-                type: boolean
-                title: Filtering field to remove expired domains
+          type: string
+        - name: resolvedTo
+          description: Include domains resolved to the address
+          in: query
+          required: false
+          type: boolean
+        - name: ownedBy
+          description: Include domains owned by the address
+          in: query
+          required: false
+          type: boolean
+        - name: onlyActive
+          description: Filtering field to remove expired domains
+          in: query
+          required: false
+          type: boolean
       tags:
         - DomainsExtractor
-  /api/v1/{chainId}/domains/{domainId}/events:
+  /api/v1/{chainId}/domains/{name}:
     get:
+      summary: Get detailed information about domain for Detailed domain page
+      operationId: DomainsExtractor_GetDomain
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1DetailedDomain'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      parameters:
+        - name: chainId
+          description: The chain (network) where domain search should be done
+          in: path
+          required: true
+          type: string
+          format: uint64
+        - name: name
+          description: Name of domain, for example vitalik.eth
+          in: path
+          required: true
+          type: string
+      tags:
+        - DomainsExtractor
+  /api/v1/{chainId}/domains/{name}/events:
+    get:
+      summary: Get list of events of domain for Detailed domain page
       operationId: DomainsExtractor_ListDomainEvents
       responses:
         "200":
@@ -102,16 +131,17 @@ paths:
           required: true
           type: string
           format: uint64
-        - name: domainId
-          description: Unique id for the domain, also known as nodehash
+        - name: name
+          description: Name of domain, for example vitalik.eth
           in: path
           required: true
           type: string
       tags:
         - DomainsExtractor
-  /api/v1/{chainId}/domains/{id}:
+  /api/v1/{chainId}/domains/{name}/resolve:
     get:
-      operationId: DomainsExtractor_GetDomain
+      summary: Get basic info about domain for ens-lookup and blockscout quick-search
+      operationId: DomainsExtractor_ResolveDomainName
       responses:
         "200":
           description: A successful response.
@@ -128,65 +158,16 @@ paths:
           required: true
           type: string
           format: uint64
-        - name: id
-          description: Unique id for the domain, also known as nodehash
+        - name: name
+          description: Name of domain, for example vitalik.eth
           in: path
           required: true
           type: string
-        - name: view
-          description: |-
-            Specifies how much information about domain should be returned.
-
-             - DOMAIN_VIEW_UNSPECIFIED: The default / unset value.
-            The API will default to the BASIC view.
-             - DOMAIN_VIEW_BASIC: Include basic metadata about the domain, but not the full contents.
-            (id, name, resolved_address, expiry_date)
-            This is the default value.
-             - DOMAIN_VIEW_FULL: Include everything.
+        - name: onlyActive
+          description: Filtering field to remove expired domains
           in: query
           required: false
-          type: string
-          enum:
-            - DOMAIN_VIEW_UNSPECIFIED
-            - DOMAIN_VIEW_BASIC
-            - DOMAIN_VIEW_FULL
-          default: DOMAIN_VIEW_UNSPECIFIED
-      tags:
-        - DomainsExtractor
-  /api/v1/{chainId}/domains:resolve:
-    post:
-      operationId: DomainsExtractor_ResolveDomainName
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1ResolveDomainNameResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: chainId
-          description: The chain (network) where domain search should be done
-          in: path
-          required: true
-          type: string
-          format: uint64
-        - name: body
-          in: body
-          required: true
-          schema:
-            type: object
-            properties:
-              name:
-                type: string
-                title: Name of domain, for example vitalik.eth
-              view:
-                $ref: '#/definitions/v1DomainView'
-                description: Specifies how much information about domain should be returned.
-              onlyActive:
-                type: boolean
-                title: Filtering field to remove expired domains
+          type: boolean
       tags:
         - DomainsExtractor
   /health:
@@ -243,11 +224,11 @@ definitions:
   v1BatchSearchAddressNamesResponse:
     type: object
     properties:
-      domainNames:
+      names:
         type: object
         additionalProperties:
           type: string
-  v1Domain:
+  v1DetailedDomain:
     type: object
     properties:
       id:
@@ -284,6 +265,25 @@ definitions:
         title: |-
           Map chain -> resolved_address that contains other blockchain addresses.
           This map will contain `current_chain_id` -> `resovled_address` if `resovled_address` is not None
+  v1Domain:
+    type: object
+    properties:
+      id:
+        type: string
+        title: Unique id for the domain, also known as nodehash
+      name:
+        type: string
+        title: The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
+      resolvedAddress:
+        type: string
+        title: Optinal. Resolved address of this domain
+      owner:
+        type: string
+        title: The account that owns the domain
+      expiryDate:
+        type: string
+        format: uint64
+        title: Optinal. Unix timestamp of expiry date. None means never expires
   v1DomainEvent:
     type: object
     properties:
@@ -300,20 +300,6 @@ definitions:
       action:
         type: string
         title: Optinal. Action name
-  v1DomainView:
-    type: string
-    enum:
-      - DOMAIN_VIEW_UNSPECIFIED
-      - DOMAIN_VIEW_BASIC
-      - DOMAIN_VIEW_FULL
-    default: DOMAIN_VIEW_UNSPECIFIED
-    description: |2-
-       - DOMAIN_VIEW_UNSPECIFIED: The default / unset value.
-      The API will default to the BASIC view.
-       - DOMAIN_VIEW_BASIC: Include basic metadata about the domain, but not the full contents.
-      (id, name, resolved_address, expiry_date)
-      This is the default value.
-       - DOMAIN_VIEW_FULL: Include everything.
   v1HealthCheckResponse:
     type: object
     properties:
@@ -322,7 +308,7 @@ definitions:
   v1ListDomainEventsResponse:
     type: object
     properties:
-      domainEvents:
+      items:
         type: array
         items:
           type: object
@@ -330,32 +316,11 @@ definitions:
   v1ResolveAddressResponse:
     type: object
     properties:
-      resolved:
+      items:
         type: array
         items:
           type: object
           $ref: '#/definitions/v1Domain'
         title: |-
-          List of domains that resolved to requested address
+          List of domains that resolved to or owned by requested address
           Sorted by relevance, so first address could be displayed as main resolved address
-      owned:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1Domain'
-        title: List of domains owned by requested address
-  v1ResolveDomainNameResponse:
-    type: object
-    properties:
-      domain:
-        $ref: '#/definitions/v1Domain'
-        description: |-
-          Basic domain info.
-          May be empty in case if domain name haven't been resolved.
-          The caller should check that `domain.id` is not zero.
-      domainEvents:
-        type: array
-        items:
-          type: object
-          $ref: '#/definitions/v1DomainEvent'
-        description: List of domain events. Is empty, if BASIC domain view have been requested.

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -80,6 +80,12 @@ paths:
               onlyActive:
                 type: boolean
                 title: Filtering field to remove expired domains
+              sort:
+                type: string
+                title: Sorting field. Default is `registration_date`
+              order:
+                $ref: '#/definitions/v1OrderDirection'
+                title: Order direction. Defaut is ASC
       tags:
         - DomainsExtractor
   /api/v1/{chainId}/domains/{name}:
@@ -134,6 +140,21 @@ paths:
           in: path
           required: true
           type: string
+        - name: sort
+          description: Sorting field. Default is `timestamp`
+          in: query
+          required: false
+          type: string
+        - name: order
+          description: Order direction. Default is ASC
+          in: query
+          required: false
+          type: string
+          enum:
+            - NOT_SET
+            - ASC
+            - DESC
+          default: NOT_SET
       tags:
         - DomainsExtractor
   /api/v1/{chainId}/domains:lookup:
@@ -168,6 +189,12 @@ paths:
               onlyActive:
                 type: boolean
                 title: Filtering field to remove expired domains
+              sort:
+                type: string
+                title: Sorting field. Default is `registration_date`
+              order:
+                $ref: '#/definitions/v1OrderDirection'
+                title: Order direction. Default is ASC
       tags:
         - DomainsExtractor
   /health:
@@ -221,6 +248,11 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/protobufAny'
+  v1Address:
+    type: object
+    properties:
+      hash:
+        type: string
   v1BatchResolveAddressNamesResponse:
     type: object
     properties:
@@ -242,13 +274,13 @@ definitions:
         format: uint64
         title: Integer representation of labelhash
       owner:
-        type: string
+        $ref: '#/definitions/v1Address'
         title: The account that owns the domain
       resolvedAddress:
-        type: string
+        $ref: '#/definitions/v1Address'
         title: Optinal. Resolved address of this domain
       registrant:
-        type: string
+        $ref: '#/definitions/v1Address'
         title: Optinal. The account that owns the ERC721 NFT for the domain
       expiryDate:
         type: string
@@ -275,11 +307,15 @@ definitions:
         type: string
         title: The human readable name, if known. Unknown portions replaced with hash in square brackets (eg, foo.[1234].eth)
       resolvedAddress:
-        type: string
+        $ref: '#/definitions/v1Address'
         title: Optinal. Resolved address of this domain
       owner:
-        type: string
+        $ref: '#/definitions/v1Address'
         title: The account that owns the domain
+      registrationDate:
+        type: string
+        format: uint64
+        title: Optinal. Unix timestamp of expiry date. None means never expires
       expiryDate:
         type: string
         format: uint64
@@ -295,7 +331,7 @@ definitions:
         format: uint64
         title: Timestamp of this transaction
       fromAddress:
-        type: string
+        $ref: '#/definitions/v1Address'
         title: /Sender of transaction
       action:
         type: string
@@ -341,6 +377,13 @@ definitions:
           Sorted by relevance, so first address could be displayed as main resolved address
       pagination:
         $ref: '#/definitions/v1Pagination'
+  v1OrderDirection:
+    type: string
+    enum:
+      - NOT_SET
+      - ASC
+      - DESC
+    default: NOT_SET
   v1Pagination:
     type: object
     properties:


### PR DESCRIPTION
I changed API:
+ GetDomain and ListDomainEvents now accept `name` instead of `id`
+ Removed DomainView enum
+ Splitted Domain into Domain and DetailedDomain, such that user will not decide between Full and Basic info
+ Change output of ResolveAddress and ListDomain -- single field called `items` to support future pagination
+ Added pagination field to include total_records field
+ Added sorting fields
+ Added comments for every RPC function to show where frontend should use it
+ Change type of `address` fields to Address with single value `hash`. in future we may add some additional information about address, like `is_contract` etc