### PR TITLE
eth-bytecode-db: update values in the database if they have already existed

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_multi_part.rs
@@ -161,3 +161,28 @@ async fn test_accepts_partial_verification_metadata_in_input() {
     )
         .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_update_source_then_search() {
+    let default_request = VerifySolidityMultiPartRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        evm_version: None,
+        optimization_runs: None,
+        source_files: Default::default(),
+        libraries: Default::default(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Solidity;
+    test_cases::test_update_source_then_search::<MockSolidityVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/solidity_standard_json.rs
@@ -146,3 +146,25 @@ async fn test_accepts_partial_verification_metadata_in_input() {
     )
         .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_update_source_then_search() {
+    let default_request = VerifySolidityStandardJsonRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        input: "".to_string(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Solidity;
+    test_cases::test_update_source_then_search::<MockSolidityVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_multi_part.rs
@@ -156,3 +156,27 @@ async fn test_accepts_partial_verification_metadata_in_input() {
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn test_update_source_then_search() {
+    let default_request = VerifyVyperMultiPartRequest {
+        bytecode: "".to_string(),
+        bytecode_type: BytecodeType::CreationInput.into(),
+        compiler_version: "".to_string(),
+        evm_version: None,
+        source_files: Default::default(),
+        interfaces: Default::default(),
+        metadata: None,
+    };
+    let source_type = verification::SourceType::Vyper;
+    test_cases::test_update_source_then_search::<MockVyperVerifierService, _>(
+        TEST_SUITE_NAME,
+        ROUTE,
+        default_request,
+        source_type,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/vyper_standard_json.rs
@@ -129,7 +129,7 @@ async fn test_search_returns_full_matches_only_if_any() {
 #[tokio::test]
 #[timeout(std::time::Duration::from_secs(60))]
 #[ignore = "Needs database to run"]
-async fn test_accepts_partial_verification_metadata_in_input() {
+async fn test_update_source_then_search() {
     let default_request = VerifyVyperStandardJsonRequest {
         bytecode: "".to_string(),
         bytecode_type: BytecodeType::CreationInput.into(),
@@ -138,7 +138,7 @@ async fn test_accepts_partial_verification_metadata_in_input() {
         metadata: None,
     };
     let source_type = verification::SourceType::Vyper;
-    test_cases::test_accepts_partial_verification_metadata_in_input::<MockVyperVerifierService, _>(
+    test_cases::test_update_source_then_search::<MockVyperVerifierService, _>(
         TEST_SUITE_NAME,
         ROUTE,
         default_request,

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/db/eth_bytecode_db.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/db/eth_bytecode_db.rs
@@ -110,8 +110,13 @@ async fn insert_files(
             content: Set(content.clone()),
             ..Default::default()
         };
-        let (file, _inserted) =
-            insert_then_select!(txn, files, active_model, [(Name, name), (Content, content)])?;
+        let (file, _inserted) = insert_then_select!(
+            txn,
+            files,
+            active_model,
+            true,
+            [(Name, name), (Content, content)]
+        )?;
 
         result.push(file);
     }
@@ -165,6 +170,7 @@ async fn insert_source_details(
         txn,
         sources,
         active_model,
+        true,
         [
             (CompilerVersion, source.compiler_version),
             (CompilerSettings, source.compiler_settings),
@@ -214,6 +220,7 @@ async fn insert_bytecodes(
             txn,
             bytecodes,
             active_model,
+            true,
             [(SourceId, source_id), (BytecodeType, bytecode_type)]
         )?;
         bytecode
@@ -232,6 +239,7 @@ async fn insert_bytecodes(
                 txn,
                 parts,
                 active_model,
+                true,
                 [(Data, part.data()), (PartType, part_type)]
             )?;
             part

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/db/verifier_alliance_db.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/db/verifier_alliance_db.rs
@@ -215,6 +215,7 @@ async fn insert_verified_contract(
         txn,
         verified_contracts,
         active_model,
+        false,
         [
             (CompilationId, compiled_contract.id),
             (ContractId, contract.id),
@@ -274,6 +275,7 @@ async fn insert_compiled_contract(
         txn,
         compiled_contracts,
         active_model,
+        false,
         [
             (Compiler, compiler),
             (Language, language),
@@ -304,6 +306,7 @@ async fn insert_contract_deployment(
         txn,
         contract_deployments,
         active_model,
+        false,
         [
             (ChainId, deployment_data.chain_id),
             (Address, deployment_data.contract_address),
@@ -355,6 +358,7 @@ async fn insert_contract(
         txn,
         contracts,
         active_model,
+        false,
         [
             (CreationCodeHash, creation_code_hash),
             (RuntimeCodeHash, runtime_code_hash)
@@ -374,8 +378,13 @@ async fn insert_code(
         code_hash: Set(code_hash.0.to_vec()),
         code: Set(Some(code)),
     };
-    let (code, _inserted) =
-        insert_then_select!(txn, code, active_model, [(CodeHash, code_hash.0.to_vec())])?;
+    let (code, _inserted) = insert_then_select!(
+        txn,
+        code,
+        active_model,
+        false,
+        [(CodeHash, code_hash.0.to_vec())]
+    )?;
 
     Ok(code)
 }

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
@@ -178,7 +178,6 @@ async fn process_verify_response(
     let (process_eth_bytecode_db_result, process_alliance_db_result) =
         futures::future::join(process_eth_bytecode_db_future, process_alliance_db_future).await;
     let _ = process_eth_bytecode_db_result.map_err(|err: anyhow::Error| {
-        println!("Error while inserting contract data into database: {err:#}");
         tracing::error!(
             ?eth_bytecode_db_action_contract_address,
             ?eth_bytecode_db_action_chain_id,
@@ -186,7 +185,6 @@ async fn process_verify_response(
         )
     });
     let _ = process_alliance_db_result.map_err(|err: anyhow::Error| {
-        println!("Error while inserting contract data into verifier alliance database: {err:#}");
         tracing::error!(
             ?alliance_db_action_contract_address,
             ?alliance_db_action_chain_id,

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
@@ -178,6 +178,7 @@ async fn process_verify_response(
     let (process_eth_bytecode_db_result, process_alliance_db_result) =
         futures::future::join(process_eth_bytecode_db_future, process_alliance_db_future).await;
     let _ = process_eth_bytecode_db_result.map_err(|err: anyhow::Error| {
+        println!("Error while inserting contract data into database: {err:#}");
         tracing::error!(
             ?eth_bytecode_db_action_contract_address,
             ?eth_bytecode_db_action_chain_id,
@@ -185,6 +186,7 @@ async fn process_verify_response(
         )
     });
     let _ = process_alliance_db_result.map_err(|err: anyhow::Error| {
+        println!("Error while inserting contract data into verifier alliance database: {err:#}");
         tracing::error!(
             ?alliance_db_action_contract_address,
             ?alliance_db_action_chain_id,

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
@@ -131,3 +131,13 @@ async fn test_verification_of_same_source_results_stored_once(
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_updated_source_replace_the_old_result() {
+    verification_test_helpers::test_verification_of_updated_source_replace_the_old_result(
+        DB_PREFIX, service,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
@@ -125,3 +125,13 @@ async fn test_verification_of_same_source_results_stored_once(
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_updated_source_replace_the_old_result() {
+    verification_test_helpers::test_verification_of_updated_source_replace_the_old_result(
+        DB_PREFIX, service,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/smart_contract_veriifer_mock.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/verification_test_helpers/smart_contract_veriifer_mock.rs
@@ -27,7 +27,6 @@ mock! {
 }
 
 mock! {
-    #[derive(Clone)]
     pub VyperVerifierService {}
 
     #[async_trait::async_trait]
@@ -41,7 +40,6 @@ mock! {
 }
 
 mock! {
-    #[derive(Clone)]
     pub SourcifyVerifierService {}
 
     #[async_trait::async_trait]

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -123,3 +123,13 @@ async fn test_verification_of_same_source_results_stored_once(service: MockVyper
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_updated_source_replace_the_old_result() {
+    verification_test_helpers::test_verification_of_updated_source_replace_the_old_result(
+        DB_PREFIX, service,
+    )
+    .await;
+}

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_standard_json.rs
@@ -123,3 +123,13 @@ async fn test_verification_of_same_source_results_stored_once(service: MockVyper
     )
     .await;
 }
+
+#[rstest]
+#[tokio::test]
+#[ignore = "Needs database to run"]
+async fn test_verification_of_updated_source_replace_the_old_result() {
+    verification_test_helpers::test_verification_of_updated_source_replace_the_old_result(
+        DB_PREFIX, service,
+    )
+    .await;
+}


### PR DESCRIPTION
The smart-contract-verifier may contains some bugs inside, which may cause it return some invalid data (e.g., #661). But already verified contracts will not change if we try to re-verify them after bugs are fixed, as for now the service have just ignored sources which are already in the database.

This PR makes the verification data store to be updated if the data for the existing unique constraints is inserted. That would allow to update the contracts inside the database by simple re-verification of them.