### PR TITLE
launcher: Fix tonic version to 0.8

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -25,7 +25,7 @@ prometheus = { version = "0.13", optional = true }
 reqwest = { version = "0.11", features = ["json"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 tokio = { version = "1", optional = true }
-tonic = { version = ">= 0.8, < 0.11", optional = true }
+tonic = { version = "0.8", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-opentelemetry = { version = "0.19", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"], optional = true }


### PR DESCRIPTION
Currently implemented constraints make resolve to the latest version of tonic (that is v0.10) when building the launcher. Howver, actix-prost support only version 0.8 right now. That makes it impossible to compile new services from scratch and require to fix the tonic version in Cargo.lock file manually.