### PR TITLE
eth-bytecode-db: Update database search order to return the latest contracts first

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
@@ -136,12 +136,14 @@ impl DatabaseService {
                 .0,
         };
 
-        let sources = search::find_contract(self.client.db_client.as_ref(), &bytecode_remote)
+        let mut matches = search::find_contract(self.client.db_client.as_ref(), &bytecode_remote)
             .await
             .map_err(|err| tonic::Status::internal(err.to_string()))?;
+        matches.sort_by_key(|m| m.updated_at);
 
-        let sources = sources
+        let sources = matches
             .into_iter()
+            .rev()
             .map(|source| SourceWrapper::from(source).into_inner())
             .collect();
 

--- a/eth-bytecode-db/eth-bytecode-db-server/src/types/source.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/types/source.rs
@@ -186,6 +186,7 @@ mod tests {
     #[test]
     fn from_search_source_to_proto_source() {
         let search_source = search::MatchContract {
+            updated_at: Default::default(),
             file_name: "file_name".to_string(),
             contract_name: "contract_name".to_string(),
             compiler_version: "compiler_version".to_string(),

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/database_search.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/database_search.rs
@@ -200,3 +200,109 @@ async fn search_all_sources(service: MockSolidityVerifierService) {
         "Invalid response returned"
     );
 }
+
+#[rstest]
+#[tokio::test]
+#[timeout(std::time::Duration::from_secs(60))]
+#[ignore = "Needs database to run"]
+async fn search_sources_returns_latest_contract() {
+    const ROUTE: &str = "/api/v2/bytecodes/sources:search";
+
+    let db = init_db(TEST_SUITE_NAME, "search_sources_returns_latest_contract").await;
+
+    let build_test_data = |metadata_hash: &str| {
+        let extra_data = smart_contract_verifier_v2::verify_response::ExtraData {
+            local_creation_input_parts: vec![
+                smart_contract_verifier_v2::verify_response::extra_data::BytecodePart {
+                    r#type: "main".to_string(),
+                    data: "0x608060405234801561001057600080fd5b506101ac806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f0eb5e5414610030575b600080fd5b6100566004803603602081101561004657600080fd5b50356001600160a01b0316610072565b604080516001600160a01b039092168252519081900360200190f35b6040516000907fcd6e305ffe05775ee4dccd218c885635a575631eb3fe360b322621bad158facb908290a1600080546001810182558180527f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56301805473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b038516179055604080516374f0fffb60e01b8152600481019290925251736b88c55cfbd4eda1320f802b724193cab062ccce916374f0fffb916024808301926020929190829003018186803b15801561014457600080fd5b505af4158015610158573d6000803e3d6000fd5b505050506040513d602081101561016e57600080fd5b50519291505056fe".to_string(),
+                },
+                smart_contract_verifier_v2::verify_response::extra_data::BytecodePart {
+                    r#type: "meta".to_string(),
+                    data: format!("0xa264697066735822{metadata_hash}64736f6c63430006080033"),
+                },
+            ],
+            local_deployed_bytecode_parts: vec![
+                smart_contract_verifier_v2::verify_response::extra_data::BytecodePart {
+                    r#type: "main".to_string(),
+                    data: "0x608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f0eb5e5414610030575b600080fd5b6100566004803603602081101561004657600080fd5b50356001600160a01b0316610072565b604080516001600160a01b039092168252519081900360200190f35b6040516000907fcd6e305ffe05775ee4dccd218c885635a575631eb3fe360b322621bad158facb908290a1600080546001810182558180527f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56301805473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b038516179055604080516374f0fffb60e01b8152600481019290925251736b88c55cfbd4eda1320f802b724193cab062ccce916374f0fffb916024808301926020929190829003018186803b15801561014457600080fd5b505af4158015610158573d6000803e3d6000fd5b505050506040513d602081101561016e57600080fd5b50519291505056fe".to_string(),
+                },
+                smart_contract_verifier_v2::verify_response::extra_data::BytecodePart {
+                    r#type: "meta".to_string(),
+                    data: format!("0xa264697066735822{metadata_hash}64736f6c63430006080033"),
+                },
+            ],
+        };
+
+        let mut test_data =
+            test_input_data::basic(verification::SourceType::Solidity, MatchType::Partial);
+        test_data.set_bytecode(extra_data);
+
+        test_data
+    };
+
+    let test_data_old =
+        build_test_data("cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe");
+    {
+        let db_url = db.db_url();
+        let verifier_addr = init_verifier_server(service(), test_data_old.verifier_response).await;
+
+        let eth_bytecode_db_base = init_eth_bytecode_db_server(db_url, verifier_addr).await;
+
+        // Fill the database with existing value
+        {
+            let dummy_request = default_verify_request();
+            let _verification_response: eth_bytecode_db_v2::VerifyResponse =
+                test_server::send_post_request(&eth_bytecode_db_base, VERIFY_ROUTE, &dummy_request)
+                    .await;
+        }
+    }
+
+    let test_data_new = {
+        let mut test_data =
+            build_test_data("12341234123412341234123412341234123412341234123412341234123412341234");
+        test_data.add_source_file(
+            "Additional.sol".to_string(),
+            "AdditionalContent".to_string(),
+        );
+        test_data
+    };
+
+    let db_url = db.db_url();
+    let verifier_addr = init_verifier_server(service(), test_data_new.verifier_response).await;
+
+    let eth_bytecode_db_base = init_eth_bytecode_db_server(db_url, verifier_addr).await;
+
+    // Fill the database with existing value
+    {
+        let dummy_request = default_verify_request();
+        let _verification_response: eth_bytecode_db_v2::VerifyResponse =
+            test_server::send_post_request(&eth_bytecode_db_base, VERIFY_ROUTE, &dummy_request)
+                .await;
+    }
+
+    let chain_id = "5".to_string();
+    let contract_address = "0x027f1fe8BbC2a7E9fE97868E82c6Ec6939086c52".to_string();
+
+    let request = SearchAllSourcesRequest {
+        bytecode: "0x608060405234801561001057600080fd5b506101ac806100206000396000f3fe608060405234801561001057600080fd5b506004361061002b5760003560e01c8063f0eb5e5414610030575b600080fd5b6100566004803603602081101561004657600080fd5b50356001600160a01b0316610072565b604080516001600160a01b039092168252519081900360200190f35b6040516000907fcd6e305ffe05775ee4dccd218c885635a575631eb3fe360b322621bad158facb908290a1600080546001810182558180527f290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e56301805473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b038516179055604080516374f0fffb60e01b8152600481019290925251736b88c55cfbd4eda1320f802b724193cab062ccce916374f0fffb916024808301926020929190829003018186803b15801561014457600080fd5b505af4158015610158573d6000803e3d6000fd5b505050506040513d602081101561016e57600080fd5b50519291505056fea26469706673582212205d1888f7386285c3a4057473423de59284f625b9678dc83756b94cdba366949d64736f6c63430006080033".to_string(),
+        bytecode_type: eth_bytecode_db_v2::BytecodeType::CreationInput.into(),
+        chain: chain_id,
+        address: contract_address,
+    };
+
+    let verification_response: SearchSourcesResponse =
+        test_server::send_post_request(&eth_bytecode_db_base, ROUTE, &request).await;
+
+    let expected_response = SearchSourcesResponse {
+        sources: vec![
+            test_data_new.eth_bytecode_db_response.source.unwrap(),
+            test_data_old.eth_bytecode_db_response.source.unwrap(),
+        ],
+    };
+
+    assert_eq!(
+        expected_response, verification_response,
+        "Invalid response returned"
+    );
+}

--- a/eth-bytecode-db/eth-bytecode-db/src/search/match_contract.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/search/match_contract.rs
@@ -4,12 +4,16 @@ use anyhow::Context;
 use bytes::Bytes;
 use entity::{files, sea_orm_active_enums::BytecodeType, sources};
 use ethabi::Constructor;
-use sea_orm::{prelude::DbErr, ConnectionTrait, EntityTrait};
+use sea_orm::{
+    prelude::{DateTime, DbErr},
+    ConnectionTrait, EntityTrait,
+};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MatchContract {
+    pub updated_at: DateTime,
     pub file_name: String,
     pub contract_name: String,
     pub compiler_version: String,
@@ -77,6 +81,7 @@ impl MatchContract {
             .map(|f| (f.name, f.content))
             .collect();
         let match_contract = MatchContract {
+            updated_at: source.updated_at,
             file_name: source.file_name,
             contract_name: source.contract_name,
             compiler_version: source.compiler_version,


### PR DESCRIPTION
Updates the order of contracts returned from the database search endpoints. Before, the oldest contracts have been returned first. Now, the order has been updated to return the newest firstly