### PR TITLE
Add kv database connection

### DIFF
--- a/blockscout-ens/bens-server/src/server.rs
+++ b/blockscout-ens/bens-server/src/server.rs
@@ -51,8 +51,9 @@ pub async fn run(settings: Settings) -> Result<(), anyhow::Error> {
     let pool = Arc::new(
         PgPoolOptions::new()
             .max_connections(40)
-            .connect(&settings.database.url)
-            .await?,
+            .connect(&settings.database.connect.url())
+            .await
+            .context("database connect")?,
     );
     let blockscout_clients = settings
         .blockscout

--- a/blockscout-ens/bens-server/src/server.rs
+++ b/blockscout-ens/bens-server/src/server.rs
@@ -48,10 +48,11 @@ pub async fn run(settings: Settings) -> Result<(), anyhow::Error> {
 
     let health = Arc::new(HealthService::default());
 
+    let database_url = settings.database.connect.url();
     let pool = Arc::new(
         PgPoolOptions::new()
             .max_connections(40)
-            .connect(&settings.database.connect.url())
+            .connect(&database_url)
             .await
             .context("database connect")?,
     );

--- a/blockscout-ens/bens-server/src/settings.rs
+++ b/blockscout-ens/bens-server/src/settings.rs
@@ -39,36 +39,44 @@ pub struct DatabaseSettings {
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub enum DatabaseConnectSettings {
     Url(String),
-    KV(DatabaseKVConnection),
+    Kv(DatabaseKvConnection),
 }
 
 impl DatabaseConnectSettings {
-    pub fn url(&self) -> String {
+    pub fn url(self) -> String {
         match self {
-            DatabaseConnectSettings::Url(s) => s.clone(),
-            DatabaseConnectSettings::KV(kv) => kv.url(),
+            DatabaseConnectSettings::Url(s) => s,
+            DatabaseConnectSettings::Kv(kv) => kv.url(),
         }
     }
 }
 
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
-pub struct DatabaseKVConnection {
+pub struct DatabaseKvConnection {
     pub host: String,
-    pub port: i32,
+    pub port: u16,
     pub user: String,
     pub password: String,
     #[serde(default)]
-    pub dbname: String,
+    pub dbname: Option<String>,
     #[serde(default)]
-    pub options: String,
+    pub options: Option<String>,
 }
 
-impl DatabaseKVConnection {
-    pub fn url(&self) -> String {
+impl DatabaseKvConnection {
+    pub fn url(self) -> String {
+        let dbname = self
+            .dbname
+            .map(|dbname| format!("/{dbname}"))
+            .unwrap_or_default();
+        let options = self
+            .options
+            .map(|options| format!("?{options}"))
+            .unwrap_or_default();
         format!(
-            "postgresql://{}:{}@{}:{}/{}{}",
-            self.user, self.password, self.host, self.port, self.dbname, self.options
+            "postgresql://{}:{}@{}:{}{}{}",
+            self.user, self.password, self.host, self.port, dbname, options
         )
     }
 }

--- a/blockscout-ens/bens-server/tests/domains.rs
+++ b/blockscout-ens/bens-server/tests/domains.rs
@@ -16,7 +16,7 @@ async fn basic_domain_extracting_works(pool: PgPool) {
         "{postgres_url}{}",
         pool.connect_options().get_database().unwrap()
     );
-    std::env::set_var("BENS__DATABASE__URL", db_url);
+    std::env::set_var("BENS__DATABASE__CONNECT__URL", db_url);
     let clients = mocked_blockscout_clients().await;
     std::env::set_var("BENS__CONFIG", "./tests/config.test.toml");
     let mut settings = Settings::build().expect("Failed to build settings");


### PR DESCRIPTION
Added option to configure database connection using key-value approach.

for example

```bash
BENS__DATABASE__CONNECT__KV__HOST=localhost
BENS__DATABASE__CONNECT__KV__PORT=15432
BENS__DATABASE__CONNECT__KV__USER=user
BENS__DATABASE__CONNECT__KV__PASSWORD=password
BENS__DATABASE__CONNECT__KV__DBNAME=graph_node
BENS__DATABASE__CONNECT__KV__OPTIONS="sslmode=prefer"
```

is alternative approach to 

```bash
BENS__DATABASE__CONNECT__URL="postgresql://user:password@localhost:15432/graph_node?sslmode=prefer"
```