### PR TITLE
Add materialized view for address name resolving

### DIFF
--- a/blockscout-ens/Cargo.lock
+++ b/blockscout-ens/Cargo.lock
@@ -658,6 +658,7 @@ dependencies = [
  "sqlx",
  "thiserror",
  "tokio",
+ "tokio-cron-scheduler",
  "tonic",
  "tracing",
  "tracing-subscriber",
@@ -1275,6 +1276,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff76b51e4c068c52bfd2866e1567bee7c567ae8f24ada09fd4307019e25eab7"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]
@@ -3177,6 +3189,17 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5647,6 +5670,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-cron-scheduler"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c1fd54a857b29c6cd1846f31903d0ae8e28175615c14a277aed45c58d8e27"
+dependencies = [
+ "chrono",
+ "cron",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid 1.5.0",
+]
+
+[[package]]
 name = "tokio-io-timeout"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6153,6 +6191,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
+ "getrandom 0.2.10",
  "serde",
 ]
 

--- a/blockscout-ens/bens-logic/examples/resolve_benchmark.rs
+++ b/blockscout-ens/bens-logic/examples/resolve_benchmark.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<(), anyhow::Error> {
         BlockscoutClient::new("https://rootstock.blockscout.com".parse().unwrap(), 5, 30);
     let clients: HashMap<i64, BlockscoutClient> =
         HashMap::from_iter([(1, eth_client), (30, rootstock_client)]);
-    let reader = SubgraphReader::initialize(pool.clone(), clients).await?;
+    let reader = SubgraphReader::initialize(pool.clone(), clients, true).await?;
 
     let addresses = vec![
         "0x0292f204513eeafe8c032ffc4cb4c7e10eca908c",
@@ -141,7 +141,7 @@ async fn main() -> Result<(), anyhow::Error> {
         })
         .await
         .expect("failed to quick resolve");
-    // job size is 94. elapsed 1.1955539s. resolved as 13 domains
+    // job size is 94. elapsed 0.65092486s. resolved as 14 domains
     println!(
         "job size is {}. elapsed {:?}s. resolved as {} domains",
         size,

--- a/blockscout-ens/bens-logic/src/subgraphs_reader/sql/address_names.rs
+++ b/blockscout-ens/bens-logic/src/subgraphs_reader/sql/address_names.rs
@@ -2,6 +2,8 @@ use crate::subgraphs_reader::SubgraphReadError;
 use sqlx::{postgres::PgPool, Executor};
 use tracing::instrument;
 
+use super::{DOMAIN_DEFAULT_WHERE_CLAUSE, DOMAIN_NOT_EXPIRED_WHERE_CLAUSE};
+
 #[instrument(
     name = "create_address_names_view",
     skip(pool),
@@ -24,13 +26,9 @@ pub async fn create_address_names_view(
         from {schema}.domain
         where
             resolved_address IS NOT NULL
-            AND label_name IS NOT NULL
             AND name NOT LIKE '%[%'
-            AND (
-                expiry_date is null
-                OR to_timestamp(expiry_date) > now()
-            )
-            AND block_range @> 2147483647
+            AND {DOMAIN_DEFAULT_WHERE_CLAUSE}
+            AND {DOMAIN_NOT_EXPIRED_WHERE_CLAUSE}
         ORDER BY resolved_address, created_at
         "#,
     )))

--- a/blockscout-ens/bens-logic/src/subgraphs_reader/sql/address_names.rs
+++ b/blockscout-ens/bens-logic/src/subgraphs_reader/sql/address_names.rs
@@ -1,0 +1,87 @@
+use crate::subgraphs_reader::SubgraphReadError;
+use sqlx::{postgres::PgPool, Executor};
+use tracing::instrument;
+
+#[instrument(
+    name = "create_address_names_view",
+    skip(pool),
+    err(level = "error"),
+    level = "info"
+)]
+pub async fn create_address_names_view(
+    pool: &PgPool,
+    schema: &str,
+) -> Result<(), SubgraphReadError> {
+    let mut tx = pool.begin().await?;
+
+    tx.execute(sqlx::query(&format!(
+        r#"
+        CREATE MATERIALIZED VIEW IF NOT EXISTS {schema}.address_names AS
+        SELECT DISTINCT ON (resolved_address)
+            id,
+            name AS domain_name,
+            resolved_address
+        from {schema}.domain
+        where
+            resolved_address IS NOT NULL
+            AND label_name IS NOT NULL
+            AND name NOT LIKE '%[%'
+            AND (
+                expiry_date is null
+                OR to_timestamp(expiry_date) > now()
+            )
+            AND block_range @> 2147483647
+        ORDER BY resolved_address, created_at
+        "#,
+    )))
+    .await?;
+
+    tx.execute(sqlx::query(&format!(
+        r#"
+        CREATE UNIQUE INDEX IF NOT EXISTS
+        address_names_unique_resolved_address
+        ON {schema}.address_names (resolved_address);
+        "#
+    )))
+    .await?;
+
+    let function_name = refresh_function_name(schema);
+    tx.execute(sqlx::query(&format!(
+        r#"
+        CREATE OR REPLACE FUNCTION {function_name}
+        RETURNS void AS
+        $$
+        BEGIN
+            REFRESH MATERIALIZED VIEW CONCURRENTLY {schema}.address_names;
+        END;
+        $$
+        LANGUAGE plpgsql;
+        "#
+    )))
+    .await?;
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
+#[instrument(
+    name = "refresh_address_names_view",
+    skip(pool),
+    err(level = "error"),
+    level = "info"
+)]
+pub async fn refresh_address_names_view(
+    pool: &PgPool,
+    schema: &str,
+) -> Result<(), SubgraphReadError> {
+    let function_name = refresh_function_name(schema);
+    sqlx::query(&format!("SELECT {function_name};"))
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+fn refresh_function_name(schema: &str) -> String {
+    format!("{schema}_refresh_address_names()")
+}

--- a/blockscout-ens/bens-logic/src/subgraphs_reader/sql/domain.rs
+++ b/blockscout-ens/bens-logic/src/subgraphs_reader/sql/domain.rs
@@ -40,12 +40,12 @@ COALESCE(to_timestamp(expiry_date) < now(), false) AS is_expired
 // `block_range @>` is special sql syntax for fast filtering int4range
 // to access current version of domain.
 // Source: https://github.com/graphprotocol/graph-node/blob/19fd41bb48511f889dc94f5d82e16cd492f29da1/store/postgres/src/block_range.rs#L26
-const DOMAIN_DEFAULT_WHERE_CLAUSE: &str = r#"
+pub const DOMAIN_DEFAULT_WHERE_CLAUSE: &str = r#"
 label_name IS NOT NULL
 AND block_range @> 2147483647
 "#;
 
-const DOMAIN_NOT_EXPIRED_WHERE_CLAUSE: &str = r#"
+pub const DOMAIN_NOT_EXPIRED_WHERE_CLAUSE: &str = r#"
 (
     expiry_date is null
     OR to_timestamp(expiry_date) > now()

--- a/blockscout-ens/bens-logic/src/subgraphs_reader/sql/mod.rs
+++ b/blockscout-ens/bens-logic/src/subgraphs_reader/sql/mod.rs
@@ -1,5 +1,7 @@
+mod address_names;
 mod domain;
 mod transaction_history;
 
+pub use address_names::*;
 pub use domain::*;
 pub use transaction_history::*;

--- a/blockscout-ens/bens-server/Cargo.toml
+++ b/blockscout-ens/bens-server/Cargo.toml
@@ -25,6 +25,7 @@ url = { version = "2", features = ["serde"] }
 hex = "0.4"
 thiserror = "1"
 chrono = "0.4"
+tokio-cron-scheduler = "0.9.4"
 
 [dependencies.sqlx]
 version = "0.7"

--- a/blockscout-ens/bens-server/src/services/domain_extractor.rs
+++ b/blockscout-ens/bens-server/src/services/domain_extractor.rs
@@ -10,13 +10,14 @@ use bens_proto::blockscout::bens::v1::{
     ListDomainEventsRequest, ListDomainEventsResponse, LookupAddressRequest, LookupAddressResponse,
     LookupDomainNameRequest, LookupDomainNameResponse, Pagination,
 };
+use std::sync::Arc;
 
 pub struct DomainsExtractorService {
-    pub subgraph_reader: SubgraphReader,
+    pub subgraph_reader: Arc<SubgraphReader>,
 }
 
 impl DomainsExtractorService {
-    pub fn new(subgraph_reader: SubgraphReader) -> Self {
+    pub fn new(subgraph_reader: Arc<SubgraphReader>) -> Self {
         Self { subgraph_reader }
     }
 }

--- a/blockscout-ens/bens-server/src/settings.rs
+++ b/blockscout-ens/bens-server/src/settings.rs
@@ -18,7 +18,8 @@ pub struct Settings {
     pub tracing: TracingSettings,
     #[serde(default)]
     pub jaeger: JaegerSettings,
-
+    #[serde(default)]
+    pub subgraph: SubgraphSettings,
     pub database: DatabaseSettings,
     #[serde(default)]
     pub blockscout: BlockscoutSettings,
@@ -26,6 +27,32 @@ pub struct Settings {
 
 impl ConfigSettings for Settings {
     const SERVICE_NAME: &'static str = "BENS";
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct SubgraphSettings {
+    #[serde(default = "default_cache_enabled")]
+    pub cache_enabled: bool,
+    #[serde(default = "default_refresh_cache_schedule")]
+    pub refresh_cache_schedule: String,
+}
+
+fn default_refresh_cache_schedule() -> String {
+    "0 0 * * * *".to_string() // every hour
+}
+
+fn default_cache_enabled() -> bool {
+    true
+}
+
+impl Default for SubgraphSettings {
+    fn default() -> Self {
+        Self {
+            refresh_cache_schedule: default_refresh_cache_schedule(),
+            cache_enabled: default_cache_enabled(),
+        }
+    }
 }
 
 // TODO: move database settings to blockscout-service-launcher
@@ -139,6 +166,7 @@ impl Settings {
             metrics: Default::default(),
             tracing: Default::default(),
             jaeger: Default::default(),
+            subgraph: Default::default(),
             database: DatabaseSettings {
                 connect: DatabaseConnectSettings::Url(database_url),
             },

--- a/blockscout-ens/bens-server/tests/domains.rs
+++ b/blockscout-ens/bens-server/tests/domains.rs
@@ -33,7 +33,19 @@ async fn basic_domain_extracting_works(pool: PgPool) {
             )
         })
         .collect();
+    settings.subgraph.cache_enabled = true;
 
+    // first start with enabled cache
+    check_basic_scenario(settings.clone(), base.clone()).await;
+    // second start with same settings to check
+    // that creation of cache tables works fine
+    check_basic_scenario(settings.clone(), base.clone()).await;
+    // third start with disabled cache
+    settings.subgraph.cache_enabled = false;
+    check_basic_scenario(settings, base).await;
+}
+
+async fn check_basic_scenario(settings: Settings, base: Url) {
     init_server(
         || async {
             bens_server::run(settings).await.unwrap();


### PR DESCRIPTION
I added materialized view for quick batch ENS name resolving. I decided to write view updating inside server (thanks [tokio-cron-scheduler](https://github.com/mvniekerk/tokio-cron-scheduler/tree/main)) rather than use `pg_cron`.

+ the feature can be enabled/disabled using `BENS__SUBGRAPH__CACHE_ENABLED=true/false` variable.
+ sheduler will refresh view according to `BENS__SUBGRAPH__REFRESH_CACHE_SCHEDULE` (6-items extended crontab format)