### PR TITLE
Add lookup-methods post-action for solidity verifier

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier-server/src/services/sourcify_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/services/sourcify_verifier.rs
@@ -96,7 +96,7 @@ fn process_verification_result(
     response: Result<sc_sourcify::Success, Error>,
 ) -> Result<VerifyResponseWrapper, Status> {
     match response {
-        Ok(verification_success) => Ok(VerifyResponseWrapper::ok(verification_success)),
+        Ok(verification_success) => Ok(VerifyResponseWrapper::ok(verification_success, None)),
         Err(err) => match err {
             Error::Internal(err) => {
                 tracing::error!("internal error: {err:#?}");

--- a/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
@@ -80,7 +80,7 @@ impl VyperVerifier for VyperVerifierService {
         let result = vyper::multi_part::verify(self.client.clone(), request.try_into()?).await;
 
         let response = if let Ok(verification_success) = result {
-            VerifyResponseWrapper::ok(verification_success)
+            VerifyResponseWrapper::ok(verification_success, None)
         } else {
             let err = result.unwrap_err();
             match err {
@@ -134,7 +134,7 @@ impl VyperVerifier for VyperVerifierService {
         let result = vyper::standard_json::verify(self.client.clone(), verification_request).await;
 
         let response = if let Ok(verification_success) = result {
-            VerifyResponseWrapper::ok(verification_success)
+            VerifyResponseWrapper::ok(verification_success, None)
         } else {
             let err = result.unwrap_err();
             match err {

--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/verify_response.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/verify_response.rs
@@ -84,16 +84,17 @@ impl VerifyResponseOk for SourcifySuccess {
 }
 
 impl VerifyResponseWrapper {
-    pub fn ok<T: VerifyResponseOk>(success: T) -> Self {
+    pub fn ok<T: VerifyResponseOk>(
+        success: T,
+        post_action_responses: Option<PostActionResponses>,
+    ) -> Self {
         let (source, extra_data) = success.result();
         VerifyResponse {
             message: "OK".to_string(),
             status: Status::Success.into(),
             source: Some(source),
             extra_data: Some(extra_data),
-            post_action_responses: Some(PostActionResponses {
-                lookup_methods: None,
-            }),
+            post_action_responses,
         }
         .into()
     }
@@ -190,7 +191,7 @@ mod tests {
             deployed_bytecode_artifacts: Default::default(),
         };
 
-        let response = VerifyResponseWrapper::ok(verification_success.clone()).into_inner();
+        let response = VerifyResponseWrapper::ok(verification_success.clone(), None).into_inner();
 
         let expected = VerifyResponse {
             message: "OK".to_string(),

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/solidity.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/solidity.rs
@@ -258,6 +258,24 @@ async fn test_success(test_case: impl TestCase) {
             "Invalid deployed bytecode artifacts"
         )
     }
+
+    if let Some(expected_lookup_methods) = test_case.lookup_methods() {
+        let lookup_methods = verification_response
+            .post_action_responses
+            .map(|value| {
+                serde_json::to_value(&value).unwrap_or_else(|err| {
+                    panic!(
+                        "Lookup methods serialization failed: {:?}; err: {}",
+                        value, err
+                    )
+                })
+            })
+            .expect("Lookup methods are missing");
+        assert_eq!(
+            lookup_methods, expected_lookup_methods,
+            "Invalid lookup methods"
+        )
+    }
 }
 
 async fn _test_failure(test_case: impl TestCase, expected_message: &str) {

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_types.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/solidity_types.rs
@@ -53,6 +53,10 @@ pub trait TestCase {
     fn deployed_bytecode_artifacts(&self) -> Option<serde_json::Value> {
         None
     }
+
+    fn lookup_methods(&self) -> Option<serde_json::Value> {
+        None
+    }
 }
 
 pub fn from_file<T: TestCase + DeserializeOwned>(test_case: &str) -> T {
@@ -79,6 +83,7 @@ pub struct Flattened {
     pub expected_compiler_artifacts: Option<serde_json::Value>,
     pub expected_creation_input_artifacts: Option<serde_json::Value>,
     pub expected_deployed_bytecode_artifacts: Option<serde_json::Value>,
+    pub expected_lookup_methods: Option<serde_json::Value>,
 
     // Verification metadata related values
     pub chain_id: Option<String>,
@@ -105,7 +110,8 @@ impl TestCase for Flattened {
             "metadata": {
                 "chainId": self.chain_id,
                 "contractAddress": self.contract_address
-            }
+            },
+            "postActions": ["lookup-methods"]
         })
     }
 
@@ -171,6 +177,10 @@ impl TestCase for Flattened {
 
     fn deployed_bytecode_artifacts(&self) -> Option<serde_json::Value> {
         self.expected_deployed_bytecode_artifacts.clone()
+    }
+
+    fn lookup_methods(&self) -> Option<serde_json::Value> {
+        self.expected_lookup_methods.clone()
     }
 }
 

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_solidity/simple_storage.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_solidity/simple_storage.json
@@ -5,6 +5,22 @@
     "compiler_version": "v0.8.18+commit.87f61d96",
     "contract_name": "Storage",
     "source_code": "// SPDX-License-Identifier: GPL-3.0\n\npragma solidity >=0.7.0 <0.9.0;\n\n/**\n * @title Storage\n * @dev Store & retrieve value in a variable\n */\ncontract Storage {\n\n    uint256 number;\n\n    /**\n     * Some user related comment.\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n\n    /**\n     * @dev Return value \n     * @return value of 'number'\n     */\n    function retrieve() public view returns (uint256){\n        return number;\n    }\n}",
+    "expected_lookup_methods": {
+        "lookupMethods": {
+            "methods":{
+                "2e64cec1": {
+                    "fileName": "source.sol",
+                    "fileOffset": 450,
+                    "length": 79
+                },
+                "6057361d": {
+                    "fileName": "source.sol",
+                    "fileOffset": 305,
+                    "length": 64
+                }
+            }
+        }
+    },
     "expected_compiler_artifacts": {
         "abi": [{"inputs":[],"name":"retrieve","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"num","type":"uint256"}],"name":"store","outputs":[],"stateMutability":"nonpayable","type":"function"}],
         "userdoc": {"kind":"user","methods":{"store(uint256)":{"notice":"Some user related comment."}},"version":1},

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_solidity/two_cbor_auxdata.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_solidity/two_cbor_auxdata.json
@@ -5,6 +5,27 @@
     "compiler_version": "v0.8.18+commit.87f61d96",
     "contract_name": "CarFactory",
     "source_code": "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.17;\n\ncontract Car {\n    \n    string public model;\n    address public carAddr;\n\n    constructor( string memory _model)  {\n        model = _model;\n        carAddr = address(this);\n    }\n}\n\ncontract CarFactory {\n    Car[] public cars;\n\n    function create( string memory _model) public {\n        Car car = new Car( _model);\n        cars.push(car);\n    }\n\n\n    function create2( string memory _model, bytes32 _salt) public {\n        Car car = (new Car){salt: _salt}( _model);\n        cars.push(car);\n    }\n\n    \n}\n",
+    "expected_lookup_methods": {
+        "lookupMethods": {
+            "methods":{
+                "973d5e44": {
+                    "fileName": "source.sol",
+                    "fileOffset": 410,
+                    "length": 144
+                },
+                "b6a46b3b": {
+                    "fileName": "source.sol",
+                    "fileOffset": 290,
+                    "length": 113
+                },
+                "f7746e36": {
+                    "fileName": "source.sol",
+                    "fileOffset": 266,
+                    "length": 17
+                }
+            }
+        }
+    },
     "expected_compiler_artifacts": {
         "abi": [{"inputs":[{"internalType":"uint256","name":"","type":"uint256"}],"name":"cars","outputs":[{"internalType":"contract Car","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"_model","type":"string"}],"name":"create","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"string","name":"_model","type":"string"},{"internalType":"bytes32","name":"_salt","type":"bytes32"}],"name":"create2","outputs":[],"stateMutability":"nonpayable","type":"function"}],
         "userdoc": {"kind":"user","methods":{},"version":1},

--- a/smart-contract-verifier/smart-contract-verifier/src/lib.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/lib.rs
@@ -29,7 +29,9 @@ pub use compiler::{Compilers, Fetcher, ListFetcher, S3Fetcher, Version};
 pub use verifier::{BytecodePart, Error as VerificationError};
 
 pub use crate::sourcify::{SourcifyApiClient, Success as SourcifySuccess};
-pub use lookup_methods::{find_methods, LookupMethodsRequest, LookupMethodsResponse};
+pub use lookup_methods::{
+    find_methods, find_methods_from_compiler_output, LookupMethodsRequest, LookupMethodsResponse,
+};
 pub use solidity::{
     Client as SolidityClient, SolcValidator, SolidityCompiler, Success as SoliditySuccess,
 };

--- a/smart-contract-verifier/smart-contract-verifier/src/lookup_methods/find_methods.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/lookup_methods/find_methods.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use bytes::Bytes;
 use ethers_core::abi::Abi;
-use ethers_solc::sourcemap::SourceMap;
+use ethers_solc::{sourcemap::SourceMap, CompilerOutput};
 use std::{collections::BTreeMap, iter::repeat};
 
 pub struct LookupMethodsRequest {
@@ -18,9 +18,68 @@ pub struct LookupMethodsResponse {
     pub methods: BTreeMap<String, Method>,
 }
 
+pub fn find_methods_from_compiler_output(
+    contract_name: &String,
+    output: &CompilerOutput,
+) -> anyhow::Result<LookupMethodsResponse> {
+    let file_ids = output
+        .sources
+        .iter()
+        .map(|(name, file)| (file.id, name.clone()))
+        .collect();
+
+    let (_, contract) = output
+        .contracts_iter()
+        .find(|(name, _)| *name == contract_name)
+        .ok_or_else(|| anyhow::anyhow!("contract {contract_name} not found"))?;
+
+    let evm = contract
+        .evm
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("evm missing"))?;
+    let deployed_bytecode = evm
+        .deployed_bytecode
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("deployed bytecode missing"))?;
+    let bytecode = deployed_bytecode
+        .bytecode
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("bytecode missing"))?;
+    let source_map = bytecode
+        .source_map()
+        .ok_or_else(|| anyhow::anyhow!("source map missing"))??;
+    let bytecode_raw = &bytecode
+        .object
+        .as_bytes()
+        .ok_or_else(|| anyhow::anyhow!("invalid bytecode"))?
+        .0;
+    let methods = parse_selectors_from_method_ids(&evm.method_identifiers)?;
+
+    Ok(find_methods_internal(
+        methods,
+        bytecode_raw,
+        &source_map,
+        &file_ids,
+    ))
+}
+
 pub fn find_methods(request: LookupMethodsRequest) -> LookupMethodsResponse {
-    let methods = parse_selectors(request.abi);
-    let opcodes = disassemble_bytecode(&request.bytecode);
+    let methods = parse_selectors_from_abi(&request.abi);
+    find_methods_internal(
+        methods,
+        &request.bytecode,
+        &request.source_map,
+        &request.file_ids,
+    )
+}
+
+fn find_methods_internal(
+    methods: BTreeMap<String, [u8; 4]>,
+    bytecode: &Bytes,
+    source_map: &SourceMap,
+    file_ids: &BTreeMap<u32, String>,
+) -> LookupMethodsResponse {
+    let opcodes = disassemble_bytecode(bytecode);
 
     let methods = methods
         .into_iter()
@@ -33,13 +92,7 @@ pub fn find_methods(request: LookupMethodsRequest) -> LookupMethodsResponse {
                 }
             };
 
-            tracing::debug!(func_sig, func_index, "found function");
-            let method = match Method::from_source_map(
-                selector,
-                &request.source_map,
-                func_index,
-                &request.file_ids,
-            ) {
+            let method = match Method::from_source_map(selector, source_map, func_index, file_ids) {
                 Ok(m) => m,
                 Err(err) => {
                     tracing::warn!(func_sig, err = err.to_string(), "failed to parse method");
@@ -105,7 +158,20 @@ fn find_src_map_index(selector: &[u8; 4], opcodes: &[DisassembledOpcode]) -> Opt
     None
 }
 
-fn parse_selectors(abi: Abi) -> BTreeMap<String, [u8; 4]> {
+fn parse_selectors_from_method_ids(
+    methods: &BTreeMap<String, String>,
+) -> anyhow::Result<BTreeMap<String, [u8; 4]>> {
+    let methods: BTreeMap<String, [u8; 4]> = methods
+        .iter()
+        .map(|(name, selector)| {
+            let mut result = [0u8; 4];
+            hex::decode_to_slice(selector, &mut result).map(|_| (name.to_owned(), result))
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(methods)
+}
+
+fn parse_selectors_from_abi(abi: &Abi) -> BTreeMap<String, [u8; 4]> {
     abi.functions()
         .map(|f| (f.signature(), f.short_signature()))
         .collect()

--- a/smart-contract-verifier/smart-contract-verifier/src/lookup_methods/mod.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/lookup_methods/mod.rs
@@ -3,4 +3,6 @@ mod find_methods;
 mod method;
 mod opcodes;
 
-pub use find_methods::{find_methods, LookupMethodsRequest, LookupMethodsResponse};
+pub use find_methods::{
+    find_methods, find_methods_from_compiler_output, LookupMethodsRequest, LookupMethodsResponse,
+};


### PR DESCRIPTION
* Add `lookup-methods` post-action handler for solidity verifier service.
* Update tests