### PR TITLE
Extend logs for verifier and eth-bytecode-db services

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -1825,6 +1825,7 @@ dependencies = [
  "tokio-stream",
  "tonic",
  "tracing",
+ "uuid 1.6.1",
  "verifier-alliance-entity",
  "verifier-alliance-migration",
 ]
@@ -4855,7 +4856,7 @@ dependencies = [
  "time",
  "tracing",
  "url",
- "uuid 1.3.1",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -4921,7 +4922,7 @@ dependencies = [
  "sea-query-derive",
  "serde_json",
  "time",
- "uuid 1.3.1",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -4937,7 +4938,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "time",
- "uuid 1.3.1",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -5398,7 +5399,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.3.1",
+ "uuid 1.6.1",
  "webpki-roots 0.24.0",
 ]
 
@@ -5484,7 +5485,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "uuid 1.3.1",
+ "uuid 1.6.1",
  "whoami",
 ]
 
@@ -5529,7 +5530,7 @@ dependencies = [
  "thiserror",
  "time",
  "tracing",
- "uuid 1.3.1",
+ "uuid 1.6.1",
  "whoami",
 ]
 
@@ -5555,7 +5556,7 @@ dependencies = [
  "time",
  "tracing",
  "url",
- "uuid 1.3.1",
+ "uuid 1.6.1",
 ]
 
 [[package]]
@@ -6320,10 +6321,11 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.3.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b55a3fef2a1e3b3a00ce878640918820d3c51081576ac657d23af9fc7928fdb"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
+ "getrandom",
  "serde",
 ]
 

--- a/eth-bytecode-db/eth-bytecode-db-proto/swagger/v2/eth-bytecode-db.swagger.yaml
+++ b/eth-bytecode-db/eth-bytecode-db-proto/swagger/v2/eth-bytecode-db.swagger.yaml
@@ -252,6 +252,7 @@ definitions:
       - NOT_SERVING
       - SERVICE_UNKNOWN
     default: UNKNOWN
+    description: ' - SERVICE_UNKNOWN: Used only by the Watch method.'
   SourceMatchType:
     type: string
     enum:
@@ -275,12 +276,13 @@ definitions:
       code:
         type: integer
         format: int32
+      message:
+        type: string
       details:
         type: array
         items:
+          type: object
           $ref: '#/definitions/protobufAny'
-      message:
-        type: string
   protobufAny:
     type: object
     properties:
@@ -310,9 +312,6 @@ definitions:
   v2SearchAllSourcesRequest:
     type: object
     properties:
-      address:
-        type: string
-        title: / The address of the contract being verified
       bytecode:
         type: string
         title: / Bytecode to search the sources for
@@ -322,16 +321,21 @@ definitions:
       chain:
         type: string
         title: / Id of the chain the contract should be verified on
+      address:
+        type: string
+        title: / The address of the contract being verified
   v2SearchAllSourcesResponse:
     type: object
     properties:
       ethBytecodeDbSources:
         type: array
         items:
+          type: object
           $ref: '#/definitions/v2Source'
       sourcifySources:
         type: array
         items:
+          type: object
           $ref: '#/definitions/v2Source'
   v2SearchSourcesRequest:
     type: object
@@ -348,92 +352,93 @@ definitions:
       sources:
         type: array
         items:
+          type: object
           $ref: '#/definitions/v2Source'
   v2SearchSourcifySourcesRequest:
     type: object
     properties:
-      address:
-        type: string
-        title: / The address of the contract being verified
       chain:
         type: string
         title: / Id of the chain the contract should be verified on
+      address:
+        type: string
+        title: / The address of the contract being verified
   v2Source:
     type: object
     properties:
-      abi:
+      fileName:
         type: string
-        title: |-
-          / Contract abi (https://docs.soliditylang.org/en/latest/abi-spec.html?highlight=abi#json);
-          / (does not exist for Yul contracts)
-      compilationArtifacts:
+        title: / The name of the file verified contract was located at
+      contractName:
         type: string
-        description: |-
-          / General and compiler-specific artifacts (abi, userdoc, devdoc, licenses, ast, etc),
-          / encoded as a json.
+        title: / The name of the contract which was verified
+      compilerVersion:
+        type: string
+        title: Compiler version used to compile the contract
       compilerSettings:
         type: string
         title: |-
           / 'settings' key in Standard Input JSON
           / (https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description)
-      compilerVersion:
+      sourceType:
+        $ref: '#/definitions/SourceSourceType'
+      sourceFiles:
+        type: object
+        additionalProperties:
+          type: string
+      abi:
         type: string
-        title: Compiler version used to compile the contract
+        title: |-
+          / Contract abi (https://docs.soliditylang.org/en/latest/abi-spec.html?highlight=abi#json);
+          / (does not exist for Yul contracts)
       constructorArguments:
         type: string
         title: |-
           / Constructor arguments used for deploying verified contract
           / (exists only for creation inputs)
-      contractName:
+      matchType:
+        $ref: '#/definitions/SourceMatchType'
+        title: / Similar to Sourcify (see https://docs.sourcify.dev/docs/full-vs-partial-match/)
+      compilationArtifacts:
         type: string
-        title: / The name of the contract which was verified
+        description: |-
+          / General and compiler-specific artifacts (abi, userdoc, devdoc, licenses, ast, etc),
+          / encoded as a json.
       creationInputArtifacts:
         type: string
         description: / Info about the creation code (sourcemaps, linkreferences) encoded as a json.
       deployedBytecodeArtifacts:
         type: string
         description: / Info about the runtime code (sourcemaps, linkreferences, immutables) encoded as a json.
-      fileName:
-        type: string
-        title: / The name of the file verified contract was located at
-      matchType:
-        $ref: '#/definitions/SourceMatchType'
-        title: / Similar to Sourcify (see https://docs.sourcify.dev/docs/full-vs-partial-match/)
-      sourceFiles:
-        type: object
-        additionalProperties:
-          type: string
-      sourceType:
-        $ref: '#/definitions/SourceSourceType'
   v2VerificationMetadata:
     type: object
     properties:
-      blockNumber:
-        type: string
-        format: int64
-        title: / The number of the block containing the creation transaction
       chainId:
         type: string
         title: / Id of the chain the contract is verified on
       contractAddress:
         type: string
         title: / The address of the contract to be verified
-      creationCode:
-        type: string
-        title: / The bytecode from the calldata (for eoa deployments) or given to create/create2
-      deployer:
-        type: string
-        title: / The address which actually deployed the contract (i.e. called the create/create2 opcode)
-      runtimeCode:
-        type: string
-        title: The bytecode actually stored in the blockchain for the given contract
       transactionHash:
         type: string
         title: / The hash of the transaction the contract has been created at
+      blockNumber:
+        type: string
+        format: int64
+        title: / The number of the block containing the creation transaction
       transactionIndex:
         type: string
         format: int64
         title: / The position number transaction has been added into a block
+      deployer:
+        type: string
+        title: / The address which actually deployed the contract (i.e. called the create/create2 opcode)
+      creationCode:
+        type: string
+        title: / The bytecode from the calldata (for eoa deployments) or given to create/create2
+      runtimeCode:
+        type: string
+        title: The bytecode actually stored in the blockchain for the given contract
   v2VerifyFromEtherscanSourcifyRequest:
     type: object
     properties:
@@ -450,10 +455,10 @@ definitions:
     properties:
       message:
         type: string
-      source:
-        $ref: '#/definitions/v2Source'
       status:
         $ref: '#/definitions/v2VerifyResponseStatus'
+      source:
+        $ref: '#/definitions/v2Source'
   v2VerifyResponseStatus:
     type: string
     enum:
@@ -476,14 +481,6 @@ definitions:
       evmVersion:
         type: string
         title: / Version of the EVM to compile for. If absent results in default EVM version
-      libraries:
-        type: object
-        additionalProperties:
-          type: string
-        title: / Map from a library name to its address
-      metadata:
-        $ref: '#/definitions/v2VerificationMetadata'
-        title: / An optional field to be filled by explorers
       optimizationRuns:
         type: integer
         format: int32
@@ -495,6 +492,14 @@ definitions:
         additionalProperties:
           type: string
         title: / Map from a source file name to the actual source code
+      libraries:
+        type: object
+        additionalProperties:
+          type: string
+        title: / Map from a library name to its address
+      metadata:
+        $ref: '#/definitions/v2VerificationMetadata'
+        title: / An optional field to be filled by explorers
   v2VerifySolidityStandardJsonRequest:
     type: object
     properties:
@@ -524,10 +529,6 @@ definitions:
         title: |-
           / The chain (network) the contract was deployed to
           / (https://docs.sourcify.dev/docs/api/chains/)
-      chosenContract:
-        type: integer
-        format: int32
-        title: (optional) see Sourcify Api
       files:
         type: object
         additionalProperties:
@@ -536,6 +537,10 @@ definitions:
           / Files required for verification (see Sourcify Api)
           Named as `files` instead of `source_files`
           to correspond with Sourcify api
+      chosenContract:
+        type: integer
+        format: int32
+        title: (optional) see Sourcify Api
   v2VerifyVyperMultiPartRequest:
     type: object
     properties:
@@ -551,6 +556,11 @@ definitions:
       evmVersion:
         type: string
         title: / Version of the EVM to compile for. If absent results in default EVM version
+      sourceFiles:
+        type: object
+        additionalProperties:
+          type: string
+        title: / Map from a source file name to the actual source code
       interfaces:
         type: object
         additionalProperties:
@@ -561,11 +571,6 @@ definitions:
       metadata:
         $ref: '#/definitions/v2VerificationMetadata'
         title: / An optional field to be filled by explorers
-      sourceFiles:
-        type: object
-        additionalProperties:
-          type: string
-        title: / Map from a source file name to the actual source code
   v2VerifyVyperStandardJsonRequest:
     type: object
     properties:

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -26,6 +26,7 @@ sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "34827ae
 tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 tracing = "0.1"
+uuid = { version = "1.6.1", features = ["v4"] }
 
 [dev-dependencies]
 smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "2480b20" }

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/mod.rs
@@ -34,3 +34,39 @@ fn is_key_authorized(
         .unwrap_or_default();
     Ok(is_authorized)
 }
+
+macro_rules! trace_verification_request {
+    ($prefix:expr, $contract_address:expr, $chain_id:expr) => {{
+        let request_id = blockscout_display_bytes::Bytes::from(uuid::Uuid::new_v4().as_bytes());
+        tracing::info!(
+            request_id = request_id.to_string(),
+            chain_id = $chain_id,
+            contract_address = $contract_address,
+            "{} verification request received",
+            $prefix
+        );
+        request_id
+    }};
+    ($prefix:expr, $request:expr) => {{
+        let chain_id = $request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.chain_id.clone())
+            .unwrap_or_default();
+        let contract_address = $request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.contract_address.clone())
+            .unwrap_or_default();
+        let request_id = blockscout_display_bytes::Bytes::from(uuid::Uuid::new_v4().as_bytes());
+        tracing::info!(
+            request_id = request_id.to_string(),
+            chain_id = chain_id,
+            contract_address = contract_address,
+            "{} verification request received",
+            $prefix
+        );
+        request_id
+    }};
+}
+use trace_verification_request;

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/solidity_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/solidity_verifier.rs
@@ -39,6 +39,7 @@ impl solidity_verifier_server::SolidityVerifier for SolidityVerifierService {
         request: tonic::Request<VerifySolidityMultiPartRequest>,
     ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
         let (metadata, _, request) = request.into_parts();
+        let request_id = super::trace_verification_request!("Solidity multi-part", &request);
 
         let bytecode_type = request.bytecode_type();
         let verification_request = VerificationRequest {
@@ -57,9 +58,14 @@ impl solidity_verifier_server::SolidityVerifier for SolidityVerifierService {
                 .transpose()?,
             is_authorized: super::is_key_authorized(&self.authorized_keys, metadata)?,
         };
-        let result = solidity_multi_part::verify(self.client.clone(), verification_request).await;
+        let result = solidity_multi_part::verify(
+            self.client.clone(),
+            verification_request,
+            request_id.clone(),
+        )
+        .await;
 
-        verifier_base::process_verification_result(result)
+        verifier_base::process_verification_result(result, request_id)
     }
 
     async fn verify_standard_json(
@@ -67,6 +73,7 @@ impl solidity_verifier_server::SolidityVerifier for SolidityVerifierService {
         request: tonic::Request<VerifySolidityStandardJsonRequest>,
     ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
         let (metadata, _, request) = request.into_parts();
+        let request_id = super::trace_verification_request!("Solidity standard-json", &request);
 
         let bytecode_type = request.bytecode_type();
         let verification_request = VerificationRequest {
@@ -82,10 +89,14 @@ impl solidity_verifier_server::SolidityVerifier for SolidityVerifierService {
                 .transpose()?,
             is_authorized: super::is_key_authorized(&self.authorized_keys, metadata)?,
         };
-        let result =
-            solidity_standard_json::verify(self.client.clone(), verification_request).await;
+        let result = solidity_standard_json::verify(
+            self.client.clone(),
+            verification_request,
+            request_id.clone(),
+        )
+        .await;
 
-        verifier_base::process_verification_result(result)
+        verifier_base::process_verification_result(result, request_id)
     }
 
     async fn list_compiler_versions(

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/sourcify_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/sourcify_verifier.rs
@@ -23,6 +23,8 @@ impl sourcify_verifier_server::SourcifyVerifier for SourcifyVerifierService {
         request: tonic::Request<VerifySourcifyRequest>,
     ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
         let request = request.into_inner();
+        let request_id =
+            super::trace_verification_request!("Sourcify verify", &request.address, &request.chain);
 
         let verification_request = sourcify::VerificationRequest {
             address: request.address,
@@ -33,7 +35,7 @@ impl sourcify_verifier_server::SourcifyVerifier for SourcifyVerifierService {
 
         let result = sourcify::verify(self.client.clone(), verification_request).await;
 
-        verifier_base::process_verification_result(result)
+        verifier_base::process_verification_result(result, request_id)
     }
 
     async fn verify_from_etherscan(
@@ -41,6 +43,11 @@ impl sourcify_verifier_server::SourcifyVerifier for SourcifyVerifierService {
         request: tonic::Request<VerifyFromEtherscanSourcifyRequest>,
     ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
         let request = request.into_inner();
+        let request_id = super::trace_verification_request!(
+            "Sourcify verify-from-etherscan",
+            &request.address,
+            &request.chain
+        );
 
         let verification_request = sourcify_from_etherscan::VerificationRequest {
             address: request.address,
@@ -50,6 +57,6 @@ impl sourcify_verifier_server::SourcifyVerifier for SourcifyVerifierService {
         let result =
             sourcify_from_etherscan::verify(self.client.clone(), verification_request).await;
 
-        verifier_base::process_verification_result(result)
+        verifier_base::process_verification_result(result, request_id)
     }
 }

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/verifier_base.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/verifier_base.rs
@@ -6,18 +6,38 @@ use eth_bytecode_db::verification::{Error, Source};
 
 pub fn process_verification_result(
     result: Result<Source, Error>,
+    request_id: blockscout_display_bytes::Bytes,
 ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
     match result {
         Ok(source) => {
+            tracing::info!(
+                request_id = request_id.to_string(),
+                "Request processed successfully"
+            );
             let response = VerifyResponseWrapper::ok(source);
             Ok(tonic::Response::new(response.into()))
         }
         Err(Error::VerificationFailed { message }) => {
+            tracing::info!(
+                request_id = request_id.to_string(),
+                message = message,
+                "Verification failed"
+            );
             let response = VerifyResponseWrapper::err(message);
             Ok(tonic::Response::new(response.into()))
         }
-        Err(Error::InvalidArgument(message)) => Err(tonic::Status::invalid_argument(message)),
-        Err(Error::Internal(message)) => Err(tonic::Status::internal(message.to_string())),
+        Err(Error::InvalidArgument(message)) => {
+            tracing::info!(
+                request_id = request_id.to_string(),
+                message = message,
+                "Invalid argument"
+            );
+            Err(tonic::Status::invalid_argument(message))
+        }
+        Err(Error::Internal(message)) => {
+            tracing::info!(request_id=request_id.to_string(), message=%message, "Internal error");
+            Err(tonic::Status::internal(message.to_string()))
+        }
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/vyper_verifier.rs
@@ -39,6 +39,7 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
         request: tonic::Request<VerifyVyperMultiPartRequest>,
     ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
         let (metadata, _, request) = request.into_parts();
+        let request_id = super::trace_verification_request!("Vyper multi-part", &request);
 
         let bytecode_type = request.bytecode_type();
         let verification_request = VerificationRequest {
@@ -56,9 +57,14 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
                 .transpose()?,
             is_authorized: super::is_key_authorized(&self.authorized_keys, metadata)?,
         };
-        let result = vyper_multi_part::verify(self.client.clone(), verification_request).await;
+        let result = vyper_multi_part::verify(
+            self.client.clone(),
+            verification_request,
+            request_id.clone(),
+        )
+        .await;
 
-        verifier_base::process_verification_result(result)
+        verifier_base::process_verification_result(result, request_id)
     }
 
     async fn verify_standard_json(
@@ -66,6 +72,7 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
         request: tonic::Request<VerifyVyperStandardJsonRequest>,
     ) -> Result<tonic::Response<VerifyResponse>, tonic::Status> {
         let (metadata, _, request) = request.into_parts();
+        let request_id = super::trace_verification_request!("Vyper standard-json", &request);
 
         let bytecode_type = request.bytecode_type();
         let verification_request = VerificationRequest {
@@ -81,9 +88,14 @@ impl vyper_verifier_server::VyperVerifier for VyperVerifierService {
                 .transpose()?,
             is_authorized: super::is_key_authorized(&self.authorized_keys, metadata)?,
         };
-        let result = vyper_standard_json::verify(self.client.clone(), verification_request).await;
+        let result = vyper_standard_json::verify(
+            self.client.clone(),
+            verification_request,
+            request_id.clone(),
+        )
+        .await;
 
-        verifier_base::process_verification_result(result)
+        verifier_base::process_verification_result(result, request_id)
     }
 
     async fn list_compiler_versions(

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
@@ -36,6 +36,7 @@ impl From<VerificationRequest<MultiPartFiles>> for VerifySolidityMultiPartReques
 pub async fn verify(
     mut client: Client,
     request: VerificationRequest<MultiPartFiles>,
+    request_id: blockscout_display_bytes::Bytes,
 ) -> Result<Source, Error> {
     let is_authorized = request.is_authorized;
     let bytecode_type = request.bytecode_type;
@@ -45,12 +46,22 @@ pub async fn verify(
     let verification_metadata = request.metadata.clone();
 
     let request: VerifySolidityMultiPartRequest = request.into();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        "sending request to the verifier"
+    );
     let response = client
         .solidity_client
         .verify_multi_part(request)
         .await
         .map_err(Error::from)?
         .into_inner();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        status = response.status,
+        message = response.message,
+        "response from the verifier"
+    );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
         client.alliance_db_client.as_deref(),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
@@ -29,6 +29,7 @@ impl From<VerificationRequest<StandardJson>> for VerifySolidityStandardJsonReque
 pub async fn verify(
     mut client: Client,
     request: VerificationRequest<StandardJson>,
+    request_id: blockscout_display_bytes::Bytes,
 ) -> Result<Source, Error> {
     let is_authorized = request.is_authorized;
 
@@ -39,12 +40,22 @@ pub async fn verify(
     let verification_metadata = request.metadata.clone();
 
     let request: VerifySolidityStandardJsonRequest = request.into();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        "sending request to the verifier"
+    );
     let response = client
         .solidity_client
         .verify_standard_json(request)
         .await
         .map_err(Error::from)?
         .into_inner();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        status = response.status,
+        message = response.message,
+        "response from the verifier"
+    );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
         client.alliance_db_client.as_deref(),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -34,6 +34,7 @@ impl From<VerificationRequest<MultiPartFiles>> for VerifyVyperMultiPartRequest {
 pub async fn verify(
     mut client: Client,
     request: VerificationRequest<MultiPartFiles>,
+    request_id: blockscout_display_bytes::Bytes,
 ) -> Result<Source, Error> {
     let is_authorized = request.is_authorized;
     let bytecode_type = request.bytecode_type;
@@ -43,12 +44,22 @@ pub async fn verify(
     let verification_metadata = request.metadata.clone();
 
     let request: VerifyVyperMultiPartRequest = request.into();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        "sending request to the verifier"
+    );
     let response = client
         .vyper_client
         .verify_multi_part(request)
         .await
         .map_err(Error::from)?
         .into_inner();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        status = response.status,
+        message = response.message,
+        "response from the verifier"
+    );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
         client.alliance_db_client.as_deref(),

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
@@ -28,6 +28,7 @@ impl From<VerificationRequest<StandardJson>> for VerifyVyperStandardJsonRequest 
 pub async fn verify(
     mut client: Client,
     request: VerificationRequest<StandardJson>,
+    request_id: blockscout_display_bytes::Bytes,
 ) -> Result<Source, Error> {
     let is_authorized = request.is_authorized;
     let bytecode_type = request.bytecode_type;
@@ -37,12 +38,22 @@ pub async fn verify(
     let verification_metadata = request.metadata.clone();
 
     let request: VerifyVyperStandardJsonRequest = request.into();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        "sending request to the verifier"
+    );
     let response = client
         .vyper_client
         .verify_standard_json(request)
         .await
         .map_err(Error::from)?
         .into_inner();
+    tracing::info!(
+        request_id = request_id.to_string(),
+        status = response.status,
+        message = response.message,
+        "response from the verifier"
+    );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
         client.alliance_db_client.as_deref(),

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_multi_part.rs
@@ -62,7 +62,8 @@ impl VerifierService<VerificationRequest<MultiPartFiles>> for MockSolidityVerifi
         client: Client,
         request: VerificationRequest<MultiPartFiles>,
     ) -> Result<Source, Error> {
-        solidity_multi_part::verify(client, request).await
+        solidity_multi_part::verify(client, request, blockscout_display_bytes::Bytes::from([]))
+            .await
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/solidity_standard_json.rs
@@ -59,7 +59,8 @@ impl VerifierService<VerificationRequest<StandardJson>> for MockSolidityVerifier
         client: Client,
         request: VerificationRequest<StandardJson>,
     ) -> Result<Source, Error> {
-        solidity_standard_json::verify(client, request).await
+        solidity_standard_json::verify(client, request, blockscout_display_bytes::Bytes::from([]))
+            .await
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/verifier_alliance.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/verifier_alliance.rs
@@ -67,7 +67,8 @@ impl VerifierService<VerificationRequest<StandardJson>> for MockSolidityVerifier
         client: Client,
         request: VerificationRequest<StandardJson>,
     ) -> Result<Source, Error> {
-        solidity_standard_json::verify(client, request).await
+        solidity_standard_json::verify(client, request, blockscout_display_bytes::Bytes::from([]))
+            .await
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_multi_part.rs
@@ -57,7 +57,7 @@ impl VerifierService<VerificationRequest<MultiPartFiles>> for MockVyperVerifierS
         client: Client,
         request: VerificationRequest<MultiPartFiles>,
     ) -> Result<Source, Error> {
-        vyper_multi_part::verify(client, request).await
+        vyper_multi_part::verify(client, request, blockscout_display_bytes::Bytes::from([])).await
     }
 }
 

--- a/eth-bytecode-db/eth-bytecode-db/tests/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/tests/vyper_standard_json.rs
@@ -59,7 +59,8 @@ impl VerifierService<VerificationRequest<StandardJson>> for MockVyperVerifierSer
         client: Client,
         request: VerificationRequest<StandardJson>,
     ) -> Result<Source, Error> {
-        vyper_standard_json::verify(client, request).await
+        vyper_standard_json::verify(client, request, blockscout_display_bytes::Bytes::from([]))
+            .await
     }
 }
 

--- a/smart-contract-verifier/Cargo.lock
+++ b/smart-contract-verifier/Cargo.lock
@@ -4344,6 +4344,7 @@ dependencies = [
  "tracing-opentelemetry 0.18.0",
  "tracing-subscriber",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -5192,9 +5193,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "uuid"
-version = "1.3.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345444e32442451b267fc254ae85a209c64be56d2890e601a0c37ff0c3c5ecd2"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom 0.2.9",
 ]

--- a/smart-contract-verifier/smart-contract-verifier-server/Cargo.toml
+++ b/smart-contract-verifier/smart-contract-verifier-server/Cargo.toml
@@ -38,6 +38,7 @@ tracing = "0.1"
 tracing-opentelemetry = "0.18"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.3"
+uuid = { version = "1.6.1", features = ["v4"] }
 
 [dev-dependencies]
 ethers-solc = { version = "2.0.10", features = ["svm-solc"] }

--- a/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
@@ -17,6 +17,7 @@ use smart_contract_verifier::{
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 use tonic::{Request, Response, Status};
+use uuid::Uuid;
 
 pub struct VyperVerifierService {
     client: Arc<VyperClient>,
@@ -77,22 +78,39 @@ impl VyperVerifier for VyperVerifierService {
             .as_ref()
             .and_then(|metadata| metadata.chain_id.clone())
             .unwrap_or_default();
+        let contract_address = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.contract_address.clone())
+            .unwrap_or_default();
+        let request_id = blockscout_display_bytes::Bytes::from(Uuid::new_v4().as_bytes());
+        tracing::info!(
+            request_id = request_id.to_string(),
+            chain_id = chain_id,
+            contract_address = contract_address,
+            "Vyper multi-part verification request received"
+        );
+
         let result = vyper::multi_part::verify(self.client.clone(), request.try_into()?).await;
 
         let response = if let Ok(verification_success) = result {
+            tracing::info!(request_id=request_id.to_string(), match_type=?verification_success.match_type, "Request processed successfully");
             VerifyResponseWrapper::ok(verification_success)
         } else {
             let err = result.unwrap_err();
+            tracing::info!(request_id=request_id.to_string(), err=%err, "Request processing failed");
             match err {
                 VerificationError::Compilation(_)
                 | VerificationError::NoMatchingContracts
                 | VerificationError::CompilerVersionMismatch(_) => VerifyResponseWrapper::err(err),
                 VerificationError::Initialization(_) | VerificationError::VersionNotFound(_) => {
-                    tracing::debug!("invalid argument: {err:#?}");
                     return Err(Status::invalid_argument(err.to_string()));
                 }
                 VerificationError::Internal(err) => {
-                    tracing::error!("internal error: {err:#?}");
+                    tracing::error!(
+                        request_id = request_id.to_string(),
+                        "internal error: {err:#?}"
+                    );
                     return Err(Status::internal(err.to_string()));
                 }
             }
@@ -117,15 +135,31 @@ impl VyperVerifier for VyperVerifierService {
             .as_ref()
             .and_then(|metadata| metadata.chain_id.clone())
             .unwrap_or_default();
+        let contract_address = request
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.contract_address.clone())
+            .unwrap_or_default();
+        let request_id = blockscout_display_bytes::Bytes::from(Uuid::new_v4().as_bytes());
+        tracing::info!(
+            request_id = request_id.to_string(),
+            chain_id = chain_id,
+            contract_address = contract_address,
+            "Vyper standard-json verification request received"
+        );
+
         let verification_request = {
             let request: Result<_, StandardJsonParseError> = request.try_into();
             if let Err(err) = request {
                 match err {
                     StandardJsonParseError::InvalidContent(_) => {
-                        return Ok(Response::new(VerifyResponseWrapper::err(err).into_inner()))
+                        let response = VerifyResponseWrapper::err(err).into_inner();
+                        tracing::info!(request_id=request_id.to_string(), response=?response, "Request processed");
+                        return Ok(Response::new(response));
                     }
                     StandardJsonParseError::BadRequest(_) => {
-                        return Err(Status::invalid_argument(err.to_string()))
+                        tracing::info!(request_id=request_id.to_string(), err=%err, "Bad request");
+                        return Err(Status::invalid_argument(err.to_string()));
                     }
                 }
             }
@@ -134,19 +168,23 @@ impl VyperVerifier for VyperVerifierService {
         let result = vyper::standard_json::verify(self.client.clone(), verification_request).await;
 
         let response = if let Ok(verification_success) = result {
+            tracing::info!(request_id=request_id.to_string(), match_type=?verification_success.match_type, "Request processed successfully");
             VerifyResponseWrapper::ok(verification_success)
         } else {
             let err = result.unwrap_err();
+            tracing::info!(request_id=request_id.to_string(), err=%err, "Request processing failed");
             match err {
                 VerificationError::Compilation(_)
                 | VerificationError::NoMatchingContracts
                 | VerificationError::CompilerVersionMismatch(_) => VerifyResponseWrapper::err(err),
                 VerificationError::Initialization(_) | VerificationError::VersionNotFound(_) => {
-                    tracing::debug!("invalid argument: {err:#?}");
                     return Err(Status::invalid_argument(err.to_string()));
                 }
                 VerificationError::Internal(err) => {
-                    tracing::error!("internal error: {err:#?}");
+                    tracing::error!(
+                        request_id = request_id.to_string(),
+                        "internal error: {err:#?}"
+                    );
                     return Err(Status::internal(err.to_string()));
                 }
             }


### PR DESCRIPTION
Adds new logs for the incoming requests. That is a temporary solution to improve observability of those services until built-in http tracing would not be added 