### PR TITLE
[ETH_BYTECODE_DB] Bump sourcify library version

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -5648,7 +5648,7 @@ dependencies = [
 [[package]]
 name = "sourcify"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=34827ae#34827ae1c21407e8712a788bf1c7ccef5fca3920"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=6a12a22#6a12a229d22ae36e3c727cebc16890b91589e629"
 dependencies = [
  "anyhow",
  "blockscout-display-bytes",

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -22,7 +22,7 @@ sea-orm = "0.12.2"
 serde = "1.0"
 serde_json = "1.0.96"
 serde_with = "2.1"
-sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "34827ae" }
+sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "6a12a22" }
 tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 tracing = "0.1"


### PR DESCRIPTION
Should fix the sourcify search failures which started after the repo paths have been changed by Sourcify