### PR TITLE
[SIG_PROVIDER], [STATS], [VISUALIZER] Bump blockscout-service-launcher to v0.10.0 

### DIFF
--- a/blockscout-ens/Cargo.lock
+++ b/blockscout-ens/Cargo.lock
@@ -30,6 +30,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,16 +757,17 @@ dependencies = [
 
 [[package]]
 name = "blockscout-service-launcher"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662512331ca49faf635aab7d25d29b2e66c020a807354d8cbd3d8a921600aa24"
+version = "0.10.0"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=22ba428#22ba428341212b9169e20a434702e38c229b2731"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "actix-web-prom",
  "anyhow",
  "cfg-if",
  "config",
  "futures",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
  "prometheus",
@@ -759,12 +775,15 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
+ "serde_json",
  "tokio",
  "tonic",
  "tracing",
+ "tracing-actix-web",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
+ "uuid 1.5.0",
 ]
 
 [[package]]
@@ -3119,6 +3138,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "mutually_exclusive_features"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d02c0b00610773bb7fc61d85e13d86c7858cbdf00e1a120bfc41bc055dbaa0e"
 
 [[package]]
 name = "native-tls"
@@ -5897,6 +5922,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-actix-web"
+version = "0.7.9"
+source = "git+https://github.com/blockscout/tracing-actix-web?branch=rimrakhimov/update-traces-for-services#66479b061021745b523eb48d0f5ae377233606e9"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid 1.5.0",
 ]
 
 [[package]]

--- a/blockscout-ens/bens-server/Cargo.toml
+++ b/blockscout-ens/bens-server/Cargo.toml
@@ -12,7 +12,7 @@ bens-logic = { path = "../bens-logic" }
 actix-web = "4.2"
 anyhow = "1.0"
 blockscout-display-bytes = "1.0"
-blockscout-service-launcher = { version = "0.9.0", features = [ "database-0_12" ] }
+blockscout-service-launcher = { git = "https://github.com/blockscout/blockscout-rs", rev = "22ba428", features = ["database-0_12"] }
 config = "0.13"
 ethers = "2.0.0"
 serde = "1.0"
@@ -38,6 +38,6 @@ features = [
 
 [dev-dependencies]
 bens-logic = { path = "../bens-logic", features = ["test-utils"] }
-blockscout-service-launcher = { version = "0.9.0", features = [ "database-0_12", "test-server" ] }
+blockscout-service-launcher = { git = "https://github.com/blockscout/blockscout-rs", rev = "22ba428", features = [ "database-0_12", "test-server" ] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 pretty_assertions = "1.4.0"

--- a/sig-provider/Cargo.lock
+++ b/sig-provider/Cargo.lock
@@ -20,6 +20,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +894,46 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry 0.19.0",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "blockscout-service-launcher"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545355abddfc1617d40529141b7e849feed732328ccf54850f691dc31cf24856"
+dependencies = [
+ "actix-cors",
+ "actix-web",
+ "actix-web-prom",
+ "anyhow",
+ "blockscout-tracing-actix-web",
+ "config",
+ "futures",
+ "once_cell",
+ "opentelemetry 0.19.0",
+ "opentelemetry-jaeger 0.18.0",
+ "prometheus",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tonic",
+ "tracing",
+ "tracing-opentelemetry 0.19.0",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "blockscout-tracing-actix-web"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9c18637c495cd78f0ba302727ca0be4f068a3a03633371c5bd1d8c0e9f1e6c"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2269,6 +2324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "mutually_exclusive_features"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d02c0b00610773bb7fc61d85e13d86c7858cbdf00e1a120bfc41bc055dbaa0e"
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,7 +3705,8 @@ dependencies = [
  "actix-web-prom",
  "anyhow",
  "async-trait",
- "blockscout-service-launcher",
+ "blockscout-service-launcher 0.10.0",
+ "blockscout-service-launcher 0.9.0",
  "bytes",
  "config",
  "ethabi",
@@ -4358,6 +4420,15 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "uuid"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/sig-provider/sig-provider-server/Cargo.toml
+++ b/sig-provider/sig-provider-server/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = "1.0"
 url = { version = "2", features = ["serde"] }
 hex = "0.4"
 ethabi = "18.0.0"
-blockscout-service-launcher = "0.9.0"
+blockscout-service-launcher = "0.10.0"
 
 [dev-dependencies]
 blockscout-service-launcher = { version = "*", features = ["test-server"] }

--- a/visualizer/Cargo.lock
+++ b/visualizer/Cargo.lock
@@ -20,6 +20,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-cors"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0346d8c1f762b41b458ed3145eea914966bb9ad20b9be0d6d463b20d45586370"
+dependencies = [
+ "actix-utils",
+ "actix-web",
+ "derive_more",
+ "futures-util",
+ "log",
+ "once_cell",
+ "smallvec",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,23 +455,42 @@ dependencies = [
 
 [[package]]
 name = "blockscout-service-launcher"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fc9022734a46409fd0e33659b7e48eff5bc1235a087f6d1f6fb7a4fbcb02d8"
+checksum = "545355abddfc1617d40529141b7e849feed732328ccf54850f691dc31cf24856"
 dependencies = [
+ "actix-cors",
  "actix-web",
  "actix-web-prom",
  "anyhow",
+ "blockscout-tracing-actix-web",
+ "config",
  "futures",
+ "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
  "prometheus",
  "serde",
+ "serde_json",
  "tokio",
  "tonic",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
+name = "blockscout-tracing-actix-web"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9c18637c495cd78f0ba302727ca0be4f068a3a03633371c5bd1d8c0e9f1e6c"
+dependencies = [
+ "actix-web",
+ "mutually_exclusive_features",
+ "pin-project",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1300,6 +1334,12 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "mutually_exclusive_features"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d02c0b00610773bb7fc61d85e13d86c7858cbdf00e1a120bfc41bc055dbaa0e"
 
 [[package]]
 name = "nom"
@@ -2494,6 +2534,15 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "uuid"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/visualizer/visualizer-server/Cargo.toml
+++ b/visualizer/visualizer-server/Cargo.toml
@@ -16,7 +16,7 @@ actix-web = "4"
 amplify = { version = "3.13.0", features = ["derive"] }
 anyhow = "1.0"
 async-trait = "0.1"
-blockscout-service-launcher = { version = "0.8.0" }
+blockscout-service-launcher = { version = "0.10.0" }
 bytes = "1.2"
 config = "0.13"
 lazy_static = "1.3"


### PR DESCRIPTION
Append request_id field into logs