### PR TITLE
[ETH_BYTECODE_DB] Support for genesis contracts in verifier alliance db

### DIFF
--- a/.github/volumes/docker-entrypoint-initdb.d/max_connections.sql
+++ b/.github/volumes/docker-entrypoint-initdb.d/max_connections.sql
@@ -1,0 +1,1 @@
+ALTER SYSTEM SET max_connections = 500;

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -37,9 +37,15 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+        volumes:
+          - /tmp/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
+      - name: Copy entrypoint scripts to the volume
+        run: sudo cp -r ../.github/volumes/docker-entrypoint-initdb.d/* /tmp/docker-entrypoint-initdb.d/
+        continue-on-error: false
 
       - name: Install deps
         uses: ./.github/actions/deps

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/alliance_test_cases/genesis.json
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/alliance_test_cases/genesis.json
@@ -1,0 +1,72 @@
+{
+    "deployed_creation_code": null,
+    "deployed_runtime_code": "0x6080604052348015600f57600080fd5b506004361060325760003560e01c80636057361d1460375780638381f58a14604f575b600080fd5b604d60048036038101906049919060af565b6069565b005b60556073565b6040516060919060e4565b60405180910390f35b8060008190555050565b60005481565b600080fd5b6000819050919050565b608f81607e565b8114609957600080fd5b50565b60008135905060a9816088565b92915050565b60006020828403121560c25760c16079565b5b600060ce84828501609c565b91505092915050565b60de81607e565b82525050565b600060208201905060f7600083018460d7565b9291505056fea26469706673582212204ac0ce5f82b26331fa3e9ae959291a55624ffaf90fcd509deafcc21a5f1da21e64736f6c63430008120033",
+
+    "compiled_creation_code": "0x608060405234801561001057600080fd5b50610133806100206000396000f3fe6080604052348015600f57600080fd5b506004361060325760003560e01c80636057361d1460375780638381f58a14604f575b600080fd5b604d60048036038101906049919060af565b6069565b005b60556073565b6040516060919060e4565b60405180910390f35b8060008190555050565b60005481565b600080fd5b6000819050919050565b608f81607e565b8114609957600080fd5b50565b60008135905060a9816088565b92915050565b60006020828403121560c25760c16079565b5b600060ce84828501609c565b91505092915050565b60de81607e565b82525050565b600060208201905060f7600083018460d7565b9291505056fea26469706673582212204ac0ce5f82b26331fa3e9ae959291a55624ffaf90fcd509deafcc21a5f1da21e64736f6c63430008120033",
+    "compiled_runtime_code": "0x6080604052348015600f57600080fd5b506004361060325760003560e01c80636057361d1460375780638381f58a14604f575b600080fd5b604d60048036038101906049919060af565b6069565b005b60556073565b6040516060919060e4565b60405180910390f35b8060008190555050565b60005481565b600080fd5b6000819050919050565b608f81607e565b8114609957600080fd5b50565b60008135905060a9816088565b92915050565b60006020828403121560c25760c16079565b5b600060ce84828501609c565b91505092915050565b60de81607e565b82525050565b600060208201905060f7600083018460d7565b9291505056fea26469706673582212204ac0ce5f82b26331fa3e9ae959291a55624ffaf90fcd509deafcc21a5f1da21e64736f6c63430008120033",
+    "compiler": "solc",
+    "version": "v0.8.18+commit.87f61d96",
+    "language": "solidity",
+    "name": "Storage",
+    "fully_qualified_name": "contracts/1_Storage.sol:Storage",
+    "sources": {
+        "contracts/1_Storage.sol": "// SPDX-License-Identifier: GPL-3.0\n\npragma solidity >=0.7.0 <0.9.0;\n\n/**\n * @title Storage\n * @dev Store & retrieve value in a variable\n */\ncontract Storage {\n    uint256 public number;\n\n    /**\n     * @dev Store value in variable\n     * @param num value to store\n     */\n    function store(uint256 num) public {\n        number = num;\n    }\n}"
+    },
+    "compiler_settings": {
+        "optimizer": {
+            "enabled": false,
+            "runs": 200
+        },
+        "libraries": {},
+        "outputSelection": {
+            "*": {
+                "*": [
+                    "*"
+                ]
+            }
+        }
+    },
+    "compilation_artifacts": {
+        "abi": [{"inputs":[],"name":"number","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"num","type":"uint256"}],"name":"store","outputs":[],"stateMutability":"nonpayable","type":"function"}],
+        "devdoc": {"details":"Store & retrieve value in a variable","kind":"dev","methods":{"store(uint256)":{"details":"Store value in variable","params":{"num":"value to store"}}},"title":"Storage","version":1},
+        "userdoc": {"kind":"user","methods":{},"version":1},
+        "storageLayout": {"storage":[{"astId":4,"contract":"contracts/1_Storage.sol:Storage","label":"number","offset":0,"slot":"0","type":"t_uint256"}],"types":{"t_uint256":{"encoding":"inplace","label":"uint256","numberOfBytes":"32"}}},
+        "sources": {"contracts/1_Storage.sol": {"id":  0} }
+    },
+    "creation_code_artifacts": {
+        "linkReferences": {},
+        "sourceMap": "141:202:0:-:0;;;;;;;;;;;;;;;;;;;",
+        "cborAuxdata": {
+            "1": {
+                "offset": 286,
+                "value": "0xa26469706673582212204ac0ce5f82b26331fa3e9ae959291a55624ffaf90fcd509deafcc21a5f1da21e64736f6c63430008120033"
+            }
+        }
+    },
+    "runtime_code_artifacts": {
+        "immutableReferences": {},
+        "linkReferences": {},
+        "sourceMap": "141:202:0:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;277:64;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;164:21;;;:::i;:::-;;;;;;;:::i;:::-;;;;;;;;277:64;331:3;322:6;:12;;;;277:64;:::o;164:21::-;;;;:::o;88:117:1:-;197:1;194;187:12;334:77;371:7;400:5;389:16;;334:77;;;:::o;417:122::-;490:24;508:5;490:24;:::i;:::-;483:5;480:35;470:63;;529:1;526;519:12;470:63;417:122;:::o;545:139::-;591:5;629:6;616:20;607:29;;645:33;672:5;645:33;:::i;:::-;545:139;;;;:::o;690:329::-;749:6;798:2;786:9;777:7;773:23;769:32;766:119;;;804:79;;:::i;:::-;766:119;924:1;949:53;994:7;985:6;974:9;970:22;949:53;:::i;:::-;939:63;;895:117;690:329;;;;:::o;1025:118::-;1112:24;1130:5;1112:24;:::i;:::-;1107:3;1100:37;1025:118;;:::o;1149:222::-;1242:4;1280:2;1269:9;1265:18;1257:26;;1293:71;1361:1;1350:9;1346:17;1337:6;1293:71;:::i;:::-;1149:222;;;;:::o",
+        "cborAuxdata": {
+            "1": {
+                "offset": 254,
+                "value": "0xa26469706673582212204ac0ce5f82b26331fa3e9ae959291a55624ffaf90fcd509deafcc21a5f1da21e64736f6c63430008120033"
+            }
+        }
+    },
+
+    "creation_match": false,
+    "creation_values": null,
+    "creation_transformations": null,
+
+    "runtime_match": true,
+    "runtime_values": {},
+    "runtime_transformations": [],
+
+    "transaction_hash": "0xefff8175f1b41ec5d77d449eefcc7c74d131db8c78b269b46d1e6e7b53060645",
+    "block_number": -1,
+    "transaction_index": -1,
+    "deployer": "0x0000000000000000000000000000000000000000",
+
+    "is_genesis": true
+}

--- a/eth-bytecode-db/eth-bytecode-db/justfile
+++ b/eth-bytecode-db/eth-bytecode-db/justfile
@@ -17,7 +17,7 @@ test-db-port := "9433"
 
 start-postgres:
     # we run it in --rm mode, so all data will be deleted after stopping
-    docker run -p {{db-port}}:5432 --name {{docker-name}} -e POSTGRES_PASSWORD={{db-password}} -e POSTGRES_USER={{db-user}} --rm -d postgres
+    docker run -p {{db-port}}:5432 --name {{docker-name}} -e POSTGRES_PASSWORD={{db-password}} -e POSTGRES_USER={{db-user}} -c max_connections=500 --rm -d postgres
     sleep 3
     # wait for postgres to start, but only if db_name is not empty
     $SHELL -c '[[ -z "{{db-name}}" ]] || docker exec -it {{docker-name}} psql -U postgres -c "create database {{db-name}};"'

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
@@ -375,16 +375,12 @@ async fn process_verifier_alliance_db_action(
                 .context("Converting source into database ready version")?;
 
             // At least one of creation and runtime code should exist to add the contract into the database.
-            if creation_code.is_none() && runtime_code.is_none() {
-                anyhow::bail!("Both creation and runtime codes are nulls")
-            }
-
             let transaction_hash = derive_transaction_hash(
                 transaction_hash.clone(),
                 creation_code.clone(),
                 runtime_code.clone(),
             )
-            .expect("At least one of creation or runtime codes must exist");
+            .ok_or_else(|| anyhow::anyhow!("Both creation and runtime codes are nulls"))?;
 
             let deployment_data = db::verifier_alliance_db::ContractDeploymentData {
                 chain_id,

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/mod.rs
@@ -94,13 +94,15 @@ enum VerifierAllianceDbAction<'a> {
         db_client: &'a DatabaseConnection,
         chain_id: i64,
         contract_address: bytes::Bytes,
-        transaction_hash: bytes::Bytes,
+        transaction_hash: Option<bytes::Bytes>,
+        creation_code: Option<bytes::Bytes>,
+        runtime_code: Option<bytes::Bytes>,
     },
     SaveWithDeploymentData {
         db_client: &'a DatabaseConnection,
         chain_id: i64,
         contract_address: bytes::Bytes,
-        transaction_hash: bytes::Bytes,
+        transaction_hash: Option<bytes::Bytes>,
         block_number: Option<i64>,
         transaction_index: Option<i64>,
         deployer: Option<bytes::Bytes>,
@@ -121,7 +123,7 @@ impl<'a> VerifierAllianceDbAction<'a> {
                 Some(VerificationMetadata {
                     chain_id: Some(chain_id),
                     contract_address: Some(contract_address),
-                    transaction_hash: Some(transaction_hash),
+                    transaction_hash,
                     block_number,
                     transaction_index,
                     deployer,
@@ -147,6 +149,8 @@ impl<'a> VerifierAllianceDbAction<'a> {
                         chain_id,
                         contract_address,
                         transaction_hash,
+                        creation_code,
+                        runtime_code,
                     }
                 }
             }
@@ -298,6 +302,24 @@ async fn process_verifier_alliance_db_action(
     source: Source,
     action: VerifierAllianceDbAction<'_>,
 ) -> Result<(), anyhow::Error> {
+    let derive_transaction_hash =
+        |transaction_hash: Option<bytes::Bytes>,
+         creation_code: Option<bytes::Bytes>,
+         runtime_code: Option<bytes::Bytes>| {
+            match transaction_hash {
+                Some(hash) => Some(hash.to_vec()),
+                None if creation_code.is_some() || runtime_code.is_some() => {
+                    let combined_hash: Vec<_> = creation_code
+                        .unwrap_or_default()
+                        .into_iter()
+                        .chain(runtime_code.unwrap_or_default())
+                        .collect();
+                    Some(keccak_hash::keccak(combined_hash).0.to_vec())
+                }
+                None => None,
+            }
+        };
+
     match action {
         VerifierAllianceDbAction::IgnoreDb => {}
         VerifierAllianceDbAction::SaveIfDeploymentExists {
@@ -305,14 +327,33 @@ async fn process_verifier_alliance_db_action(
             chain_id,
             contract_address,
             transaction_hash,
+            creation_code,
+            runtime_code,
         } => {
             let database_source = DatabaseReadySource::try_from(source)
                 .context("Converting source into database ready version")?;
 
+            let transaction_hash = match derive_transaction_hash(
+                transaction_hash,
+                creation_code,
+                runtime_code,
+            ) {
+                Some(hash) => hash,
+                // If no transaction hash can be derived,
+                // consider it like no active deployment exists.
+                None => {
+                    tracing::warn!(
+                        chain_id=chain_id,
+                        contract_address=blockscout_display_bytes::Bytes::from(contract_address.to_vec()).to_string(),
+                        "Trying to save contract without transaction hash and creation and runtime codes"
+                    );
+                    return Ok(());
+                }
+            };
             let deployment_data = db::verifier_alliance_db::ContractDeploymentData {
                 chain_id,
                 contract_address: contract_address.to_vec(),
-                transaction_hash: transaction_hash.to_vec(),
+                transaction_hash,
                 ..Default::default()
             };
             db::verifier_alliance_db::insert_data(db_client, database_source, deployment_data)
@@ -338,9 +379,13 @@ async fn process_verifier_alliance_db_action(
                 anyhow::bail!("Both creation and runtime codes are nulls")
             }
 
-            // TODO: make transaction_hash input argument optional, and calculate it
-            //       as `keccak256(creation_code || runtime_code)` in that case
-            let transaction_hash = transaction_hash.to_vec();
+            let transaction_hash = derive_transaction_hash(
+                transaction_hash.clone(),
+                creation_code.clone(),
+                runtime_code.clone(),
+            )
+            .expect("At least one of creation or runtime codes must exist");
+
             let deployment_data = db::verifier_alliance_db::ContractDeploymentData {
                 chain_id,
                 contract_address: contract_address.to_vec(),
@@ -348,23 +393,13 @@ async fn process_verifier_alliance_db_action(
                 block_number,
                 transaction_index,
                 deployer: deployer.map(|deployer| deployer.to_vec()),
-                creation_code: creation_code
-                    .as_ref()
-                    .map(|creation_code| creation_code.to_vec()),
-                runtime_code: runtime_code
-                    .as_ref()
-                    .map(|runtime_code| runtime_code.to_vec()),
+                creation_code: creation_code.map(|code| code.to_vec()),
+                runtime_code: runtime_code.map(|code| code.to_vec()),
             };
 
-            // At least one of creation and runtime code should exist to add the contract into the database.
-            if creation_code.is_some() || runtime_code.is_some() {
-                db::verifier_alliance_db::insert_deployment_data(
-                    db_client,
-                    deployment_data.clone(),
-                )
+            db::verifier_alliance_db::insert_deployment_data(db_client, deployment_data.clone())
                 .await
                 .context("Insert deployment data into verifier alliance database")?;
-            }
 
             db::verifier_alliance_db::insert_data(db_client, database_source, deployment_data)
                 .await


### PR DESCRIPTION
Apply the following rule for the contracts added in genesis or hardcoded during fork, as those do not have valid transaction hash

> in the case of a "genesis" contract, the transaction_hash should be set
        to keccak256(creation_code_hash || runtime_code_hash). this is because the transaction_hash
        needs to differ to distinguish between two versions of the same genesis contract, and so
        it needs to embed inside it the only feature that changes.