### PR TITLE
Make use of services-base image

### DIFF
--- a/blockscout-ens/Dockerfile
+++ b/blockscout-ens/Dockerfile
@@ -1,22 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.74-buster as chef
-
-WORKDIR /app
-ARG TARGETARCH
-RUN case ${TARGETARCH} in \
-        "arm64") TARGETARCH=aarch_64 ;; \
-        "amd64") TARGETARCH=x86_64 ;; \
-    esac \
-    && wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-$TARGETARCH.zip -O ./protoc.zip \
-    && unzip protoc.zip \
-    && mv ./include/* /usr/include/ \
-    && mv ./bin/protoc /usr/bin/protoc
-
-RUN case ${TARGETARCH} in \
-        "amd64") TARGETARCH=x86_64 ;; \
-    esac \
-    && wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-$TARGETARCH -O ./protoc-gen-openapiv2 \
-    && chmod +x protoc-gen-openapiv2 \
-    && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .

--- a/eth-bytecode-db/eth-bytecode-db-server/Dockerfile
+++ b/eth-bytecode-db/eth-bytecode-db-server/Dockerfile
@@ -1,15 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y curl wget unzip
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -O ./protoc.zip \
-          && unzip protoc.zip \
-          && mv ./include/* /usr/include/ \
-          && mv ./bin/protoc /usr/bin/protoc
-
-RUN wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-x86_64 -O ./protoc-gen-openapiv2 \
-          && chmod +x protoc-gen-openapiv2 \
-          && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .

--- a/sig-provider/Dockerfile
+++ b/sig-provider/Dockerfile
@@ -1,15 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y curl wget unzip
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -O ./protoc.zip \
-          && unzip protoc.zip \
-          && mv ./include/* /usr/include/ \
-          && mv ./bin/protoc /usr/bin/protoc
-
-RUN wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-x86_64 -O ./protoc-gen-openapiv2 \
-          && chmod +x protoc-gen-openapiv2 \
-          && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .

--- a/smart-contract-verifier/smart-contract-verifier-http/Dockerfile
+++ b/smart-contract-verifier/smart-contract-verifier-http/Dockerfile
@@ -1,15 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y curl wget unzip
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -O ./protoc.zip \
-          && unzip protoc.zip \
-          && mv ./include/* /usr/include/ \
-          && mv ./bin/protoc /usr/bin/protoc
-
-RUN wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-x86_64 -O ./protoc-gen-openapiv2 \
-          && chmod +x protoc-gen-openapiv2 \
-          && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .

--- a/smart-contract-verifier/smart-contract-verifier-server/Dockerfile
+++ b/smart-contract-verifier/smart-contract-verifier-server/Dockerfile
@@ -1,15 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y curl wget unzip
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -O ./protoc.zip \
-          && unzip protoc.zip \
-          && mv ./include/* /usr/include/ \
-          && mv ./bin/protoc /usr/bin/protoc
-
-RUN wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-x86_64 -O ./protoc-gen-openapiv2 \
-          && chmod +x protoc-gen-openapiv2 \
-          && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .

--- a/stats/Dockerfile
+++ b/stats/Dockerfile
@@ -1,15 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y curl wget unzip
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -O ./protoc.zip \
-          && unzip protoc.zip \
-          && mv ./include/* /usr/include/ \
-          && mv ./bin/protoc /usr/bin/protoc
-
-RUN wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-x86_64 -O ./protoc-gen-openapiv2 \
-          && chmod +x protoc-gen-openapiv2 \
-          && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .

--- a/user-ops-indexer/Dockerfile
+++ b/user-ops-indexer/Dockerfile
@@ -1,15 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.72-buster as chef
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y curl wget unzip
-RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-x86_64.zip -O ./protoc.zip \
-          && unzip protoc.zip \
-          && mv ./include/* /usr/include/ \
-          && mv ./bin/protoc /usr/bin/protoc
-
-RUN wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-x86_64 -O ./protoc-gen-openapiv2 \
-          && chmod +x protoc-gen-openapiv2 \
-          && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .

--- a/visualizer/Dockerfile
+++ b/visualizer/Dockerfile
@@ -1,23 +1,4 @@
-FROM lukemathwalker/cargo-chef:0.1.62-rust-1.74-buster as chef
-
-WORKDIR /app
-ARG TARGETARCH
-RUN case ${TARGETARCH} in \
-        "arm64") TARGETARCH=aarch_64 ;; \
-        "amd64") TARGETARCH=x86_64 ;; \
-    esac \
-    && wget https://github.com/protocolbuffers/protobuf/releases/download/v21.12/protoc-21.12-linux-$TARGETARCH.zip -O ./protoc.zip \
-    && unzip protoc.zip \
-    && mv ./include/* /usr/include/ \
-    && mv ./bin/protoc /usr/bin/protoc
-
-RUN case ${TARGETARCH} in \
-        "amd64") TARGETARCH=x86_64 ;; \
-    esac \
-    && wget https://github.com/grpc-ecosystem/grpc-gateway/releases/download/v2.15.0/protoc-gen-openapiv2-v2.15.0-linux-$TARGETARCH -O ./protoc-gen-openapiv2 \
-    && chmod +x protoc-gen-openapiv2 \
-    && mv ./protoc-gen-openapiv2 /usr/bin/protoc-gen-openapiv2
-
+FROM ghcr.io/blockscout/services-base:latest as chef
 
 FROM chef AS plan
 COPY . .


### PR DESCRIPTION
Start using services-base image for the initial build setup. The services-base is a cargo-chef image with installed `protoc` and `protoc-gen-openapiv2` binaries. Using a pre-built image would allow us to update those binary versions in one place only and propagate those changes to all service images