### PR TITLE
Make use of foundry-compilers instead of ethers-solc

### DIFF
--- a/smart-contract-verifier/Cargo.lock
+++ b/smart-contract-verifier/Cargo.lock
@@ -323,23 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-dyn-abi"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b1a44ed6b4126e4818d20c9e48176ae9d6d4fcbe6c909f8cd0bf050eb56fd8"
-dependencies = [
- "alloy-json-abi",
- "alloy-primitives",
- "alloy-sol-type-parser",
- "alloy-sol-types",
- "const-hex",
- "itoa",
- "serde",
- "serde_json",
- "winnow 0.5.40",
-]
-
-[[package]]
 name = "alloy-json-abi"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,42 +367,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-sol-macro"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e92100dee7fd1e44abbe0ef6607f18758cf0ad4e483f4c65ff5c8d85428a6d"
-dependencies = [
- "const-hex",
- "dunce",
- "heck",
- "indexmap 2.2.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.42",
- "syn-solidity",
- "tiny-keccak",
-]
-
-[[package]]
 name = "alloy-sol-type-parser"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d146adca22a853b5aaaa98a6c78bd9d8f1d627ca7b01d170edccf45430e9b2cb"
 dependencies = [
  "winnow 0.5.40",
-]
-
-[[package]]
-name = "alloy-sol-types"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7c6a8c492b1d6a4f92a8fc6a13cf39473978dd7d459d7221969ce5a73d97cd"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-macro",
- "const-hex",
- "serde",
 ]
 
 [[package]]
@@ -1309,7 +1262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown 0.12.3",
+ "hashbrown",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.7",
@@ -1537,12 +1490,6 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "equivalent"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -2016,7 +1963,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -2031,12 +1978,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -2284,18 +2225,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.3",
+ "hashbrown",
  "serde",
-]
-
-[[package]]
-name = "indexmap"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
-dependencies = [
- "equivalent",
- "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -3038,7 +2969,7 @@ dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
- "indexmap 1.9.3",
+ "indexmap",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -3054,7 +2985,7 @@ dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
- "indexmap 1.9.3",
+ "indexmap",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -3136,7 +3067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.3",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3332,7 +3263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap 1.9.3",
+ "indexmap",
 ]
 
 [[package]]
@@ -4548,7 +4479,7 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "hex",
- "indexmap 1.9.3",
+ "indexmap",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -4573,7 +4504,7 @@ version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -4708,8 +4639,6 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 name = "smart-contract-verifier"
 version = "0.6.0"
 dependencies = [
- "alloy-dyn-abi",
- "alloy-json-abi",
  "anyhow",
  "async-trait",
  "blockscout-display-bytes",
@@ -4786,8 +4715,6 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "actix-web-prom",
- "alloy-dyn-abi",
- "alloy-json-abi",
  "amplify",
  "anyhow",
  "async-trait",
@@ -5052,18 +4979,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn-solidity"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e656cbcef8a77543b5accbd76f60f9e0bc4be364b0aba4263a6f313f8a355511"
-dependencies = [
- "paste",
- "proc-macro2",
- "quote",
- "syn 2.0.42",
 ]
 
 [[package]]
@@ -5371,7 +5286,7 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap",
  "toml_datetime",
  "winnow 0.4.6",
 ]
@@ -5429,7 +5344,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
+ "indexmap",
  "pin-project",
  "pin-project-lite",
  "rand 0.8.5",

--- a/smart-contract-verifier/Cargo.lock
+++ b/smart-contract-verifier/Cargo.lock
@@ -323,6 +323,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-dyn-abi"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b1a44ed6b4126e4818d20c9e48176ae9d6d4fcbe6c909f8cd0bf050eb56fd8"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "serde",
+ "serde_json",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30c6a6c5140fc762edfe55349f9ddefa821f4b7f2339cef582de911a3f1fb6d3"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef197eb250c64962003cb08b90b17f0882c192f4a6f2f544809d424fd7cb0e7d"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "hex-literal",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "proptest",
+ "rand 0.8.5",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-rlp"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
+dependencies = [
+ "arrayvec",
+ "bytes",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e92100dee7fd1e44abbe0ef6607f18758cf0ad4e483f4c65ff5c8d85428a6d"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck",
+ "indexmap 2.2.3",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d146adca22a853b5aaaa98a6c78bd9d8f1d627ca7b01d170edccf45430e9b2cb"
+dependencies = [
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e7c6a8c492b1d6a4f92a8fc6a13cf39473978dd7d459d7221969ce5a73d97cd"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
 name = "amplify"
 version = "3.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +488,130 @@ name = "anyhow"
 version = "1.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
+
+[[package]]
+name = "ark-ff"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b3235cc41ee7a12aaaf2c575a2ad7b46713a8a50bda2fc3b003a04845c05dd6"
+dependencies = [
+ "ark-ff-asm 0.3.0",
+ "ark-ff-macros 0.3.0",
+ "ark-serialize 0.3.0",
+ "ark-std 0.3.0",
+ "derivative",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.3.3",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec847af850f44ad29048935519032c33da8aa03340876d351dfab5660d2966ba"
+dependencies = [
+ "ark-ff-asm 0.4.2",
+ "ark-ff-macros 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "digest 0.10.7",
+ "itertools 0.10.5",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "rustc_version 0.4.0",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db02d390bf6643fb404d3d22d31aee1c4bc4459600aef9113833d17e786c6e44"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c2b318ee6e10f8c2853e73a83adc0ccb88995aa978d8a3408d492ab2ee671"
+dependencies = [
+ "ark-std 0.3.0",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
+dependencies = [
+ "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
 
 [[package]]
 name = "arrayvec"
@@ -788,11 +1012,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
 dependencies = [
- "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -1085,7 +1309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.7",
@@ -1121,6 +1345,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1129,7 +1364,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -1144,6 +1379,15 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "digest"
@@ -1244,7 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1265,7 +1509,7 @@ checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1293,6 +1537,12 @@ checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1365,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.10"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a17f0708692024db9956b31d7a20163607d2745953f5ae8125ab368ba280ad"
+checksum = "aab3cef6cc1c9fd7f787043c81ad3052eff2b96a3878ef1526aa446311bdbfc9"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1392,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.10"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de34e484e7ae3cab99fbfd013d6c5dc7f9013676a4e0e414d8b12e1213e8b3ba"
+checksum = "d21df08582e0a43005018a858cc9b465c5fff9cf4056651be64f844e57d1f55f"
 dependencies = [
  "cfg-if",
  "const-hex",
@@ -1410,7 +1660,7 @@ dependencies = [
  "path-slash",
  "rayon",
  "regex",
- "semver",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "sha2",
@@ -1445,6 +1695,17 @@ name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
+name = "fastrlp"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139834ddba373bbdd213dffe02c8d110508dcf1726c2be27e8d1f7d7e1856418"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+]
 
 [[package]]
 name = "ff"
@@ -1521,6 +1782,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foundry-compilers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1b77c95e79bff02ddaa38426fc6809a3a438dce0e6a2eb212dac97da7c157b4"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "cfg-if",
+ "dirs 5.0.1",
+ "dunce",
+ "home",
+ "itertools 0.12.1",
+ "md-5",
+ "memmap2",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.17",
+ "serde",
+ "serde_json",
+ "solang-parser",
+ "svm-rs",
+ "thiserror",
+ "tracing",
+ "walkdir",
+ "yansi",
 ]
 
 [[package]]
@@ -1725,7 +2016,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.3",
  "slab",
  "tokio",
  "tokio-util",
@@ -1740,6 +2031,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash 0.7.6",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heck"
@@ -1758,6 +2055,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -1765,7 +2071,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1978,8 +2284,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -2063,19 +2379,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "js-sys"
@@ -2108,6 +2424,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "sha2",
+ "signature",
 ]
 
 [[package]]
@@ -2117,6 +2434,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -2161,9 +2488,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -2255,7 +2582,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2266,9 +2593,18 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+
+[[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -2477,10 +2813,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.15"
+name = "num-bigint"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
  "libm",
@@ -2528,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "open-fastrlp"
@@ -2682,7 +3038,7 @@ dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "js-sys",
  "once_cell",
  "pin-project-lite",
@@ -2698,7 +3054,7 @@ dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -2780,7 +3136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
  "dlv-list",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2913,7 +3269,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "hmac",
  "password-hash",
  "sha2",
@@ -2976,7 +3332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.3",
 ]
 
 [[package]]
@@ -3231,6 +3587,8 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
 dependencies = [
+ "bit-set",
+ "bit-vec",
  "bitflags 2.4.1",
  "lazy_static",
  "num-traits",
@@ -3238,6 +3596,8 @@ dependencies = [
  "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.7.5",
+ "rusty-fork",
+ "tempfile",
  "unarray",
 ]
 
@@ -3300,6 +3660,12 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -3408,9 +3774,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+checksum = "fa7237101a77a10773db45d62004a272517633fbcc3df19d96455ede1122e051"
 dependencies = [
  "either",
  "rayon-core",
@@ -3418,14 +3784,12 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
- "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "num_cpus",
 ]
 
 [[package]]
@@ -3459,14 +3823,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.4"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.7",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3480,13 +3844,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.7"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -3500,6 +3864,12 @@ name = "regex-syntax"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "relative-path"
@@ -3736,7 +4106,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros 0.14.0",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -3748,7 +4118,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "rstest_macros 0.18.2",
- "rustc_version",
+ "rustc_version 0.4.0",
 ]
 
 [[package]]
@@ -3760,7 +4130,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 1.0.109",
 ]
 
@@ -3776,10 +4146,40 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "rustc_version",
+ "rustc_version 0.4.0",
  "syn 2.0.42",
  "unicode-ident",
 ]
+
+[[package]]
+name = "ruint"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608a5726529f2f0ef81b8fde9873c4bb829d6b5b5ca6be4d97345ddf0749c825"
+dependencies = [
+ "alloy-rlp",
+ "ark-ff 0.3.0",
+ "ark-ff 0.4.2",
+ "bytes",
+ "fastrlp",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "proptest",
+ "rand 0.8.5",
+ "rlp",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
 
 [[package]]
 name = "rust-ini"
@@ -3836,11 +4236,20 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
+dependencies = [
+ "semver 0.11.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver",
+ "semver 1.0.17",
 ]
 
 [[package]]
@@ -3906,6 +4315,18 @@ name = "rustversion"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
 
 [[package]]
 name = "rxml"
@@ -4027,11 +4448,29 @@ dependencies = [
 
 [[package]]
 name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
 ]
 
 [[package]]
@@ -4109,7 +4548,7 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.3",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -4134,7 +4573,7 @@ version = "0.9.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d684e3ec7de3bf5466b32bd75303ac16f0736426e5a4e0d6e489559ce1249c"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "itoa",
  "ryu",
  "serde",
@@ -4149,7 +4588,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4160,7 +4599,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4169,8 +4608,18 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sha3-asm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac61da6b35ad76b195eb4771210f947734321a8d81d7738e1580d953bc7a15e"
+dependencies = [
+ "cc",
+ "cfg-if",
 ]
 
 [[package]]
@@ -4230,7 +4679,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -4259,6 +4708,8 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 name = "smart-contract-verifier"
 version = "0.6.0"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "anyhow",
  "async-trait",
  "blockscout-display-bytes",
@@ -4269,6 +4720,7 @@ dependencies = [
  "ethabi",
  "ethers-core",
  "ethers-solc",
+ "foundry-compilers",
  "futures",
  "hex",
  "lazy_static",
@@ -4286,7 +4738,7 @@ dependencies = [
  "reqwest-retry 0.1.5",
  "rstest 0.15.0",
  "rust-s3",
- "semver",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "serde_with",
@@ -4334,6 +4786,8 @@ version = "0.1.0"
 dependencies = [
  "actix-web",
  "actix-web-prom",
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "amplify",
  "anyhow",
  "async-trait",
@@ -4345,6 +4799,7 @@ dependencies = [
  "ethabi",
  "ethers-core",
  "ethers-solc",
+ "foundry-compilers",
  "futures",
  "lazy_static",
  "opentelemetry 0.18.0",
@@ -4403,9 +4858,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb9fa2fa2fa6837be8a2495486ff92e3ffe68a99b6eeba288e139efdd842457"
+checksum = "c425ce1c59f4b154717592f0bdf4715c3a1d55058883622d3157e1f0908a5b26"
 dependencies = [
  "itertools 0.11.0",
  "lalrpop",
@@ -4423,7 +4878,7 @@ checksum = "18f0ee752c2f80c87498dba10c2120492c42073f73b37ffb49e79fcd1e91bff3"
 dependencies = [
  "blockscout-display-bytes",
  "minicbor",
- "semver",
+ "semver 1.0.17",
  "thiserror",
 ]
 
@@ -4555,7 +5010,7 @@ dependencies = [
  "hex",
  "once_cell",
  "reqwest",
- "semver",
+ "semver 1.0.17",
  "serde",
  "serde_json",
  "sha2",
@@ -4572,7 +5027,7 @@ checksum = "aa64b5e8eecd3a8af7cfc311e29db31a268a62d5953233d3e8243ec77a71c4e3"
 dependencies = [
  "build_const",
  "hex",
- "semver",
+ "semver 1.0.17",
  "serde_json",
  "svm-rs",
 ]
@@ -4597,6 +5052,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e656cbcef8a77543b5accbd76f60f9e0bc4be364b0aba4263a6f313f8a355511"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
 ]
 
 [[package]]
@@ -4904,9 +5371,9 @@ version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "toml_datetime",
- "winnow",
+ "winnow 0.4.6",
 ]
 
 [[package]]
@@ -4962,7 +5429,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
  "rand 0.8.5",
@@ -5236,6 +5703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5243,9 +5719,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -5603,6 +6079,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5669,6 +6154,20 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.42",
+]
 
 [[package]]
 name = "zip"

--- a/smart-contract-verifier/smart-contract-verifier-server/Cargo.toml
+++ b/smart-contract-verifier/smart-contract-verifier-server/Cargo.toml
@@ -10,10 +10,6 @@ smart-contract-verifier = { path = "../smart-contract-verifier" }
 smart-contract-verifier-proto = { path = "../smart-contract-verifier-proto" }
 sig-provider-extension = { path = "../sig-provider-extension", optional = true }
 
-alloy-dyn-abi = "0.6.3"
-alloy-json-abi = "0.6.3"
-foundry-compilers = "0.3.9"
-
 actix-web = "4"
 actix-web-prom = "0.6"
 amplify = { version = "3.13.0", features = ["derive"] }
@@ -26,6 +22,7 @@ config = "0.13"
 cron = "0.11"
 ethers-solc = "2.0.10"
 ethers-core = "2.0.10"
+foundry-compilers = "0.3.9"
 futures = "0.3"
 lazy_static = "1"
 opentelemetry = { version = "0.18", features = ["rt-tokio"] }

--- a/smart-contract-verifier/smart-contract-verifier-server/Cargo.toml
+++ b/smart-contract-verifier/smart-contract-verifier-server/Cargo.toml
@@ -10,6 +10,10 @@ smart-contract-verifier = { path = "../smart-contract-verifier" }
 smart-contract-verifier-proto = { path = "../smart-contract-verifier-proto" }
 sig-provider-extension = { path = "../sig-provider-extension", optional = true }
 
+alloy-dyn-abi = "0.6.3"
+alloy-json-abi = "0.6.3"
+foundry-compilers = "0.3.9"
+
 actix-web = "4"
 actix-web-prom = "0.6"
 amplify = { version = "3.13.0", features = ["derive"] }

--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/solidity_multi_part.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/solidity_multi_part.rs
@@ -1,6 +1,6 @@
 use crate::proto::{BytecodeType, VerifySolidityMultiPartRequest};
 use blockscout_display_bytes::Bytes as DisplayBytes;
-use ethers_solc::EvmVersion;
+use foundry_compilers::EvmVersion;
 use serde::{Deserialize, Serialize};
 use smart_contract_verifier::{
     solidity::multi_part::{MultiFileContent, VerificationRequest},

--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/solidity_standard_json.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/solidity_standard_json.rs
@@ -2,7 +2,7 @@ use super::StandardJsonParseError;
 use crate::proto::{BytecodeType, VerifySolidityStandardJsonRequest};
 use anyhow::anyhow;
 use blockscout_display_bytes::Bytes as DisplayBytes;
-use ethers_solc::CompilerInput;
+use foundry_compilers::CompilerInput;
 use serde::{Deserialize, Serialize};
 use smart_contract_verifier::{
     solidity::standard_json::{StandardJsonContent, VerificationRequest},

--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/source.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/source.rs
@@ -46,7 +46,7 @@ pub fn from_solidity_success(value: SoliditySuccess) -> Source {
         "Yul" => source::SourceType::Yul,
         _ => source::SourceType::Unspecified,
     };
-    let extract_source_files = |compiler_input: ethers_solc::CompilerInput| {
+    let extract_source_files = |compiler_input: foundry_compilers::CompilerInput| {
         compiler_input
             .sources
             .into_iter()
@@ -108,9 +108,9 @@ pub fn from_sourcify_success(value: SourcifySuccess) -> Source {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ethers_solc::{
-        artifacts::{self, Libraries, Optimizer},
-        EvmVersion,
+    use foundry_compilers::{
+        artifacts::{self, Libraries, Optimizer, Settings},
+        CompilerInput, EvmVersion,
     };
     use pretty_assertions::assert_eq;
     use smart_contract_verifier::{vyper, Version};
@@ -118,7 +118,7 @@ mod tests {
 
     #[test]
     fn test_from_solidity_success() {
-        let compiler_settings = ethers_solc::artifacts::Settings {
+        let compiler_settings = Settings {
             optimizer: Optimizer {
                 enabled: Some(true),
                 runs: Some(200),
@@ -134,7 +134,7 @@ mod tests {
             ..Default::default()
         };
         let verification_success = SoliditySuccess {
-            compiler_input: ethers_solc::CompilerInput {
+            compiler_input: CompilerInput {
                 language: "Solidity".to_string(),
                 sources: BTreeMap::from([("file_name".into(), artifacts::Source::new("content"))]),
                 settings: compiler_settings.clone(),

--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/verify_response.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/verify_response.rs
@@ -164,7 +164,7 @@ mod tests {
     use super::{extra_data::bytecode_part::BytecodePartWrapper, *};
     use crate::proto::verify_response::extra_data::BytecodePart;
     use blockscout_display_bytes::Bytes as DisplayBytes;
-    use ethers_solc::CompilerInput;
+    use foundry_compilers::CompilerInput;
     use pretty_assertions::assert_eq;
     use smart_contract_verifier::{MatchType, SoliditySuccess, Version};
     use std::str::FromStr;

--- a/smart-contract-verifier/smart-contract-verifier-server/src/types/vyper_multi_part.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/types/vyper_multi_part.rs
@@ -1,6 +1,6 @@
 use crate::proto::{BytecodeType, VerifyVyperMultiPartRequest};
 use blockscout_display_bytes::Bytes as DisplayBytes;
-use ethers_solc::EvmVersion;
+use foundry_compilers::EvmVersion;
 use serde::{Deserialize, Serialize};
 use smart_contract_verifier::{
     vyper::multi_part::{MultiFileContent, VerificationRequest},

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/solidity.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/solidity.rs
@@ -318,7 +318,7 @@ async fn _test_error<T: TestCase>(
 
 mod success_tests {
     use super::*;
-    use solidity_types::Flattened;
+    use solidity_types::{Flattened, StandardJson};
 
     #[tokio::test]
     async fn returns_compilation_related_artifacts() {
@@ -344,6 +344,13 @@ mod success_tests {
     #[tokio::test]
     async fn verifies_runtime_code_with_immutables() {
         let test_case = solidity_types::from_file::<Flattened>("immutables");
+        test_success(&test_case, BytecodeType::CreationInput).await;
+        test_success(&test_case, BytecodeType::DeployedBytecode).await;
+    }
+
+    #[tokio::test]
+    async fn supports_cancun_evm_version() {
+        let test_case = solidity_types::from_file::<StandardJson>("cancun");
         test_success(&test_case, BytecodeType::CreationInput).await;
         test_success(&test_case, BytecodeType::DeployedBytecode).await;
     }

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_solidity/cancun.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_solidity/cancun.json
@@ -1,0 +1,54 @@
+{
+    "_comment": "A simple contract with cancun evm version",
+    "is_full_match": true,
+    "creation_bytecode": "0x608060405234801561000f575f80fd5b5060d98061001c5f395ff3fe6080604052348015600e575f80fd5b50600436106026575f3560e01c806345ac732814602a575b5f80fd5b60406004803603810190603c9190607d565b6042565b005b805f5d50565b5f80fd5b5f60ff82169050919050565b605f81604c565b81146068575f80fd5b50565b5f813590506077816058565b92915050565b5f60208284031215608f57608e6048565b5b5f609a84828501606b565b9150509291505056fea2646970667358221220a89d800667cbcdfd6ba7e7385c15bb850fe961dd398cfdfa50bb60245cc2d46964736f6c63430008180033",
+    "deployed_bytecode": "0x6080604052348015600e575f80fd5b50600436106026575f3560e01c806345ac732814602a575b5f80fd5b60406004803603810190603c9190607d565b6042565b005b805f5d50565b5f80fd5b5f60ff82169050919050565b605f81604c565b81146068575f80fd5b50565b5f813590506077816058565b92915050565b5f60208284031215608f57608e6048565b5b5f609a84828501606b565b9150509291505056fea2646970667358221220a89d800667cbcdfd6ba7e7385c15bb850fe961dd398cfdfa50bb60245cc2d46964736f6c63430008180033",
+    "compiler_version": "v0.8.24+commit.e11b9ed9",
+    "file_name": "contracts/Cancun.sol",
+    "contract_name": "Cancun",
+    "input": {
+        "language": "Solidity",
+        "sources": {
+            "contracts/Cancun.sol": {
+                "content": "// SPDX-License-Identifier: MIT\npragma solidity ^0.8.24;\n\ncontract Cancun {\n    // uint8 _reentry\n\n    function storeReentryLock(uint8 reentry) external {\n        assembly { \n            tstore(0x00, reentry)\n        }\n    }\n}"
+            }
+        },
+        "settings": {
+            "optimizer": {
+                "enabled": false,
+                "runs": 200
+            },
+            "evmVersion": "cancun",
+            "libraries": {},
+            "outputSelection": { "*": { "*": [ "*" ], "": [ "*" ] } }
+        }
+    },
+    "expected_compiler_artifacts": {
+        "abi": [{"inputs":[{"internalType":"uint8","name":"reentry","type":"uint8"}],"name":"storeReentryLock","outputs":[],"stateMutability":"nonpayable","type":"function"}],
+        "userdoc": {"kind":"user","methods":{},"version":1},
+        "devdoc": {"kind":"dev","methods":{},"version":1},
+        "storageLayout": {"storage":[],"types":null},
+        "sources": {"contracts/Cancun.sol": {"id":  0} }
+    },
+    "expected_creation_input_artifacts": {
+        "sourceMap": "58:168:0:-:0;;;;;;;;;;;;;;;;;;;",
+        "linkReferences": {},
+        "cborAuxdata": {
+            "0": {
+                "offset": 192,
+                "value": "0xa2646970667358221220a89d800667cbcdfd6ba7e7385c15bb850fe961dd398cfdfa50bb60245cc2d46964736f6c63430008180033"
+            }
+        }
+    },
+    "expected_deployed_bytecode_artifacts": {
+        "sourceMap": "58:168:0:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;103:121;;;;;;;;;;;;;:::i;:::-;;:::i;:::-;;;200:7;194:4;187:21;103:121;:::o;88:117:1:-;197:1;194;187:12;334:86;369:7;409:4;402:5;398:16;387:27;;334:86;;;:::o;426:118::-;497:22;513:5;497:22;:::i;:::-;490:5;487:33;477:61;;534:1;531;524:12;477:61;426:118;:::o;550:135::-;594:5;632:6;619:20;610:29;;648:31;673:5;648:31;:::i;:::-;550:135;;;;:::o;691:325::-;748:6;797:2;785:9;776:7;772:23;768:32;765:119;;;803:79;;:::i;:::-;765:119;923:1;948:51;991:7;982:6;971:9;967:22;948:51;:::i;:::-;938:61;;894:115;691:325;;;;:::o",
+        "linkReferences": {},
+        "immutableReferences": {},
+        "cborAuxdata": {
+            "0": {
+                "offset": 164,
+                "value": "0xa2646970667358221220a89d800667cbcdfd6ba7e7385c15bb850fe961dd398cfdfa50bb60245cc2d46964736f6c63430008180033"
+            }
+        }
+    }
+}

--- a/smart-contract-verifier/smart-contract-verifier/Cargo.toml
+++ b/smart-contract-verifier/smart-contract-verifier/Cargo.toml
@@ -7,10 +7,6 @@ repository = "https://github.com/blockscout/blockscout-rs"
 keywords = ["ethereum", "web3", "solidity"]
 
 [dependencies]
-alloy-dyn-abi = "0.6.3"
-alloy-json-abi = "0.6.3"
-foundry-compilers = "0.3.9"
-
 anyhow = "1.0"
 async-trait = "0.1"
 blockscout-display-bytes = { version = "1.0" }
@@ -20,6 +16,7 @@ cron = "0.11"
 ethabi = "18.0"
 ethers-core = "2.0.10"
 ethers-solc = { version = "2.0.6", features = ["async"] }
+foundry-compilers = "0.3.9"
 futures = "0.3"
 hex = "0.4"
 lazy_static = "1"

--- a/smart-contract-verifier/smart-contract-verifier/Cargo.toml
+++ b/smart-contract-verifier/smart-contract-verifier/Cargo.toml
@@ -7,6 +7,10 @@ repository = "https://github.com/blockscout/blockscout-rs"
 keywords = ["ethereum", "web3", "solidity"]
 
 [dependencies]
+alloy-dyn-abi = "0.6.3"
+alloy-json-abi = "0.6.3"
+foundry-compilers = "0.3.9"
+
 anyhow = "1.0"
 async-trait = "0.1"
 blockscout-display-bytes = { version = "1.0" }

--- a/smart-contract-verifier/smart-contract-verifier/src/compiler/compilers.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/compiler/compilers.rs
@@ -148,7 +148,7 @@ where
 mod tests {
     use super::{super::list_fetcher::ListFetcher, *};
     use crate::{consts::DEFAULT_SOLIDITY_COMPILER_LIST, solidity::SolidityCompiler};
-    use ethers_solc::{
+    use foundry_compilers::{
         artifacts::{Source, Sources},
         CompilerInput,
     };

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/compiler.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/compiler.rs
@@ -14,7 +14,7 @@ impl SolidityCompiler {
 
 #[async_trait::async_trait]
 impl EvmCompiler for SolidityCompiler {
-    type CompilerInput = ethers_solc::CompilerInput;
+    type CompilerInput = foundry_compilers::CompilerInput;
 
     async fn compile(
         &self,

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/multi_part.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/multi_part.rs
@@ -4,7 +4,7 @@ use crate::{
     verifier::{ContractVerifier, Error},
 };
 use bytes::Bytes;
-use ethers_solc::{
+use foundry_compilers::{
     artifacts::{
         output_selection::OutputSelection, BytecodeHash, Libraries, Settings, SettingsMetadata,
         Source, Sources,

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/solc_cli.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/solc_cli.rs
@@ -7,8 +7,9 @@
 use ethers_solc::{
     artifacts::Severity,
     error::{SolcError, SolcIoError},
-    CompilerInput, CompilerOutput,
+    CompilerOutput,
 };
+use foundry_compilers::CompilerInput;
 use std::{collections::BTreeMap, path::Path, process::Stdio};
 use tokio::process::Command;
 
@@ -28,11 +29,8 @@ mod serde_helpers {
 
 mod types {
     use super::serde_helpers;
-    use ethers_solc::{
-        artifacts::{Contract, Libraries},
-        error::SolcError,
-        CompilerInput, CompilerOutput,
-    };
+    use ethers_solc::{artifacts::Contract, error::SolcError, CompilerOutput};
+    use foundry_compilers::{artifacts::Libraries, CompilerInput};
     use serde::{Deserialize, Serialize};
     use std::{
         collections::{BTreeMap, HashMap},
@@ -271,10 +269,8 @@ pub async fn compile_using_cli(
 mod tests {
     use super::*;
     use crate::compiler::{Fetcher, ListFetcher, Version};
-    use ethers_solc::{
-        artifacts::{Settings, Source},
-        Artifact,
-    };
+    use ethers_solc::Artifact;
+    use foundry_compilers::artifacts::{Settings, Source};
     use hex::ToHex;
     use pretty_assertions::assert_eq;
     use std::{collections::HashSet, env::temp_dir, path::PathBuf, str::FromStr};

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/standard_json.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/standard_json.rs
@@ -4,7 +4,7 @@ use crate::{
     verifier::{ContractVerifier, Error},
 };
 use bytes::Bytes;
-use ethers_solc::{artifacts::output_selection::OutputSelection, CompilerInput};
+use foundry_compilers::{artifacts::output_selection::OutputSelection, CompilerInput};
 use std::sync::Arc;
 
 pub struct VerificationRequest {

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/types.rs
@@ -5,10 +5,11 @@ use crate::{
 };
 use blockscout_display_bytes::Bytes as DisplayBytes;
 use ethers_solc::CompilerOutput;
+use foundry_compilers::CompilerInput;
 
 #[derive(Clone, Debug)]
 pub struct Success {
-    pub compiler_input: foundry_compilers::CompilerInput,
+    pub compiler_input: CompilerInput,
     pub compiler_output: CompilerOutput,
     pub compiler_version: compiler::Version,
     pub file_path: String,
@@ -22,10 +23,8 @@ pub struct Success {
     pub deployed_bytecode_artifacts: serde_json::Value,
 }
 
-impl From<(foundry_compilers::CompilerInput, verifier::Success)> for Success {
-    fn from(
-        (compiler_input, success): (foundry_compilers::CompilerInput, verifier::Success),
-    ) -> Self {
+impl From<(CompilerInput, verifier::Success)> for Success {
+    fn from((compiler_input, success): (CompilerInput, verifier::Success)) -> Self {
         Self {
             compiler_input,
             compiler_output: success.compiler_output,

--- a/smart-contract-verifier/smart-contract-verifier/src/solidity/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/solidity/types.rs
@@ -8,7 +8,7 @@ use ethers_solc::CompilerOutput;
 
 #[derive(Clone, Debug)]
 pub struct Success {
-    pub compiler_input: ethers_solc::CompilerInput,
+    pub compiler_input: foundry_compilers::CompilerInput,
     pub compiler_output: CompilerOutput,
     pub compiler_version: compiler::Version,
     pub file_path: String,
@@ -22,8 +22,10 @@ pub struct Success {
     pub deployed_bytecode_artifacts: serde_json::Value,
 }
 
-impl From<(ethers_solc::CompilerInput, verifier::Success)> for Success {
-    fn from((compiler_input, success): (ethers_solc::CompilerInput, verifier::Success)) -> Self {
+impl From<(foundry_compilers::CompilerInput, verifier::Success)> for Success {
+    fn from(
+        (compiler_input, success): (foundry_compilers::CompilerInput, verifier::Success),
+    ) -> Self {
         Self {
             compiler_input,
             compiler_output: success.compiler_output,

--- a/smart-contract-verifier/smart-contract-verifier/src/verifier/compiler_input.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/verifier/compiler_input.rs
@@ -4,7 +4,7 @@ pub trait CompilerInput {
     fn modify(self) -> Self;
 }
 
-impl CompilerInput for ethers_solc::CompilerInput {
+impl CompilerInput for foundry_compilers::CompilerInput {
     fn modify(mut self) -> Self {
         // TODO: could we update some other field to avoid copying strings?
         self.sources.iter_mut().for_each(|(_file, source)| {

--- a/smart-contract-verifier/smart-contract-verifier/src/vyper/artifacts.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/vyper/artifacts.rs
@@ -1,7 +1,7 @@
 use crate::verifier;
-use ethers_solc::artifacts::{
+use foundry_compilers::artifacts::{
     output_selection::{FileOutputSelection, OutputSelection},
-    serde_helpers,
+    serde_helpers, Source, Sources,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -16,7 +16,7 @@ pub type Interfaces = BTreeMap<PathBuf, Interface>;
 #[serde(rename_all = "camelCase")]
 pub struct CompilerInput {
     pub language: String,
-    pub sources: ethers_solc::artifacts::Sources,
+    pub sources: Sources,
     #[serde(default)]
     pub interfaces: Interfaces,
     #[serde(default)]
@@ -42,7 +42,7 @@ pub struct Settings {
         with = "serde_helpers::display_from_str_opt",
         skip_serializing_if = "Option::is_none"
     )]
-    pub evm_version: Option<ethers_solc::EvmVersion>,
+    pub evm_version: Option<foundry_compilers::EvmVersion>,
     /// Indicates whether or not optimizations are turned on.
     /// This is true by default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -89,7 +89,7 @@ mod interfaces {
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
 pub enum Interface {
-    Vyper(ethers_solc::artifacts::Source),
+    Vyper(Source),
     Abi(interfaces::AbiSource),
     ContractTypes(interfaces::ContractTypesSource),
 }
@@ -120,9 +120,7 @@ impl Interface {
                 _ => Err(anyhow::anyhow!("\"{path:?}\" is an invalid interface")),
             }
         } else {
-            Ok(Interface::Vyper(ethers_solc::artifacts::Source::new(
-                content,
-            )))
+            Ok(Interface::Vyper(Source::new(content)))
         }
     }
 
@@ -229,7 +227,7 @@ mod tests {
             (
                 vyper_data.0,
                 vyper_data.1.to_string(),
-                Interface::Vyper(ethers_solc::artifacts::Source::new(vyper_data.1)),
+                Interface::Vyper(Source::new(vyper_data.1)),
             ),
             (
                 contract_types_data.0,
@@ -274,7 +272,7 @@ mod tests {
 
         let test_data = [
             (
-                Interface::Vyper(ethers_solc::artifacts::Source::new(vyper_content)),
+                Interface::Vyper(Source::new(vyper_content)),
                 "@external\r\n@payable\r\ndef exchange_multiple(_route: address[9], _swap_params: uint256[3][4], _amount: uint256, _expected: uint256, _pools: address[4]) -> uint256: \r\n    pass\r\n\r\n@external\r\n@view\r\ndef get_exchange_multiple_amount(_route: address[9], _swap_params: uint256[3][4], _amount: uint256, _pools: address[4]) -> uint256: \r\n    pass"
             ),
             (

--- a/smart-contract-verifier/smart-contract-verifier/src/vyper/compiler.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/vyper/compiler.rs
@@ -97,7 +97,7 @@ mod tests {
         compiler::{self, Compilers, ListFetcher},
         consts::DEFAULT_VYPER_COMPILER_LIST,
     };
-    use ethers_solc::artifacts::Source;
+    use foundry_compilers::artifacts::Source;
     use std::{
         collections::{BTreeMap, HashSet},
         env::temp_dir,

--- a/smart-contract-verifier/smart-contract-verifier/src/vyper/multi_part.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/vyper/multi_part.rs
@@ -8,7 +8,7 @@ use crate::{
     verifier::{ContractVerifier, Error},
 };
 use bytes::Bytes;
-use ethers_solc::{
+use foundry_compilers::{
     artifacts::{Source, Sources},
     EvmVersion,
 };

--- a/smart-contract-verifier/smart-contract-verifier/src/vyper/standard_json.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/vyper/standard_json.rs
@@ -4,7 +4,7 @@ use crate::{
     verifier::{ContractVerifier, Error},
 };
 use bytes::Bytes;
-use ethers_solc::artifacts::output_selection::OutputSelection;
+use foundry_compilers::artifacts::output_selection::OutputSelection;
 use std::sync::Arc;
 
 pub struct VerificationRequest {

--- a/smart-contract-verifier/smart-contract-verifier/tests/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier/tests/types.rs
@@ -1,6 +1,6 @@
 pub mod solidity {
     use bytes::Bytes;
-    use ethers_solc::{CompilerInput, EvmVersion};
+    use foundry_compilers::{CompilerInput, EvmVersion};
     use smart_contract_verifier::{
         solidity::{multi_part, standard_json},
         Version as CompilerVersion,
@@ -94,7 +94,7 @@ pub mod solidity {
 
 pub mod vyper {
     use bytes::Bytes;
-    use ethers_solc::EvmVersion;
+    use foundry_compilers::EvmVersion;
     use smart_contract_verifier::{vyper::multi_part, Version as CompilerVersion};
     use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
 


### PR DESCRIPTION
`ethers-solc` library has not added support for the "Cancun" evm version. This PR starts using the `foundry-compilers` crate instead of deprecated `ethers-solc` for input related structs. 

Output related structs continues to use `ethers-solc`, as there are still some problems with returning proper abis via `foundry-compilers`