### PR TITLE
Add icon_url into Chains list

### DIFF
--- a/proxy-verifier/proxy-verifier-proto/proto/v1/proxy-verifier.proto
+++ b/proxy-verifier/proxy-verifier-proto/proto/v1/proxy-verifier.proto
@@ -149,6 +149,7 @@ message ListCompilersResponse {
 message Chain {
   string id = 1;
   string name = 2;
+  string icon_url = 3;
 }
 
 message Contract {

--- a/proxy-verifier/proxy-verifier-proto/swagger/v1/proxy-verifier.swagger.yaml
+++ b/proxy-verifier/proxy-verifier-proto/swagger/v1/proxy-verifier.swagger.yaml
@@ -257,6 +257,8 @@ definitions:
         type: string
       name:
         type: string
+      iconUrl:
+        type: string
   v1Compiler:
     type: object
     properties:

--- a/proxy-verifier/proxy-verifier-server/src/config.rs
+++ b/proxy-verifier/proxy-verifier-server/src/config.rs
@@ -54,5 +54,6 @@ impl ChainsSettings {
 pub struct ChainSettings {
     pub name: String,
     pub api_url: url::Url,
+    pub icon_url: Option<url::Url>,
     pub sensitive_api_key: Option<String>,
 }


### PR DESCRIPTION
Adds `icon_url` into Chain message. Is required as frontend requires icons to display near the chain names