### PR TITLE
Fix variable name in service template

### DIFF
--- a/service-template/Cargo.toml
+++ b/service-template/Cargo.toml
@@ -7,7 +7,7 @@ members = [
     {% if entity -%}
     "{{project-name}}-entity",
     {% endif -%}
-    {% if migration -%}
+    {% if migrations -%}
     "{{project-name}}-migration",
     {% endif -%}
     "{{project-name}}-proto",


### PR DESCRIPTION
Migration crate wasn't being added to `.toml` because of typo in variable name