### PR TITLE
Update versions of github actions (+ test fix)

### DIFF
--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -150,7 +150,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -43,7 +43,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -137,7 +137,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "blockscout-ens"
           file: "blockscout-ens/Dockerfile"

--- a/.github/workflows/eth-bytecode-db-extractors.yml
+++ b/.github/workflows/eth-bytecode-db-extractors.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set postgres max_connections
         run: |
@@ -95,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -132,7 +132,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "eth-bytecode-db"
           file: "eth-bytecode-db/eth-bytecode-db-server/Dockerfile"

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -161,7 +161,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -148,7 +148,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -156,7 +156,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/libs.yml
+++ b/.github/workflows/libs.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps

--- a/.github/workflows/multichain-search.yml
+++ b/.github/workflows/multichain-search.yml
@@ -129,7 +129,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/multichain-search.yml
+++ b/.github/workflows/multichain-search.yml
@@ -124,7 +124,7 @@ jobs:
       
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/multichain-search.yml
+++ b/.github/workflows/multichain-search.yml
@@ -116,7 +116,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/multichain-search.yml
+++ b/.github/workflows/multichain-search.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "multichain-search/backend"
           file: "multichain-search/backend/Dockerfile"

--- a/.github/workflows/multichain-search.yml
+++ b/.github/workflows/multichain-search.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # - name: Install deps
       #   uses: ./.github/actions/deps
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # - name: Install deps
       #   uses: ./.github/actions/deps
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/proxy-verifier.yml
+++ b/.github/workflows/proxy-verifier.yml
@@ -118,7 +118,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/scoutcloud.yml
+++ b/.github/workflows/scoutcloud.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "scoutcloud"
           file: "scoutcloud/Dockerfile"

--- a/.github/workflows/scoutcloud.yml
+++ b/.github/workflows/scoutcloud.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Set up Docker Buildx

--- a/.github/workflows/scoutcloud.yml
+++ b/.github/workflows/scoutcloud.yml
@@ -39,7 +39,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -113,7 +113,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/scoutcloud.yml
+++ b/.github/workflows/scoutcloud.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/scoutcloud.yml
+++ b/.github/workflows/scoutcloud.yml
@@ -129,7 +129,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -131,7 +131,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: "sig-provider"
           file: "sig-provider/Dockerfile"

--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -118,7 +118,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/sig-provider.yml
+++ b/.github/workflows/sig-provider.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/smart-contract-verifier.yml
+++ b/.github/workflows/smart-contract-verifier.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/smart-contract-verifier.yml
+++ b/.github/workflows/smart-contract-verifier.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/smart-contract-verifier.yml
+++ b/.github/workflows/smart-contract-verifier.yml
@@ -118,7 +118,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/smart-contract-verifier.yml
+++ b/.github/workflows/smart-contract-verifier.yml
@@ -131,7 +131,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/smart-contract-verifier.yml
+++ b/.github/workflows/smart-contract-verifier.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "smart-contract-verifier"
           file: "smart-contract-verifier/smart-contract-verifier-server/Dockerfile"

--- a/.github/workflows/smart-guessr.yml
+++ b/.github/workflows/smart-guessr.yml
@@ -67,7 +67,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -150,7 +150,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -43,7 +43,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "stats"
           file: "stats/Dockerfile"

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -137,7 +137,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/user-ops-indexer.yml
+++ b/.github/workflows/user-ops-indexer.yml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 

--- a/.github/workflows/user-ops-indexer.yml
+++ b/.github/workflows/user-ops-indexer.yml
@@ -134,7 +134,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/user-ops-indexer.yml
+++ b/.github/workflows/user-ops-indexer.yml
@@ -147,7 +147,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/user-ops-indexer.yml
+++ b/.github/workflows/user-ops-indexer.yml
@@ -43,7 +43,7 @@ jobs:
           - 5432:5432
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/.github/workflows/user-ops-indexer.yml
+++ b/.github/workflows/user-ops-indexer.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "user-ops-indexer"
           file: "user-ops-indexer/Dockerfile"

--- a/.github/workflows/visualizer.yml
+++ b/.github/workflows/visualizer.yml
@@ -148,9 +148,9 @@ jobs:
           file: "visualizer/Dockerfile"
           push: ${{ steps.tags_extractor.outputs.tags != '' }}
           tags: ${{ steps.tags_extractor.outputs.tags }}
-          platforms: |
-            linux/amd64
-            linux/arm64/v8
+          # platforms: |
+          #   linux/amd64
+          #   linux/arm64/v8
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-cache
           cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,ref={0}/{1}:build-cache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}

--- a/.github/workflows/visualizer.yml
+++ b/.github/workflows/visualizer.yml
@@ -127,7 +127,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/libs/sourcify/src/client.rs
+++ b/libs/sourcify/src/client.rs
@@ -467,9 +467,9 @@ mod tests {
 
         #[tokio::test]
         async fn verify_from_etherscan_contract_not_verified() {
-            let chain_id = "5";
+            let chain_id = "11155111";
             let contract_address =
-                parse_contract_address("0x847F2d0c193E90963aAD7B2791aAE8d7310dFF6A");
+                parse_contract_address("0xa4E5DF47af3Cf0746DF6337E3F45286887e86680");
 
             let result = client()
                 .verify_from_etherscan(chain_id, contract_address)

--- a/service-template/.github/workflows/{{project-name}}.yml
+++ b/service-template/.github/workflows/{{project-name}}.yml
@@ -138,7 +138,7 @@ jobs:
           (if ! [[ "$t" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$t, ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest; elif ! [[ "$m" == "" ]]; then echo tags=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:$m; else echo tags=; fi) >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/service-template/.github/workflows/{{project-name}}.yml
+++ b/service-template/.github/workflows/{{project-name}}.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       {% endraw -%}

--- a/service-template/.github/workflows/{{project-name}}.yml
+++ b/service-template/.github/workflows/{{project-name}}.yml
@@ -45,7 +45,7 @@ jobs:
     {%- endif %}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install deps
         uses: ./.github/actions/deps
@@ -122,7 +122,7 @@ jobs:
     steps:
       {% raw -%}
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: regex

--- a/service-template/.github/workflows/{{project-name}}.yml
+++ b/service-template/.github/workflows/{{project-name}}.yml
@@ -151,7 +151,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       {% endraw -%}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: Build and push
         uses: docker/build-push-action@v5
         with:

--- a/service-template/.github/workflows/{{project-name}}.yml
+++ b/service-template/.github/workflows/{{project-name}}.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: "{{project-name}}"
           file: "{{project-name}}/Dockerfile"


### PR DESCRIPTION
There are some warnings in CI that should be fixed by bumping actions versions.
example:
https://github.com/blockscout/blockscout-rs/actions/runs/8560946122/job/23461168368?pr=823#step:8:23

the update should be trivial as the updated actions have barely any options and seem to do elementary stuff