### PR TITLE
[BENS] Perform to_checksum to response addresses

### DIFF
--- a/blockscout-ens/bens-server/src/conversion/domain.rs
+++ b/blockscout-ens/bens-server/src/conversion/domain.rs
@@ -94,7 +94,7 @@ pub fn batch_resolve_from_logic(
     let names = output
         .into_iter()
         .map(|(address, name)| {
-            let address = checksummed(&address_from_str_inner(&address)?, chain_id);
+            let address = address_from_str_logic(&address, chain_id)?.hash;
             Ok((address, name))
         })
         .collect::<Result<_, _>>()?;

--- a/blockscout-ens/bens-server/src/conversion/domain.rs
+++ b/blockscout-ens/bens-server/src/conversion/domain.rs
@@ -1,4 +1,4 @@
-use super::ConversionError;
+use super::{address_from_str_logic, checksummed, ConversionError};
 use crate::conversion::order_direction_from_inner;
 use bens_logic::{
     entity::subgraph::domain::Domain,
@@ -9,7 +9,7 @@ use bens_logic::{
 };
 use bens_proto::blockscout::bens::v1 as proto;
 use ethers::types::Address;
-use std::str::FromStr;
+use std::{collections::BTreeMap, str::FromStr};
 
 const DEFAULT_PAGE_SIZE: u32 = 50;
 
@@ -87,26 +87,43 @@ pub fn batch_resolve_from_inner(
     })
 }
 
+pub fn batch_resolve_from_logic(
+    output: BTreeMap<String, String>,
+    chain_id: i64,
+) -> Result<proto::BatchResolveAddressNamesResponse, ConversionError> {
+    let names = output
+        .into_iter()
+        .map(|(address, name)| {
+            let address = checksummed(&address_from_str_inner(&address)?, chain_id);
+            Ok((address, name))
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(proto::BatchResolveAddressNamesResponse { names })
+}
+
 pub fn detailed_domain_from_logic(
     output: GetDomainOutput,
+    chain_id: i64,
 ) -> Result<proto::DetailedDomain, ConversionError> {
     let domain = output.domain;
-    let owner = Some(proto::Address { hash: domain.owner });
+    let owner = Some(address_from_str_logic(&domain.owner, chain_id)?);
     let resolved_address = domain
         .resolved_address
-        .map(|resolved_address| proto::Address {
-            hash: resolved_address,
-        });
-    let wrapped_owner = domain.wrapped_owner.map(|wrapped_owner| proto::Address {
-        hash: wrapped_owner,
-    });
+        .map(|resolved_address| address_from_str_logic(&resolved_address, chain_id))
+        .transpose()?;
+
+    let wrapped_owner = domain
+        .wrapped_owner
+        .map(|wrapped_owner| address_from_str_logic(&wrapped_owner, chain_id))
+        .transpose()?;
     let registrant = domain
         .registrant
-        .map(|registrant| proto::Address { hash: registrant });
+        .map(|registrant| address_from_str_logic(&registrant, chain_id))
+        .transpose()?;
     let tokens = output
         .tokens
         .into_iter()
-        .map(domain_token_from_logic)
+        .map(|t| domain_token_from_logic(t, chain_id))
         .collect();
     Ok(proto::DetailedDomain {
         id: domain.id,
@@ -122,14 +139,16 @@ pub fn detailed_domain_from_logic(
     })
 }
 
-pub fn domain_from_logic(d: Domain) -> Result<proto::Domain, ConversionError> {
-    let owner = Some(proto::Address { hash: d.owner });
-    let resolved_address = d.resolved_address.map(|resolved_address| proto::Address {
-        hash: resolved_address,
-    });
-    let wrapped_owner = d.wrapped_owner.map(|wrapped_owner| proto::Address {
-        hash: wrapped_owner,
-    });
+pub fn domain_from_logic(d: Domain, chain_id: i64) -> Result<proto::Domain, ConversionError> {
+    let owner = Some(address_from_str_logic(&d.owner, chain_id)?);
+    let resolved_address = d
+        .resolved_address
+        .map(|resolved_address| address_from_str_logic(&resolved_address, chain_id))
+        .transpose()?;
+    let wrapped_owner = d
+        .wrapped_owner
+        .map(|wrapped_owner| address_from_str_logic(&wrapped_owner, chain_id))
+        .transpose()?;
     Ok(proto::Domain {
         id: d.id,
         name: d.name.unwrap_or_default(),
@@ -174,10 +193,10 @@ fn date_from_logic(d: chrono::DateTime<chrono::Utc>) -> String {
     d.to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
-fn domain_token_from_logic(t: DomainToken) -> proto::Token {
+fn domain_token_from_logic(t: DomainToken, chain_id: i64) -> proto::Token {
     proto::Token {
         id: t.id,
-        contract_hash: format!("{:#x}", t.contract),
+        contract_hash: checksummed(&t.contract, chain_id),
         r#type: domain_token_type_from_logic(t._type).into(),
     }
 }

--- a/blockscout-ens/bens-server/src/conversion/events.rs
+++ b/blockscout-ens/bens-server/src/conversion/events.rs
@@ -24,7 +24,7 @@ pub fn event_from_logic(
     e: DomainEvent,
     chain_id: i64,
 ) -> Result<proto::DomainEvent, ConversionError> {
-    let from_address = Some(address_from_logic(e.from_address, chain_id));
+    let from_address = Some(address_from_logic(&e.from_address, chain_id));
     Ok(proto::DomainEvent {
         transaction_hash: hex(e.transaction_hash),
         timestamp: e.timestamp,

--- a/blockscout-ens/bens-server/src/conversion/events.rs
+++ b/blockscout-ens/bens-server/src/conversion/events.rs
@@ -5,7 +5,7 @@ use bens_logic::{
 };
 use bens_proto::blockscout::bens::v1 as proto;
 
-use super::{order_direction_from_inner, ConversionError};
+use super::{address_from_logic, order_direction_from_inner, ConversionError};
 
 pub fn list_domain_events_from_inner(
     inner: proto::ListDomainEventsRequest,
@@ -20,10 +20,11 @@ pub fn list_domain_events_from_inner(
     })
 }
 
-pub fn event_from_logic(e: DomainEvent) -> Result<proto::DomainEvent, ConversionError> {
-    let from_address = Some(proto::Address {
-        hash: hex(e.from_address),
-    });
+pub fn event_from_logic(
+    e: DomainEvent,
+    chain_id: i64,
+) -> Result<proto::DomainEvent, ConversionError> {
+    let from_address = Some(address_from_logic(e.from_address, chain_id));
     Ok(proto::DomainEvent {
         transaction_hash: hex(e.transaction_hash),
         timestamp: e.timestamp,
@@ -36,7 +37,7 @@ pub fn event_sort_from_inner(inner: &str) -> Result<EventSort, ConversionError> 
     match inner {
         "" | "timestamp" => Ok(EventSort::BlockNumber),
         _ => Err(ConversionError::UserRequest(format!(
-            "unknow sort field '{inner}'"
+            "unknown sort field '{inner}'"
         ))),
     }
 }

--- a/blockscout-ens/bens-server/src/conversion/mod.rs
+++ b/blockscout-ens/bens-server/src/conversion/mod.rs
@@ -10,14 +10,6 @@ mod events;
 pub use domain::*;
 pub use events::*;
 
-pub fn order_direction_from_inner(inner: proto::Order) -> Order {
-    match inner {
-        proto::Order::Unspecified => Order::Desc,
-        proto::Order::Asc => Order::Asc,
-        proto::Order::Desc => Order::Desc,
-    }
-}
-
 #[derive(Error, Debug)]
 pub enum ConversionError {
     #[error("invalid argument: {0}")]
@@ -27,23 +19,36 @@ pub enum ConversionError {
     LogicOutput(String),
 }
 
-fn checksummed(address: &Address, chain_id: i64) -> String {
+#[inline]
+pub fn order_direction_from_inner(inner: proto::Order) -> Order {
+    match inner {
+        proto::Order::Unspecified => Order::Desc,
+        proto::Order::Asc => Order::Asc,
+        proto::Order::Desc => Order::Desc,
+    }
+}
+
+#[inline]
+pub fn checksummed(address: &Address, chain_id: i64) -> String {
     match chain_id {
         30 | 31 => to_checksum(address, Some(chain_id as u8)),
         _ => to_checksum(address, None),
     }
 }
 
-fn address_from_logic(address: Address, chain_id: i64) -> proto::Address {
+#[inline]
+pub fn address_from_logic(address: &Address, chain_id: i64) -> proto::Address {
     proto::Address {
-        hash: checksummed(&address, chain_id),
+        hash: checksummed(address, chain_id),
     }
 }
 
-fn address_from_str_logic(addr: &str, chain_id: i64) -> Result<proto::Address, ConversionError> {
+#[inline]
+pub fn address_from_str_logic(
+    addr: &str,
+    chain_id: i64,
+) -> Result<proto::Address, ConversionError> {
     let addr = Address::from_str(addr)
         .map_err(|e| ConversionError::LogicOutput(format!("invalid address '{addr}': {e}")))?;
-    Ok(proto::Address {
-        hash: checksummed(&addr, chain_id),
-    })
+    Ok(address_from_logic(&addr, chain_id))
 }

--- a/blockscout-ens/bens-server/src/services/domain_extractor.rs
+++ b/blockscout-ens/bens-server/src/services/domain_extractor.rs
@@ -1,4 +1,7 @@
-use crate::conversion::{self, batch_resolve_from_inner, pagination_from_logic, ConversionError};
+use crate::conversion::{
+    self, batch_resolve_from_inner, batch_resolve_from_logic, pagination_from_logic,
+    ConversionError,
+};
 use async_trait::async_trait;
 use bens_logic::{
     entity,
@@ -29,6 +32,7 @@ impl DomainsExtractor for DomainsExtractorService {
         request: tonic::Request<GetDomainRequest>,
     ) -> Result<tonic::Response<DetailedDomain>, tonic::Status> {
         let request = request.into_inner();
+        let chain_id = request.chain_id;
         let input =
             conversion::get_domain_input_from_inner(request).map_err(map_convertion_error)?;
         let domain = self
@@ -36,7 +40,7 @@ impl DomainsExtractor for DomainsExtractorService {
             .get_domain(input)
             .await
             .map_err(map_subgraph_error)?
-            .map(conversion::detailed_domain_from_logic)
+            .map(|d| conversion::detailed_domain_from_logic(d, chain_id))
             .transpose()
             .map_err(map_convertion_error)?
             .ok_or_else(|| tonic::Status::not_found("domain not found"))?;
@@ -48,6 +52,7 @@ impl DomainsExtractor for DomainsExtractorService {
         request: tonic::Request<ListDomainEventsRequest>,
     ) -> Result<tonic::Response<ListDomainEventsResponse>, tonic::Status> {
         let request = request.into_inner();
+        let chain_id = request.chain_id;
         let input =
             conversion::list_domain_events_from_inner(request).map_err(map_convertion_error)?;
         let items: Vec<DomainEvent> = self
@@ -56,7 +61,7 @@ impl DomainsExtractor for DomainsExtractorService {
             .await
             .map_err(map_subgraph_error)?
             .into_iter()
-            .map(conversion::event_from_logic)
+            .map(|e| conversion::event_from_logic(e, chain_id))
             .collect::<Result<_, _>>()
             .map_err(map_convertion_error)?;
         let response = ListDomainEventsResponse { items };
@@ -68,6 +73,7 @@ impl DomainsExtractor for DomainsExtractorService {
         request: tonic::Request<LookupDomainNameRequest>,
     ) -> Result<tonic::Response<LookupDomainNameResponse>, tonic::Status> {
         let request = request.into_inner();
+        let chain_id = request.chain_id;
         let input =
             conversion::lookup_domain_name_from_inner(request).map_err(map_convertion_error)?;
         let page_size = input.pagination.page_size;
@@ -76,7 +82,7 @@ impl DomainsExtractor for DomainsExtractorService {
             .lookup_domain_name(input)
             .await
             .map_err(map_subgraph_error)?;
-        let domains = from_resolved_domains_result(result.items)?;
+        let domains = from_resolved_domains_result(result.items, chain_id)?;
         let response = LookupDomainNameResponse {
             items: domains,
             next_page_params: pagination_from_logic(result.next_page_token, page_size),
@@ -89,6 +95,7 @@ impl DomainsExtractor for DomainsExtractorService {
         request: tonic::Request<LookupAddressRequest>,
     ) -> Result<tonic::Response<LookupAddressResponse>, tonic::Status> {
         let request = request.into_inner();
+        let chain_id = request.chain_id;
         let input = conversion::lookup_address_from_inner(request).map_err(map_convertion_error)?;
         let page_size = input.pagination.page_size;
         let result = self
@@ -96,7 +103,7 @@ impl DomainsExtractor for DomainsExtractorService {
             .lookup_address(input)
             .await
             .map_err(map_subgraph_error)?;
-        let items = from_resolved_domains_result(result.items)?;
+        let items = from_resolved_domains_result(result.items, chain_id)?;
         let response = LookupAddressResponse {
             items,
             next_page_params: pagination_from_logic(result.next_page_token, page_size),
@@ -109,22 +116,22 @@ impl DomainsExtractor for DomainsExtractorService {
         request: tonic::Request<GetAddressRequest>,
     ) -> Result<tonic::Response<GetAddressResponse>, tonic::Status> {
         let request = request.into_inner();
-        let network_id = request.chain_id;
+        let chain_id = request.chain_id;
         let address =
             conversion::address_from_str_inner(&request.address).map_err(map_convertion_error)?;
 
         let domain = self
             .subgraph_reader
-            .get_address(network_id, address)
+            .get_address(chain_id, address)
             .await
             .map_err(map_subgraph_error)?
-            .map(conversion::detailed_domain_from_logic)
+            .map(|d| conversion::detailed_domain_from_logic(d, chain_id))
             .transpose()
             .map_err(map_convertion_error)?;
 
         let resolved_domains_count = self
             .subgraph_reader
-            .count_domains_by_address(network_id, address, true, false)
+            .count_domains_by_address(chain_id, address, true, false)
             .await
             .map_err(map_subgraph_error)? as i32;
         Ok(tonic::Response::new(GetAddressResponse {
@@ -138,13 +145,14 @@ impl DomainsExtractor for DomainsExtractorService {
         request: tonic::Request<BatchResolveAddressNamesRequest>,
     ) -> Result<tonic::Response<BatchResolveAddressNamesResponse>, tonic::Status> {
         let request = request.into_inner();
+        let chain_id = request.chain_id;
         let input = batch_resolve_from_inner(request).map_err(map_convertion_error)?;
         let names = self
             .subgraph_reader
             .batch_resolve_address_names(input)
             .await
             .map_err(map_subgraph_error)?;
-        let response = BatchResolveAddressNamesResponse { names };
+        let response = batch_resolve_from_logic(names, chain_id).map_err(map_convertion_error)?;
         Ok(tonic::Response::new(response))
     }
 }
@@ -170,10 +178,11 @@ fn map_convertion_error(err: ConversionError) -> tonic::Status {
 
 fn from_resolved_domains_result(
     result: impl IntoIterator<Item = entity::subgraph::domain::Domain>,
+    chain_id: i64,
 ) -> Result<Vec<Domain>, tonic::Status> {
     result
         .into_iter()
-        .map(conversion::domain_from_logic)
+        .map(|d| conversion::domain_from_logic(d, chain_id))
         .collect::<Result<_, _>>()
         .map_err(map_convertion_error)
 }

--- a/blockscout-ens/bens-server/tests/domains.rs
+++ b/blockscout-ens/bens-server/tests/domains.rs
@@ -67,20 +67,20 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "ETH": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
         },
         "owner": {
-            "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+            "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
         },
         "registrant": {
-            "hash": "0x220866b1a2219f40e72f5c628b65d54268ca3a9d",
+            "hash": "0x220866B1A2219f40e72f5c628B65D54268cA3A9D",
         },
         "wrapped_owner": null,
         "registration_date": "2017-06-18T08:39:14.000Z",
         "resolved_address": {
-            "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+            "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
         },
         "tokens": [
             {
                 "id": "79233663829379634837589865448569342784712482819484549289560981379859480642508",
-                "contract_hash": "0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85",
+                "contract_hash": "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
                 "type": "NATIVE_DOMAIN_TOKEN",
             }
         ],
@@ -96,29 +96,29 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "name": "wa🇬🇲i.eth",
             "other_addresses": {},
             "owner": {
-                "hash": "0xd4416b13d2b3a9abae7acd5d6c2bbdbe25686401",
+                "hash": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
             },
             "registrant": {
-                "hash": "0x9c996076a85b46061d9a70ff81f013853a86b619",
+                "hash": "0x9C996076A85B46061D9a70ff81F013853A86b619",
             },
             "registration_date": "2021-11-12T11:36:46.000Z",
             "resolved_address": {
-                "hash": "0x9c996076a85b46061d9a70ff81f013853a86b619",
+                "hash": "0x9C996076A85B46061D9a70ff81F013853A86b619",
             },
             "tokens": [
                 {
-                    "contract_hash": "0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85",
+                    "contract_hash": "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
                     "id": "46567936673033819165815925923418529171479684343878036049875289456825310839168",
                     "type": "NATIVE_DOMAIN_TOKEN",
                 },
                 {
-                    "contract_hash": "0xd4416b13d2b3a9abae7acd5d6c2bbdbe25686401",
+                    "contract_hash": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
                     "id": "42184447928009120460686389475560276149795188091233200941948299907753855407605",
                     "type": "WRAPPED_DOMAIN_TOKEN",
                 },
             ],
             "wrapped_owner": {
-                "hash": "0x9c996076a85b46061d9a70ff81f013853a86b619",
+                "hash": "0x9C996076A85B46061D9a70ff81F013853A86b619",
             },
         })
     );
@@ -128,7 +128,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         {
             "action": "setResolver",
             "from_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "timestamp": "2021-02-15T17:19:17.000000Z",
             "transaction_hash": "0xbb13efab7f1f798f63814a4d184e903e050b38c38aa407f9294079ee7b3110c9"
@@ -136,7 +136,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         {
             "action": "multicall",
             "from_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "timestamp": "2021-02-15T17:19:09.000000Z",
             "transaction_hash": "0x160ef4492c731ac6b59beebe1e234890cd55d4c556f8847624a0b47125fe4f84"
@@ -144,7 +144,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         {
             "action": "migrateAll",
             "from_address": {
-                "hash": "0x0904dac3347ea47d208f3fd67402d039a3b99859"
+                "hash": "0x0904Dac3347eA47d208F3Fd67402D039a3b99859"
             },
             "timestamp": "2020-02-06T18:23:40.000000Z",
             "transaction_hash": "0xc3f86218c67bee8256b74b9b65d746a40bb5318a8b57948b804dbbbc3d0d7864"
@@ -152,7 +152,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         {
             "action": "setAddr",
             "from_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "timestamp": "2019-10-29T13:47:34.000000Z",
             "transaction_hash": "0x09922ac0caf1efcc8f68ce004f382b46732258870154d8805707a1d4b098dfd0"
@@ -160,7 +160,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         {
             "action": "transferRegistrars",
             "from_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "timestamp": "2019-07-10T05:58:51.000000Z",
             "transaction_hash": "0xea30bda97a7e9afcca208d5a648e8ec1e98b245a8884bf589dec8f4aa332fb14"
@@ -168,7 +168,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         {
             "action": "finalizeAuction",
             "from_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "timestamp": "2017-06-18T08:39:14.000000Z",
             "transaction_hash": "0xdd16deb1ea750037c3ed1cae5ca20ff9db0e664a5146e5a030137d277a9247f3"
@@ -199,12 +199,12 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "id": "0x68b620f61c87062cf680144f898582a631c90e39dd1badb35c241be0a7284fff",
             "name": "sashaxyz.eth",
             "owner": {
-                "hash": "0x66a6f7744ce4dea450910b81a7168588f992eafb",
+                "hash": "0x66A6f7744ce4DEa450910B81A7168588F992eAfB",
             },
             "wrapped_owner": null,
             "registration_date": "2021-12-24T10:23:57.000Z",
             "resolved_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
             },
         }),
         json!({
@@ -212,14 +212,14 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "id": "0x5d438d292de31e08576d5bcd8a93aa41b401b9d9aeaba57da1a32c003e5fd5f5",
             "name": "wa🇬🇲i.eth",
             "owner": {
-                "hash": "0xd4416b13d2b3a9abae7acd5d6c2bbdbe25686401",
+                "hash": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
             },
             "wrapped_owner": {
-                "hash": "0x9c996076a85b46061d9a70ff81f013853a86b619",
+                "hash": "0x9C996076A85B46061D9a70ff81F013853A86b619",
             },
             "registration_date": "2021-11-12T11:36:46.000Z",
             "resolved_address": {
-                "hash": "0x9c996076a85b46061d9a70ff81f013853a86b619",
+                "hash": "0x9C996076A85B46061D9a70ff81F013853A86b619",
             },
         }),
         json!({
@@ -227,12 +227,12 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "id": "0xeb4f647bea6caa36333c816d7b46fdcb05f9466ecacc140ea8c66faf15b3d9f1",
             "name": "test.eth",
             "owner": {
-                "hash": "0xbd6bbe64bf841b81fc5a6e2b760029e316f2783b",
+                "hash": "0xbD6BBE64Bf841b81FC5A6e2b760029e316F2783B",
             },
             "wrapped_owner": null,
             "registration_date": "2019-10-24T07:26:47.000Z",
             "resolved_address": {
-                "hash": "0xeefb13c7d42efcc655e528da6d6f7bbcf9a2251d",
+                "hash": "0xeefB13C7D42eFCc655E528dA6d6F7bBcf9A2251d",
             },
         }),
         json!({
@@ -240,7 +240,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "id": "0x6db3aa7fbaf005b22a12dd698aa41e3456ea93d2ab312796ee29fca980c99dcd",
             "name": "biglobe.eth",
             "owner": {
-                "hash": "0x916a3bc6f0306426adaaa101fe28fea7a5f69b06",
+                "hash": "0x916a3bC6F0306426adAAA101FE28Fea7A5f69b06",
             },
             "registration_date": "2017-07-08T02:11:54.000Z",
             "resolved_address": null,
@@ -274,10 +274,10 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "id": "0x68b620f61c87062cf680144f898582a631c90e39dd1badb35c241be0a7284fff",
             "name": "sashaxyz.eth",
             "resolved_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "owner": {
-                "hash": "0x66a6f7744ce4dea450910b81a7168588f992eafb"
+                "hash": "0x66A6f7744ce4DEa450910B81A7168588F992eAfB"
             },
             "wrapped_owner": null,
             "registration_date": "2021-12-24T10:23:57.000Z",
@@ -299,10 +299,10 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
             "id": "0xee6c4522aab0003e8d14cd40a6af439055fd2577951148c14b6cea9a53475835",
             "name": "vitalik.eth",
             "resolved_address": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "owner": {
-                "hash": "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+                "hash": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"
             },
             "wrapped_owner": null,
             "registration_date": "2017-06-18T08:39:14.000Z",
@@ -318,7 +318,7 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         HashMap::from_iter([
             (
                 "address".into(),
-                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045".into(),
+                "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045".into(),
             ),
             ("resolved_to".into(), "true".into()),
             ("owned_by".into(), "true".into()),
@@ -337,9 +337,11 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         &json!({
             "addresses": [
                 "0xeefb13c7d42efcc655e528da6d6f7bbcf9a2251d",
+                // unchecksummed
                 "0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
                 "0x9f7f7ddbfb8e14d1756580ba8037530da0880b99",
-                "0x9c996076a85b46061d9a70ff81f013853a86b619",
+                // checksummed
+                "0x9C996076A85B46061D9a70ff81F013853A86b619",
                 "0xee6c4522aab0003e8d14cd40a6af439055fd2577",
             ],
         }),
@@ -349,15 +351,15 @@ async fn check_basic_scenario_eth(settings: Settings, base: Url) {
         response,
         json!({
             "names": {
-                "0x9c996076a85b46061d9a70ff81f013853a86b619": "wa🇬🇲i.eth",
-                "0xd8da6bf26964af9d7eed9e03e53415d37aa96045": "vitalik.eth",
+                "0x9C996076A85B46061D9a70ff81F013853A86b619": "wa🇬🇲i.eth",
+                "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045": "vitalik.eth",
             }
         })
     );
 
     let response: Value = send_get_request(
         &base,
-        "/api/v1/1/addresses/0xd8da6bf26964af9d7eed9e03e53415d37aa96045",
+        "/api/v1/1/addresses/0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
     )
     .await;
     assert_eq!(
@@ -392,20 +394,20 @@ async fn check_basic_scenario_gno(settings: Settings, base: Url) {
             "name": "levvv.gno",
             "other_addresses": {},
             "owner": {
-                "hash": "0xc0de20a37e2dac848f81a93bd85fe4acdde7c0de",
+                "hash": "0xc0De20A37E2dAC848F81A93BD85FE4ACDdE7C0DE",
             },
             "wrapped_owner": null,
             "registrant":{
-                "hash": "0xc0de20a37e2dac848f81a93bd85fe4acdde7c0de",
+                "hash": "0xc0De20A37E2dAC848F81A93BD85FE4ACDdE7C0DE",
             },
             "registration_date": "2023-11-29T09:09:25.000Z",
             "resolved_address":{
-                "hash": "0xc0de20a37e2dac848f81a93bd85fe4acdde7c0de",
+                "hash": "0xc0De20A37E2dAC848F81A93BD85FE4ACDdE7C0DE",
             },
             "tokens": [
                 {
                     "id": "11990319655936053415661126359086567018700354293176496925267203544835860524390",
-                    "contract_hash": "0xfd3d666db2557983f3f04d61f90e35cc696f6d60",
+                    "contract_hash": "0xfd3d666dB2557983F3F04d61f90E35cc696f6D60",
                     "type": "NATIVE_DOMAIN_TOKEN",
                 }
             ]


### PR DESCRIPTION
during batch resolving blockscout tries to fetch addresses from response map using checksum address, but BENS returns addresses in lower case (from graph-node database). This PR provides checksum address serialization according to chain_id (for rootstock 🥲 )