### PR TITLE
[LAUNCHER] Return `init_logs` without filter method

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.11.1"
+version = "0.12.0"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/tracing/init.rs
+++ b/libs/blockscout-service-launcher/src/tracing/init.rs
@@ -10,11 +10,24 @@ use tracing_subscriber::{
     filter::LevelFilter, fmt::format::FmtSpan, layer::SubscriberExt, prelude::*, Layer,
 };
 
-pub fn init_logs<F: Fn(&Metadata) -> bool + Send + Sync + 'static>(
+pub fn init_logs(
     service_name: &str,
     tracing_settings: &TracingSettings,
     jaeger_settings: &JaegerSettings,
-    filter: Option<tracing_subscriber::filter::FilterFn<F>>,
+) -> Result<(), anyhow::Error> {
+    init_logs_with_filter(
+        service_name,
+        tracing_settings,
+        jaeger_settings,
+        tracing_subscriber::filter::filter_fn(move |_| true),
+    )
+}
+
+pub fn init_logs_with_filter<F: Fn(&Metadata) -> bool + Send + Sync + 'static>(
+    service_name: &str,
+    tracing_settings: &TracingSettings,
+    jaeger_settings: &JaegerSettings,
+    filter: tracing_subscriber::filter::FilterFn<F>,
 ) -> Result<(), anyhow::Error> {
     // If tracing is disabled, there is nothing to initialize
     if !tracing_settings.enabled {


### PR DESCRIPTION
Remove filter optional from `init_logs` function. Move creation with filter into 'init_logs_with_filter'. That should allow not to update init_trace application for services that do not need it