### PR TITLE
[ETH_BYTECODE_DB] Fix search-all requests fails

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -5807,7 +5807,7 @@ checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 [[package]]
 name = "smart-contract-verifier-proto"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=b855922a#b855922a4d96f38b9bb12e7868044e86110f1dd9"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=7a6e9400#7a6e9400e26772a7e387d6aebb807eccf166872b"
 dependencies = [
  "actix-prost",
  "actix-prost-build",
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "sourcify"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=6a12a22#6a12a229d22ae36e3c727cebc16890b91589e629"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=6e78959b#6e78959ba1d206be9723a699ba7561d52ee381de"
 dependencies = [
  "anyhow",
  "blockscout-display-bytes",
@@ -7043,7 +7043,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verification-common"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=b855922a#b855922a4d96f38b9bb12e7868044e86110f1dd9"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=7a6e9400#7a6e9400e26772a7e387d6aebb807eccf166872b"
 dependencies = [
  "bytes",
 ]

--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "sourcify"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=6e78959b#6e78959ba1d206be9723a699ba7561d52ee381de"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=457af68#457af68c8c09046530ec174112be6443ae34ff19"
 dependencies = [
  "anyhow",
  "blockscout-display-bytes",

--- a/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/Cargo.toml
@@ -12,4 +12,4 @@ members = [
 
 [workspace.dependencies]
 blockscout-service-launcher = "0.10.0"
-smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "b855922a" }
+smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "7a6e9400" }

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -23,7 +23,7 @@ sea-orm = "0.12.2"
 serde = "1.0"
 serde_json = "1.0.96"
 serde_with = "2.1"
-sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "6e78959b" }
+sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "457af68" }
 tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 tracing = "0.1"

--- a/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db-server/Cargo.toml
@@ -23,7 +23,7 @@ sea-orm = "0.12.2"
 serde = "1.0"
 serde_json = "1.0.96"
 serde_with = "2.1"
-sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "6a12a22" }
+sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "6e78959b" }
 tokio = { version = "1.23", features = [ "rt-multi-thread", "macros" ] }
 tonic = "0.8"
 tracing = "0.1"

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
@@ -155,8 +155,8 @@ impl Database for DatabaseService {
             search_sourcify_sources_task
         );
 
-        let trace_error = |source: &str, err: tonic::Status| {
-            tracing::error!(
+        let trace_error = |source: &str, err: &tonic::Status| {
+            tracing::warn!(
                 contract_address = contract_address,
                 chain_id = chain_id,
                 status =? err,
@@ -165,16 +165,16 @@ impl Database for DatabaseService {
         };
 
         let eth_bytecode_db_sources = eth_bytecode_db_sources
-            .map_err(|err| trace_error("eth_bytecode_db", err))
+            .inspect_err(|err| trace_error("eth_bytecode_db", err))
             .unwrap_or_default();
         let alliance_sources = alliance_sources
             .transpose()
-            .map_err(|err| trace_error("alliance", err))
+            .inspect_err(|err| trace_error("alliance", err))
             .unwrap_or_default()
             .unwrap_or_default();
         let mut sourcify_source = sourcify_source
             .transpose()
-            .map_err(|err| trace_error("sourcify", err))
+            .inspect_err(|err| trace_error("sourcify", err))
             .unwrap_or_default()
             .flatten();
 

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/database_search.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/database_search.rs
@@ -11,7 +11,7 @@ use eth_bytecode_db_proto::blockscout::eth_bytecode_db::{
         EventDescription, SearchAllSourcesRequest, SearchAllSourcesResponse,
         SearchAllianceSourcesRequest, SearchEventDescriptionsRequest,
         SearchEventDescriptionsResponse, SearchSourcesRequest, SearchSourcesResponse,
-        SearchSourcifySourcesRequest, Source,
+        /*SearchSourcifySourcesRequest,*/ Source,
     },
 };
 use pretty_assertions::assert_eq;
@@ -48,7 +48,8 @@ fn service() -> MockSolidityVerifierService {
     MockSolidityVerifierService::new()
 }
 
-#[rstest]
+// TODO: uncomment when sourcify search is fixed
+/*#[rstest]
 #[tokio::test]
 #[timeout(std::time::Duration::from_secs(60))]
 #[ignore = "Needs database to run"]
@@ -102,7 +103,7 @@ async fn search_sourcify_sources(service: MockSolidityVerifierService) {
         expected_sources, verification_response.sources,
         "Invalid sources returned"
     );
-}
+}*/
 
 #[rstest]
 #[tokio::test]
@@ -196,7 +197,7 @@ async fn search_all_sources(
     let verification_response: SearchAllSourcesResponse =
         test_server::send_post_request(&eth_bytecode_db_with_alliance_base, ROUTE, &request).await;
 
-    let expected_sourcify_sources = match only_local {
+    let _expected_sourcify_sources = match only_local {
         Some(true) => vec![],
         None | Some(false) =>
             vec![
@@ -220,7 +221,9 @@ async fn search_all_sources(
 
     let expected_response = SearchAllSourcesResponse {
         eth_bytecode_db_sources: vec![test_data.eth_bytecode_db_response.source.unwrap()],
-        sourcify_sources: expected_sourcify_sources,
+        // TODO: uncomment when sourcify search is fixed
+        // sourcify_sources: expected_sourcify_sources,
+        sourcify_sources: vec![],
         alliance_sources: vec![test_case
             .to_test_input_data()
             .eth_bytecode_db_response

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/database_search.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/database_search.rs
@@ -11,7 +11,7 @@ use eth_bytecode_db_proto::blockscout::eth_bytecode_db::{
         EventDescription, SearchAllSourcesRequest, SearchAllSourcesResponse,
         SearchAllianceSourcesRequest, SearchEventDescriptionsRequest,
         SearchEventDescriptionsResponse, SearchSourcesRequest, SearchSourcesResponse,
-        /*SearchSourcifySourcesRequest,*/ Source,
+        SearchSourcifySourcesRequest, Source,
     },
 };
 use pretty_assertions::assert_eq;
@@ -48,8 +48,7 @@ fn service() -> MockSolidityVerifierService {
     MockSolidityVerifierService::new()
 }
 
-// TODO: uncomment when sourcify search is fixed
-/*#[rstest]
+#[rstest]
 #[tokio::test]
 #[timeout(std::time::Duration::from_secs(60))]
 #[ignore = "Needs database to run"]
@@ -103,7 +102,7 @@ async fn search_sourcify_sources(service: MockSolidityVerifierService) {
         expected_sources, verification_response.sources,
         "Invalid sources returned"
     );
-}*/
+}
 
 #[rstest]
 #[tokio::test]
@@ -197,7 +196,7 @@ async fn search_all_sources(
     let verification_response: SearchAllSourcesResponse =
         test_server::send_post_request(&eth_bytecode_db_with_alliance_base, ROUTE, &request).await;
 
-    let _expected_sourcify_sources = match only_local {
+    let expected_sourcify_sources = match only_local {
         Some(true) => vec![],
         None | Some(false) =>
             vec![
@@ -221,9 +220,7 @@ async fn search_all_sources(
 
     let expected_response = SearchAllSourcesResponse {
         eth_bytecode_db_sources: vec![test_data.eth_bytecode_db_response.source.unwrap()],
-        // TODO: uncomment when sourcify search is fixed
-        // sourcify_sources: expected_sourcify_sources,
-        sourcify_sources: vec![],
+        sourcify_sources: expected_sourcify_sources,
         alliance_sources: vec![test_case
             .to_test_input_data()
             .eth_bytecode_db_response

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -39,7 +39,7 @@ tokio = "1.22"
 tokio-stream = { version = "0.1" }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"]}
-verification-common = { git = "https://github.com/blockscout/blockscout-rs", rev = "b855922a" }
+verification-common = { git = "https://github.com/blockscout/blockscout-rs", rev = "7a6e9400" }
 
 [dev-dependencies]
 actix-web = "4.2"


### PR DESCRIPTION
Make error in one source not to fail the whole search request. Update `sourcify` lib to the latest revision with support of updated Sourcify paths