### PR TITLE
[BENS] Add base blockscout url for protocol

### DIFF
--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -156,6 +156,8 @@ jobs:
         with:
           context: "blockscout-ens"
           file: "blockscout-ens/Dockerfile"
+          build-contexts: |
+            proto=proto
           push: ${{ steps.tags_extractor.outputs.tags != '' }}
           tags: ${{ steps.tags_extractor.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/blockscout-ens/Cargo.lock
+++ b/blockscout-ens/Cargo.lock
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "bens-server"
-version = "0.1.0"
+version = "1.3.0"
 dependencies = [
  "actix-web",
  "anyhow",

--- a/blockscout-ens/Dockerfile
+++ b/blockscout-ens/Dockerfile
@@ -9,6 +9,8 @@ COPY --from=plan /app/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 FROM chef AS build
+# Include proto common definitions (will be used in a `build-contexts` section)
+COPY --from=proto . /proto
 COPY . .
 COPY --from=cache /app/target target
 COPY --from=cache $CARGO_HOME $CARGO_HOME

--- a/blockscout-ens/bens-logic/src/protocols/domain_name.rs
+++ b/blockscout-ens/bens-logic/src/protocols/domain_name.rs
@@ -1,4 +1,5 @@
-use super::{domain_id, Protocol, ProtocolError};
+use super::{domain_id, ProtocolError};
+use crate::protocols::protocoler::DeployedProtocol;
 use ethers::types::{Address, Bytes};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -51,16 +52,19 @@ impl DomainName {
 #[derive(Debug, Clone)]
 pub struct DomainNameOnProtocol<'a> {
     pub inner: DomainName,
-    pub protocol: &'a Protocol,
+    pub deployed_protocol: DeployedProtocol<'a>,
 }
 
 impl<'a> DomainNameOnProtocol<'a> {
-    pub fn new(name: &str, protocol: &'a Protocol) -> Result<Self, ProtocolError> {
-        let name = DomainName::new(name, protocol.info.empty_label_hash.clone())?;
+    pub fn new(name: &str, protocol_network: DeployedProtocol<'a>) -> Result<Self, ProtocolError> {
+        let name = DomainName::new(
+            name,
+            protocol_network.protocol.info.empty_label_hash.clone(),
+        )?;
 
         Ok(Self {
             inner: name,
-            protocol,
+            deployed_protocol: protocol_network,
         })
     }
 }

--- a/blockscout-ens/bens-logic/src/protocols/mod.rs
+++ b/blockscout-ens/bens-logic/src/protocols/mod.rs
@@ -5,7 +5,8 @@ mod protocoler;
 pub use domain_name::{DomainName, DomainNameOnProtocol};
 pub use hash_name::domain_id;
 pub use protocoler::{
-    AddressResolveTechnique, Network, Protocol, ProtocolInfo, ProtocolMeta, Protocoler, Tld,
+    AddressResolveTechnique, DeployedProtocol, Network, Protocol, ProtocolInfo, ProtocolMeta,
+    Protocoler, Tld,
 };
 
 #[derive(thiserror::Error, Debug)]

--- a/blockscout-ens/bens-logic/src/protocols/protocoler.rs
+++ b/blockscout-ens/bens-logic/src/protocols/protocoler.rs
@@ -27,8 +27,15 @@ pub struct Protocol {
     pub subgraph_schema: String,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct DeployedProtocol<'a> {
+    pub protocol: &'a Protocol,
+    pub deployment_network: &'a Network,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct ProtocolInfo {
+    pub network_id: i64,
     pub slug: String,
     pub tld_list: NonEmpty<Tld>,
     pub subgraph_name: String,
@@ -97,6 +104,13 @@ impl Protocoler {
             }
         }
 
+        for protocol in protocols.values() {
+            let network_id = protocol.info.network_id;
+            if !networks.contains_key(&network_id) {
+                return Err(anyhow!("unknown network id {network_id}"));
+            }
+        }
+
         Ok(Self {
             networks,
             protocols,
@@ -107,15 +121,17 @@ impl Protocoler {
         self.protocols.values()
     }
 
-    pub fn protocol_by_slug(&self, slug: &str) -> Option<&Protocol> {
-        self.protocols.get(slug)
+    pub fn protocol_by_slug(&self, slug: &str) -> Option<DeployedProtocol> {
+        self.protocols
+            .get(slug)
+            .map(|protocol| protocol.deployed_on_network(self))
     }
 
     pub fn protocols_of_network(
         &self,
         network_id: i64,
         maybe_filter: Option<NonEmpty<String>>,
-    ) -> Result<(&Network, NonEmpty<&Protocol>), ProtocolError> {
+    ) -> Result<NonEmpty<DeployedProtocol<'_>>, ProtocolError> {
         let network = self
             .networks
             .get(&network_id)
@@ -124,9 +140,11 @@ impl Protocoler {
             .use_protocols
             .iter()
             .map(|name| {
-                self.protocols
+                let protocol = self
+                    .protocols
                     .get(name)
-                    .expect("protocol should be in the map")
+                    .expect("protocol should be in the map");
+                protocol.deployed_on_network(self)
             })
             .collect::<Vec<_>>();
         let net_protocols = if let Some(filter) = maybe_filter {
@@ -136,7 +154,7 @@ impl Protocoler {
                     .map(|f| {
                         net_protocols
                             .iter()
-                            .find(|&p| p.info.slug == f)
+                            .find(|&p| p.protocol.info.slug == f)
                             .copied()
                             .ok_or_else(|| ProtocolError::ProtocolNotFound(f))
                     })
@@ -146,16 +164,16 @@ impl Protocoler {
         } else {
             NonEmpty::from_vec(net_protocols).expect("build from nonempty iterator")
         };
-        Ok((network, net_protocols))
+        Ok(net_protocols)
     }
 
     pub fn main_protocol_of_network(
         &self,
         network_id: i64,
         maybe_filter: Option<NonEmpty<String>>,
-    ) -> Result<(&Network, &Protocol), ProtocolError> {
+    ) -> Result<DeployedProtocol<'_>, ProtocolError> {
         self.protocols_of_network(network_id, maybe_filter)
-            .map(|(n, p)| (n, p.head))
+            .map(|p| p.head)
     }
 
     pub fn protocols_of_network_for_tld(
@@ -163,13 +181,13 @@ impl Protocoler {
         network_id: i64,
         tld: Tld,
         maybe_filter: Option<NonEmpty<String>>,
-    ) -> Result<(&Network, Vec<&Protocol>), ProtocolError> {
-        let (network, protocols) = self.protocols_of_network(network_id, maybe_filter)?;
+    ) -> Result<Vec<DeployedProtocol<'_>>, ProtocolError> {
+        let protocols = self.protocols_of_network(network_id, maybe_filter)?;
         let protocols = protocols
             .into_iter()
-            .filter(|p| p.info.tld_list.contains(&tld))
+            .filter(|p| p.protocol.info.tld_list.contains(&tld))
             .collect();
-        Ok((network, protocols))
+        Ok(protocols)
     }
 
     pub fn names_options_in_network(
@@ -177,16 +195,15 @@ impl Protocoler {
         name: &str,
         network_id: i64,
         maybe_filter: Option<NonEmpty<String>>,
-    ) -> Result<(&Network, Vec<DomainNameOnProtocol>), ProtocolError> {
+    ) -> Result<Vec<DomainNameOnProtocol>, ProtocolError> {
         let tld = Tld::from_domain_name(name)
             .ok_or_else(|| ProtocolError::InvalidName(name.to_string()))?;
-        let (network, protocols) =
-            self.protocols_of_network_for_tld(network_id, tld, maybe_filter)?;
+        let protocols = self.protocols_of_network_for_tld(network_id, tld, maybe_filter)?;
         let names_with_protocols = protocols
             .into_iter()
-            .filter_map(|protocol| DomainNameOnProtocol::new(name, protocol).ok())
+            .filter_map(|p| DomainNameOnProtocol::new(name, p).ok())
             .collect();
-        Ok((network, names_with_protocols))
+        Ok(names_with_protocols)
     }
 
     pub fn main_name_in_network(
@@ -194,12 +211,12 @@ impl Protocoler {
         name: &str,
         network_id: i64,
         maybe_filter: Option<NonEmpty<String>>,
-    ) -> Result<(&Network, DomainNameOnProtocol), ProtocolError> {
-        let (network, maybe_name) = self
+    ) -> Result<DomainNameOnProtocol, ProtocolError> {
+        let maybe_name = self
             .names_options_in_network(name, network_id, maybe_filter)
-            .map(|(n, mut names)| (n, names.pop()))?;
+            .map(|mut names| names.pop())?;
         let name = maybe_name.ok_or_else(|| ProtocolError::InvalidName(name.to_string()))?;
-        Ok((network, name))
+        Ok(name)
     }
 
     pub fn name_in_protocol(
@@ -208,18 +225,29 @@ impl Protocoler {
         network_id: i64,
         protocol_id: &str,
         maybe_filter: Option<NonEmpty<String>>,
-    ) -> Result<(&Network, DomainNameOnProtocol), ProtocolError> {
-        let (network, protocols) = self.names_options_in_network(name, network_id, maybe_filter)?;
-        let protocol = protocols
+    ) -> Result<DomainNameOnProtocol, ProtocolError> {
+        let names = self.names_options_in_network(name, network_id, maybe_filter)?;
+        let name = names
             .into_iter()
-            .find(|p| p.protocol.info.slug == protocol_id)
+            .find(|name| name.deployed_protocol.protocol.info.slug == protocol_id)
             .ok_or_else(|| ProtocolError::ProtocolNotFound(protocol_id.to_string()))?;
-        Ok((network, protocol))
+        Ok(name)
     }
 }
 
 impl Protocol {
     pub fn subgraph_table(&self, table: &str) -> TableRef {
         (Alias::new(&self.subgraph_schema), Alias::new(table)).into_table_ref()
+    }
+
+    pub fn deployed_on_network<'a>(&'a self, protocoler: &'a Protocoler) -> DeployedProtocol<'a> {
+        let network = protocoler
+            .networks
+            .get(&self.info.network_id)
+            .expect("network should be in the map");
+        DeployedProtocol {
+            protocol: self,
+            deployment_network: network,
+        }
     }
 }

--- a/blockscout-ens/bens-logic/src/subgraphs_reader/patch.rs
+++ b/blockscout-ens/bens-logic/src/subgraphs_reader/patch.rs
@@ -61,7 +61,11 @@ pub fn patch_detailed_domain(
 }
 
 fn update_domain_name_in_background(pool: Arc<PgPool>, domain_name: DomainNameOnProtocol) {
-    let schema = domain_name.protocol.subgraph_schema.clone();
+    let schema = domain_name
+        .deployed_protocol
+        .protocol
+        .subgraph_schema
+        .clone();
     let domain_name = domain_name.inner.clone();
     tokio::spawn(async move {
         let name = domain_name.name.clone();

--- a/blockscout-ens/bens-logic/src/subgraphs_reader/types.rs
+++ b/blockscout-ens/bens-logic/src/subgraphs_reader/types.rs
@@ -1,7 +1,7 @@
 use super::pagination::{DomainPaginationInput, Order};
 use crate::{
     entity::subgraph::domain::{DetailedDomain, Domain},
-    protocols::Protocol,
+    protocols::{Network, Protocol},
 };
 use ethers::types::Address;
 use nonempty::NonEmpty;
@@ -104,6 +104,7 @@ pub struct GetDomainOutput {
     pub domain: DetailedDomain,
     pub tokens: Vec<DomainToken>,
     pub protocol: Protocol,
+    pub deployment_network: Network,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -123,4 +124,5 @@ pub enum DomainTokenType {
 pub struct LookupOutput {
     pub domain: Domain,
     pub protocol: Protocol,
+    pub deployment_network: Network,
 }

--- a/blockscout-ens/bens-logic/src/test_utils.rs
+++ b/blockscout-ens/bens-logic/src/test_utils.rs
@@ -108,6 +108,7 @@ pub async fn mocked_networks_and_protocols(
         "ens".to_string(),
         ProtocolInfo {
             slug: "ens".to_string(),
+            network_id: 1,
             tld_list: nonempty![Tld::new("eth")],
             subgraph_name: "ens-subgraph".to_string(),
             ..Default::default()

--- a/blockscout-ens/bens-proto/build.rs
+++ b/blockscout-ens/bens-proto/build.rs
@@ -71,7 +71,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ]));
     compile(
         &["proto/bens.proto", "proto/health.proto"],
-        &["proto"],
+        &["proto", "../../proto"],
         gens,
     )?;
     Ok(())

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -2,7 +2,27 @@ syntax = "proto3";
 
 package blockscout.bens.v1;
 
+import "protoc-gen-openapiv2/options/annotations.proto";
+
 option go_package = "github.com/blockscout/blockscout-rs/bens";
+
+option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
+  info: {
+    title: "Blockscout ENS";
+    version: "1.3.0";
+    contact: {
+      name: "Blockscout";
+      url: "https://blockscout.com";
+      email: "support@blockscout.com";
+    };
+  };
+  host: "bens.services.blockscout.com"
+  external_docs: {
+    url: "https://github.com/blockscout/blockscout-rs";
+    description: "More about blockscout microservices";
+  }
+};
+
 
 service DomainsExtractor {
   // Get detailed information about domain for Detailed domain page

--- a/blockscout-ens/bens-proto/proto/bens.proto
+++ b/blockscout-ens/bens-proto/proto/bens.proto
@@ -71,6 +71,7 @@ message ProtocolInfo {
   string short_name = 2;
   string title = 3;
   string description = 4;
+  string deployment_blockscout_base_url = 8;
   repeated string tld_list = 5;
   optional string icon_url = 6;
   optional string docs_url = 7;

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -545,6 +545,8 @@ definitions:
         type: string
       description:
         type: string
+      deployment_blockscout_base_url:
+        type: string
       tld_list:
         type: array
         items:

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -1,10 +1,15 @@
 swagger: "2.0"
 info:
-  title: bens.proto
-  version: version not set
+  title: Blockscout ENS
+  version: 1.3.0
+  contact:
+    name: Blockscout
+    url: https://blockscout.com
+    email: support@blockscout.com
 tags:
   - name: DomainsExtractor
   - name: Health
+host: bens.services.blockscout.com
 consumes:
   - application/json
 produces:
@@ -570,3 +575,6 @@ definitions:
       - NATIVE_DOMAIN_TOKEN
       - WRAPPED_DOMAIN_TOKEN
     default: NATIVE_DOMAIN_TOKEN
+externalDocs:
+  description: More about blockscout microservices
+  url: https://github.com/blockscout/blockscout-rs

--- a/blockscout-ens/bens-server/Cargo.toml
+++ b/blockscout-ens/bens-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bens-server"
-version = "0.1.0"
+version = "1.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/blockscout-ens/bens-server/config/prod.json
+++ b/blockscout-ens/bens-server/config/prod.json
@@ -96,6 +96,7 @@
         "tld_list": [
           "eth"
         ],
+        "network_id": 1,
         "subgraph_name": "ens-subgraph",
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
@@ -111,6 +112,7 @@
         "tld_list": [
           "gno"
         ],
+        "network_id": 100,
         "subgraph_name": "genome-subgraph",
         "address_resolve_technique": "reverse_registry",
         "empty_label_hash": "0xc4a8c56f9b0096f720f38bd557d30306dbd78f7751d277e05f062d1b85912a63",
@@ -127,6 +129,7 @@
         "tld_list": [
           "rsk"
         ],
+        "network_id": 30,
         "subgraph_name": "rns-subgraph",
         "address_resolve_technique": "all_domains",
         "native_token_contract": "0x45d3E4fB311982a06ba52359d44cB4f5980e0ef1",
@@ -142,6 +145,7 @@
         "tld_list": [
           "base"
         ],
+        "network_id": 8453,
         "subgraph_name": "base-name-service-subgraph",
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0xaCe5602d169Edeb874bfE584a651801B8ac67093",
@@ -157,6 +161,7 @@
         "tld_list": [
           "mode"
         ],
+        "network_id": 34443,
         "subgraph_name": "mode-subgraph",
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0x2ad86eeec513ac16804bb05310214c3fd496835b",
@@ -173,6 +178,7 @@
         "tld_list": [
           "ll"
         ],
+        "network_id": 1890,
         "subgraph_name": "lightlink-subgraph",
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0x5183ba1dee9770760360533cf00b9d8e26495927",
@@ -189,6 +195,7 @@
         "tld_list": [
           "poly"
         ],
+        "network_id": 137,
         "subgraph_name": "zns-subgraph",
         "address_resolve_technique": "all_domains",
         "meta": {

--- a/blockscout-ens/bens-server/config/staging.json
+++ b/blockscout-ens/bens-server/config/staging.json
@@ -7,7 +7,7 @@
           "url": "https://eth-sepolia.blockscout.com"
         },
         "use_protocols": [
-          "ens"
+          "ens", "genome", "rns", "base-name-service", "mode"
         ]
       },
       "10200": {
@@ -46,12 +46,13 @@
     "protocols": {
       "ens": {
         "tld_list": ["eth"],
+        "network_id": 11155111,
         "subgraph_name": "ens-subgraph",
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
         "meta": {
           "short_name": "ENS",
-          "title": "Ethereum Name Service",
+          "title": "Ethereum Name Service (Testnet)",
           "description": "The Ethereum Name Service (ENS) is a distributed, open, and extensible naming system based on the Ethereum blockchain.",
           "icon_url": "https://i.imgur.com/GOfUwCb.jpeg",
           "docs_url": "https://docs.ens.domains/"
@@ -59,13 +60,14 @@
       },
       "genome": {
         "tld_list": ["gno"],
+        "network_id": 10200,
         "subgraph_name": "genome-subgraph",
         "address_resolve_technique": "reverse_registry",
         "empty_label_hash": "0x1a13b687a5ff1d8ab1a9e189e1507a6abe834a9296cc8cff937905e3dee0c4f6",
         "native_token_contract": "0xfd3d666dB2557983F3F04d61f90E35cc696f6D60",
         "meta": {
           "short_name": "Genome",
-          "title": "Genome Domains",
+          "title": "Genome Domains (Testnet)",
           "description": "GNO Domains Connecting gnosis chain",
           "icon_url": "https://i.imgur.com/xlDoPfF.png",
           "docs_url": "https://genomedomains.com/"
@@ -73,12 +75,13 @@
       },
       "rns": {
         "tld_list": ["rsk"],
+        "network_id": 31,
         "subgraph_name": "rns-subgraph",
         "address_resolve_technique": "all_domains",
         "native_token_contract": "0xca0a477e19bac7e0e172ccfd2e3c28a7200bdb71",
         "meta": {
           "short_name": "RNS",
-          "title": "Rootstock Name Service",
+          "title": "Rootstock Name Service (Testnet)",
           "description": "Rootstock Name Service (RNS) is a decentralized naming service, which allows users to have a readable domain name for their addresses.",
           "icon_url": "https://i.imgur.com/o0MATMs.png",
           "docs_url": "https://dev.rootstock.io/rif/rns/"
@@ -86,12 +89,13 @@
       },
       "base-name-service": {
         "tld_list": ["base"],
+        "network_id": 84531,
         "subgraph_name": "base-name-service-subgraph",
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0x707Db367E3E1e0d503924160E32D3981AD86C80e",
         "meta": {
           "short_name": "BNS",
-          "title": "Base Name Service",
+          "title": "Base Name Service (Testnet)",
           "description": "Base Name Service (BNS) is a decentralized naming service, which allows users to have a readable domain name for their addresses.",
           "icon_url": "https://i.imgur.com/2ZZT3zl.png",
           "docs_url": "https://basename.gitbook.io/bns-docs"
@@ -99,13 +103,14 @@
       },
       "mode": {
         "tld_list": ["mode"],
+        "network_id": 919,
         "subgraph_name": "mode-subgraph",
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0xCa3a57e014937C29526De98e4A8A334a7D04792b",
         "empty_label_hash": "0xea1eb1136f380e6643b69866632ce3b493100790c9c84416f2769d996a1c38b1",
         "meta": {
           "short_name": "MNS",
-          "title": "Mode Name Service",
+          "title": "Mode Name Service (Testnet)",
           "description": "Mode Name Service (MNS) is a decentralized naming service, which allows users to have a readable domain name for their addresses.",
           "icon_url": "https://i.imgur.com/6QXp70g.png",
           "docs_url": "https://docs.modedomains.xyz/"

--- a/blockscout-ens/bens-server/src/conversion/domain.rs
+++ b/blockscout-ens/bens-server/src/conversion/domain.rs
@@ -125,6 +125,7 @@ pub fn detailed_domain_from_logic(
 ) -> Result<proto::DetailedDomain, ConversionError> {
     let domain = output.domain;
     let protocol = output.protocol;
+    let network = output.deployment_network;
     let owner = Some(address_from_str_logic(&domain.owner, chain_id)?);
     let resolved_address = domain
         .resolved_address
@@ -144,7 +145,7 @@ pub fn detailed_domain_from_logic(
         .into_iter()
         .map(|t| domain_token_from_logic(t, chain_id))
         .collect();
-    let protocol = Some(protocol_from_logic(protocol));
+    let protocol = Some(protocol_from_logic(protocol, network));
     Ok(proto::DetailedDomain {
         id: domain.id,
         name: domain.name.unwrap_or_default(),
@@ -174,7 +175,10 @@ pub fn domain_from_logic(
         .wrapped_owner
         .map(|wrapped_owner| address_from_str_logic(&wrapped_owner, chain_id))
         .transpose()?;
-    let protocol = Some(protocol_from_logic(output.protocol));
+    let protocol = Some(protocol_from_logic(
+        output.protocol,
+        output.deployment_network,
+    ));
     Ok(proto::Domain {
         id: domain.id,
         name: domain.name.unwrap_or_default(),

--- a/blockscout-ens/bens-server/src/conversion/protocol.rs
+++ b/blockscout-ens/bens-server/src/conversion/protocol.rs
@@ -1,12 +1,13 @@
-use bens_logic::protocols::Protocol;
+use bens_logic::protocols::{Network, Protocol};
 use bens_proto::blockscout::bens::v1 as proto;
 
-pub fn protocol_from_logic(p: Protocol) -> proto::ProtocolInfo {
+pub fn protocol_from_logic(p: Protocol, n: Network) -> proto::ProtocolInfo {
     proto::ProtocolInfo {
         id: p.info.slug,
         short_name: p.info.meta.short_name,
         title: p.info.meta.title,
         description: p.info.meta.description,
+        deployment_blockscout_base_url: n.blockscout_client.url().to_string(),
         icon_url: p.info.meta.icon_url,
         docs_url: p.info.meta.docs_url,
         tld_list: p.info.tld_list.into_iter().map(|tld| tld.0).collect(),

--- a/blockscout-ens/bens-server/src/server.rs
+++ b/blockscout-ens/bens-server/src/server.rs
@@ -98,6 +98,7 @@ pub async fn run(settings: Settings) -> Result<(), anyhow::Error> {
                 name.clone(),
                 ProtocolInfo {
                     slug: name,
+                    network_id: p.network_id,
                     tld_list: p.tld_list,
                     subgraph_name: p.subgraph_name,
                     address_resolve_technique: p.address_resolve_technique,

--- a/blockscout-ens/bens-server/src/settings.rs
+++ b/blockscout-ens/bens-server/src/settings.rs
@@ -56,8 +56,10 @@ impl Default for SubgraphsReaderSettings {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct ProtocolSettings {
     pub tld_list: NonEmpty<Tld>,
+    pub network_id: i64,
     pub subgraph_name: String,
     #[serde(default)]
     pub address_resolve_technique: AddressResolveTechnique,
@@ -71,6 +73,7 @@ pub struct ProtocolSettings {
 pub struct ProtocolSettingsMeta(pub ProtocolMeta);
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NetworkSettings {
     pub blockscout: BlockscoutSettings,
     #[serde(default)]

--- a/blockscout-ens/bens-server/tests/config.test.json
+++ b/blockscout-ens/bens-server/tests/config.test.json
@@ -39,9 +39,8 @@
     "protocols": {
       "ens": {
         "tld_list": ["eth"],
-        "ordinal": 0,
+        "network_id": 1,
         "subgraph_name": "ens-subgraph",
-        "use_cache": true,
         "address_resolve_technique": "reverse_registry",
         "native_token_contract": "0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85",
         "meta": {
@@ -52,9 +51,8 @@
       },
       "genome": {
         "tld_list": ["gno"],
-        "ordinal": 1,
+        "network_id": 10200,
         "subgraph_name": "genome-subgraph",
-        "use_cache": false,
         "address_resolve_technique": "reverse_registry",
         "empty_label_hash": "0x1a13b687a5ff1d8ab1a9e189e1507a6abe834a9296cc8cff937905e3dee0c4f6",
         "native_token_contract": "0xfd3d666dB2557983F3F04d61f90E35cc696f6D60",

--- a/blockscout-ens/bens-server/tests/data/context.json
+++ b/blockscout-ens/bens-server/tests/data/context.json
@@ -6,7 +6,8 @@
     "description": "ens description",
     "tld_list": ["eth"],
     "icon_url": null,
-    "docs_url": null
+    "docs_url": null,
+    "deployment_blockscout_base_url": "{{ens_base_url}}"
   },
   "genome_protocol": {
     "id": "genome",
@@ -15,6 +16,7 @@
     "description": "genome description",
     "tld_list": ["gno"],
     "icon_url": null,
-    "docs_url": null
+    "docs_url": null,
+    "deployment_blockscout_base_url": "{{genome_base_url}}"
   }
 }

--- a/blockscout-ens/justfile
+++ b/blockscout-ens/justfile
@@ -11,6 +11,9 @@ export DATABASE_URL := "postgres://" + db-user + ":" + db-password + "@" + db-ho
 docker-name := env_var_or_default('DOCKER_NAME', "bens-postgres")
 test-db-port := env_var_or_default('TEST_DB_PORT', "9433")
 
+docker-build *args:
+    docker build --build-context proto=../proto . {{args}}
+
 start-postgres:
     # we run it in --rm mode, so all data will be deleted after stopping
     docker run -p {{db-port}}:5432 --name {{docker-name}} -e POSTGRES_PASSWORD={{db-password}} -e POSTGRES_USER={{db-user}} --rm -d postgres -N 500


### PR DESCRIPTION
After we added multiprotocol feature, network A, that connected to protocol P, doesnt know that P is deployed on network B. Therefore domain history links and domain NFT links doesn't work properly (they lead to network A instead of network B)

This PR faced this problem and return `base_blockscout_url` inside protocol information

Also, changed swagger to use commom `proto` directory