### PR TITLE
Fix "Publish to NPM" workflow

### DIFF
--- a/.github/workflows/npm-publisher.yml
+++ b/.github/workflows/npm-publisher.yml
@@ -28,6 +28,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     name: Publish package to NPM registry
+    permissions:
+        id-token: write
 
     steps:
         - name: Checkout repo

--- a/.github/workflows/npm-publisher.yml
+++ b/.github/workflows/npm-publisher.yml
@@ -40,6 +40,9 @@ jobs:
             node-version: '20.x'
             registry-url: 'https://registry.npmjs.org'
 
+        - name: Install Protoc
+          uses: arduino/setup-protoc@v3
+
         - name: Update package version
           run: |
             cd ./${{ inputs.project_name }}/types


### PR DESCRIPTION
I forgot to install `protoc` in the GitHub CI pipeline 😓. This Pull Request fixes it.