### PR TITLE
[DISPLAY_BYTES] Make helper methods public

### DIFF
--- a/libs/display-bytes/Cargo.toml
+++ b/libs/display-bytes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-display-bytes"
-version = "1.0.0"
+version = "1.1.0"
 description = "Wrapper type around Bytes to deserialize/serialize \"0x\" prefixed hex strings."
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/display-bytes/Cargo.toml
+++ b/libs/display-bytes/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["encoding"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1.3"
+bytes = "1"
 ethers-core = { version = "1.0", optional = true}
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/libs/display-bytes/Cargo.toml
+++ b/libs/display-bytes/Cargo.toml
@@ -15,4 +15,6 @@ bytes = "1"
 ethers-core = { version = "1.0", optional = true}
 hex = "0.4"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_with = "3.0"
 thiserror = "1.0"

--- a/libs/display-bytes/src/bytes.rs
+++ b/libs/display-bytes/src/bytes.rs
@@ -148,13 +148,9 @@ impl FromStr for Bytes {
     type Err = ParseBytesError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if let Some(value) = value.strip_prefix("0x") {
-            hex::decode(value)
-        } else {
-            hex::decode(value)
-        }
-        .map(Into::into)
-        .map_err(|e| ParseBytesError(format!("Invalid hex: {e}")))
+        super::decode_hex(value)
+            .map(Into::into)
+            .map_err(|e| ParseBytesError(format!("Invalid hex: {e}")))
     }
 }
 
@@ -171,13 +167,9 @@ where
     D: Deserializer<'de>,
 {
     let value = String::deserialize(d)?;
-    if let Some(value) = value.strip_prefix("0x") {
-        hex::decode(value)
-    } else {
-        hex::decode(&value)
-    }
-    .map(Into::into)
-    .map_err(|e| serde::de::Error::custom(e.to_string()))
+    super::decode_hex(&value)
+        .map(Into::into)
+        .map_err(|e| serde::de::Error::custom(e.to_string()))
 }
 
 #[cfg(test)]

--- a/libs/display-bytes/src/lib.rs
+++ b/libs/display-bytes/src/lib.rs
@@ -1,7 +1,31 @@
 #[cfg(feature = "ethers-core")]
 pub use ethers_core::types::Bytes;
+#[cfg(feature = "ethers-core")]
+pub use ethers_core::types::{deserialize_bytes, serialize_bytes};
 
 #[cfg(not(feature = "ethers-core"))]
 mod bytes;
 #[cfg(not(feature = "ethers-core"))]
 pub use crate::bytes::Bytes;
+#[cfg(not(feature = "ethers-core"))]
+pub use crate::bytes::{deserialize_bytes, serialize_bytes};
+
+/// Allows to decode both "0x"-prefixed and non-prefixed hex strings
+pub fn decode_hex(value: &str) -> Result<Vec<u8>, hex::FromHexError> {
+    if let Some(value) = value.strip_prefix("0x") {
+        hex::decode(value)
+    } else {
+        hex::decode(value)
+    }
+}
+
+pub trait ToHex {
+    /// Encodes given value as "0x"-prefixed hex string
+    fn to_hex(&self) -> String;
+}
+
+impl<T: AsRef<[u8]>> ToHex for T {
+    fn to_hex(&self) -> String {
+        format!("0x{}", hex::encode(self))
+    }
+}

--- a/libs/display-bytes/src/lib.rs
+++ b/libs/display-bytes/src/lib.rs
@@ -1,14 +1,12 @@
 #[cfg(feature = "ethers-core")]
 pub use ethers_core::types::Bytes;
-#[cfg(feature = "ethers-core")]
-pub use ethers_core::types::{deserialize_bytes, serialize_bytes};
 
 #[cfg(not(feature = "ethers-core"))]
 mod bytes;
 #[cfg(not(feature = "ethers-core"))]
 pub use crate::bytes::Bytes;
-#[cfg(not(feature = "ethers-core"))]
-pub use crate::bytes::{deserialize_bytes, serialize_bytes};
+
+pub mod serde_as;
 
 /// Allows to decode both "0x"-prefixed and non-prefixed hex strings
 pub fn decode_hex(value: &str) -> Result<Vec<u8>, hex::FromHexError> {
@@ -20,12 +18,20 @@ pub fn decode_hex(value: &str) -> Result<Vec<u8>, hex::FromHexError> {
 }
 
 pub trait ToHex {
-    /// Encodes given value as "0x"-prefixed hex string
+    /// Encodes given value as "0x"-prefixed hex string using lowercase characters
     fn to_hex(&self) -> String;
+
+    fn to_hex_upper(&self) -> String {
+        self.to_hex().to_uppercase()
+    }
 }
 
 impl<T: AsRef<[u8]>> ToHex for T {
     fn to_hex(&self) -> String {
         format!("0x{}", hex::encode(self))
+    }
+
+    fn to_hex_upper(&self) -> String {
+        format!("0x{}", hex::encode_upper(self))
     }
 }

--- a/libs/display-bytes/src/serde_as.rs
+++ b/libs/display-bytes/src/serde_as.rs
@@ -1,0 +1,146 @@
+//! De/Serialization of hexadecimal encoded bytes with "0x" prefix
+//!
+//! Adapted from `serde_with::hex` (https://docs.rs/serde_with/3.8.1/serde_with/hex/index.html)
+//!
+//! Please check the documentation on the [`Hex`] type for details.
+
+use serde_with::formats;
+use serde_with::{SerializeAs, DeserializeAs};
+use serde::{Serializer, Deserializer, Deserialize, de::Error as DeError};
+use std::marker::PhantomData;
+use std::borrow::Cow;
+use crate::ToHex;
+
+/// Serialize bytes as a hex string
+///
+/// The type serializes a sequence of bytes as a hexadecimal string.
+/// It works on any type implementing `AsRef<[u8]>` for serialization and `TryFrom<Vec<u8>>` for deserialization.
+///
+/// The format type parameter specifies if the hex string should use lower- or uppercase characters.
+/// Valid options are the types [`formats::Lowercase`] and [`formats::Uppercase`].
+/// Deserialization always supports lower- and uppercase characters, even mixed in one string.
+///
+/// # Example
+///
+/// ```rust
+/// # use serde::{Deserialize, Serialize};
+/// # use serde_json::json;
+/// # use serde_with::serde_as;
+/// #
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq, Eq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct BytesLowercase(
+///     // Equivalent to blockscout_display_bytes::serde_as::Hex<serde_with::formats::Lowercase>
+///     #[serde_as(as = "blockscout_display_bytes::serde_as::Hex")]
+///     Vec<u8>
+/// );
+///
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq, Eq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct BytesUppercase(
+///     #[serde_as(as = "blockscout_display_bytes::serde_as::Hex<serde_with::formats::Uppercase>")]
+///     Vec<u8>
+/// );
+///
+/// let b = b"Hello World!";
+///
+/// // Hex with lowercase letters
+/// assert_eq!(
+///     json!("0x48656c6c6f20576f726c6421"),
+///     serde_json::to_value(BytesLowercase(b.to_vec())).unwrap()
+/// );
+/// // Hex with uppercase letters
+/// assert_eq!(
+///     json!("0x48656C6C6F20576F726C6421"),
+///     serde_json::to_value(BytesUppercase(b.to_vec())).unwrap()
+/// );
+///
+/// // Serialization always work from lower- and uppercase characters, even mixed case.
+/// assert_eq!(
+///     BytesLowercase(vec![0x00, 0xaa, 0xbc, 0x99, 0xff]),
+///     serde_json::from_value(json!("00aAbc99FF")).unwrap()
+/// );
+/// assert_eq!(
+///     BytesUppercase(vec![0x00, 0xaa, 0xbc, 0x99, 0xff]),
+///     serde_json::from_value(json!("00aAbc99FF")).unwrap()
+/// );
+///
+/// #[serde_as]
+/// # #[derive(Debug, PartialEq, Eq)]
+/// #[derive(Deserialize, Serialize)]
+/// struct ByteArray(
+///     // Equivalent to serde_with::hex::Hex<serde_with::formats::Lowercase>
+///     #[serde_as(as = "blockscout_display_bytes::serde_as::Hex")]
+///     [u8; 12]
+/// );
+///
+/// let b = *b"Hello World!";
+///
+/// assert_eq!(
+///     json!("0x48656c6c6f20576f726c6421"),
+///     serde_json::to_value(ByteArray(b)).unwrap()
+/// );
+///
+/// // Serialization always work from lower- and uppercase characters, even mixed case.
+/// assert_eq!(
+///     ByteArray([0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0xaa, 0xbc, 0x99, 0xff]),
+///     serde_json::from_value(json!("0x0011223344556677aAbc99FF")).unwrap()
+/// );
+///
+/// // Remember that the conversion may fail. (The following errors are specific to fixed-size arrays)
+/// let error_result: Result<ByteArray, _> = serde_json::from_value(json!("42")); // Too short
+/// error_result.unwrap_err();
+///
+/// let error_result: Result<ByteArray, _> =
+///     serde_json::from_value(json!("0x000000000000000000000000000000")); // Too long
+/// error_result.unwrap_err();
+/// ```
+pub struct Hex<FORMAT: formats::Format = formats::Lowercase>(PhantomData<FORMAT>);
+
+impl<T> SerializeAs<T> for Hex<formats::Lowercase>
+    where
+        T: AsRef<[u8]>,
+{
+    fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(&ToHex::to_hex(source))
+    }
+}
+
+impl<T> SerializeAs<T> for Hex<formats::Uppercase>
+    where
+        T: AsRef<[u8]>,
+{
+    fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(&ToHex::to_hex_upper(source))
+    }
+}
+
+impl<'de, T, FORMAT> DeserializeAs<'de, T> for Hex<FORMAT>
+    where
+        T: TryFrom<Vec<u8>>,
+        FORMAT: formats::Format,
+{
+    fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        <Cow<'de, str> as Deserialize<'de>>::deserialize(deserializer)
+            .and_then(|s| crate::decode_hex(s.as_ref()).map_err(DeError::custom))
+            .and_then(|vec: Vec<u8>| {
+                let length = vec.len();
+                vec.try_into().map_err(|_e: T::Error| {
+                    DeError::custom(format_args!(
+                        "Can't convert a Byte Vector of length {length} to the output type."
+                    ))
+                })
+            })
+    }
+}

--- a/libs/display-bytes/src/serde_as.rs
+++ b/libs/display-bytes/src/serde_as.rs
@@ -4,12 +4,10 @@
 //!
 //! Please check the documentation on the [`Hex`] type for details.
 
-use serde_with::formats;
-use serde_with::{SerializeAs, DeserializeAs};
-use serde::{Serializer, Deserializer, Deserialize, de::Error as DeError};
-use std::marker::PhantomData;
-use std::borrow::Cow;
 use crate::ToHex;
+use serde::{de::Error as DeError, Deserialize, Deserializer, Serializer};
+use serde_with::{formats, DeserializeAs, SerializeAs};
+use std::{borrow::Cow, marker::PhantomData};
 
 /// Serialize bytes as a hex string
 ///
@@ -100,37 +98,37 @@ use crate::ToHex;
 pub struct Hex<FORMAT: formats::Format = formats::Lowercase>(PhantomData<FORMAT>);
 
 impl<T> SerializeAs<T> for Hex<formats::Lowercase>
-    where
-        T: AsRef<[u8]>,
+where
+    T: AsRef<[u8]>,
 {
     fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&ToHex::to_hex(source))
     }
 }
 
 impl<T> SerializeAs<T> for Hex<formats::Uppercase>
-    where
-        T: AsRef<[u8]>,
+where
+    T: AsRef<[u8]>,
 {
     fn serialize_as<S>(source: &T, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
+    where
+        S: Serializer,
     {
         serializer.serialize_str(&ToHex::to_hex_upper(source))
     }
 }
 
 impl<'de, T, FORMAT> DeserializeAs<'de, T> for Hex<FORMAT>
-    where
-        T: TryFrom<Vec<u8>>,
-        FORMAT: formats::Format,
+where
+    T: TryFrom<Vec<u8>>,
+    FORMAT: formats::Format,
 {
     fn deserialize_as<D>(deserializer: D) -> Result<T, D::Error>
-        where
-            D: Deserializer<'de>,
+    where
+        D: Deserializer<'de>,
     {
         <Cow<'de, str> as Deserialize<'de>>::deserialize(deserializer)
             .and_then(|s| crate::decode_hex(s.as_ref()).map_err(DeError::custom))


### PR DESCRIPTION
Makes methods related to serialization and deserialization of "0x"-prefixed hex strings public, so they can be used from other crates without explicit use of `blockscout_display_bytes::Bytes` struct