### PR TITLE
Fix usage of "npm-publisher" workflow

### DIFF
--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -119,6 +119,8 @@ jobs:
       (needs.lint.result == 'success' || needs.lint.result == 'cancelled')
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    outputs:
+      semver: ${{ steps.regex.outputs.group2 }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -165,10 +167,11 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:build-cache
           cache-to: ${{ github.ref == 'refs/heads/main' && format('type=registry,ref={0}/{1}:build-cache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
 
-      - name: Publish types package
-        uses: './.github/workflows/npm-publisher.yml'
-        if: steps.regex.outputs.group2 != ''
-        continue-on-error: true
-        with:
-          version: ${{ steps.regex.outputs.group2 }}
-          project_name: blockscout-ens
+  publish_types_package:
+    name: Publish types package
+    uses: './.github/workflows/npm-publisher.yml'
+    needs: push
+    if: needs.push.outputs.semver != ''
+    with:
+      version: ${{ needs.push.outputs.semver }}
+      project_name: blockscout-ens


### PR DESCRIPTION
In the recent BENS release the "npm-publisher" workflow [failed to run](https://github.com/blockscout/blockscout-rs/actions/runs/9549139652/job/26318271312). Apparently, that's because the reusable workflows [can only be run as a separate job](https://github.com/blockscout/blockscout-rs/actions/runs/9549139652/job/26318271312), not as a job step. 😓🙈

> "Tom, you gotta read the docs more carefully!" 😂

This code change should fix it. 🤞