### PR TITLE
[launcher] Update test server runner

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.12.0"
+version = "0.12.1"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/test_server.rs
+++ b/libs/blockscout-service-launcher/src/test_server.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
     time::Duration,
 };
-use tokio::time::timeout;
+use tokio::{task::JoinHandle, time::timeout};
 
 fn get_free_port() -> u16 {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
@@ -22,7 +22,7 @@ pub fn get_test_server_settings() -> (ServerSettings, Url) {
     (server, base)
 }
 
-pub async fn init_server<F, R>(run: F, base: &Url)
+pub async fn init_server<F, R>(run: F, base: &Url) -> JoinHandle<Result<(), anyhow::Error>>
 where
     F: FnOnce() -> R + Send + 'static,
     R: Future<Output = Result<(), anyhow::Error>> + Send,
@@ -58,6 +58,8 @@ where
             }
         }
     }
+
+    server_handle
 }
 
 async fn send_annotated_request<Response: for<'a> serde::Deserialize<'a>>(


### PR DESCRIPTION
Update test_server runner to print more detailed messages if server did not start successfully. Should print a more detailed reason, why server wasn't been able to start in time instead of just "Server did not start in time" message.

Make `init_server` method return the handle of the server, in case the client would like to terminate the server manually
