### PR TITLE
Pass secrets to "NPM publisher" workflow while calling it from "BENS release" workflow

### DIFF
--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -172,6 +172,7 @@ jobs:
     uses: './.github/workflows/npm-publisher.yml'
     needs: push
     if: needs.push.outputs.semver != ''
+    secrets: inherit
     with:
       version: ${{ needs.push.outputs.semver }}
       project_name: blockscout-ens

--- a/blockscout-ens/types/package.json
+++ b/blockscout-ens/types/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/blockscout/blockscout-rs.git",
+    "url": "git+https://github.com/blockscout/blockscout-rs.git",
     "directory": "blockscout-ens/types"
   },
   "license": "MIT",


### PR DESCRIPTION
The [recent run](https://github.com/blockscout/blockscout-rs/actions/runs/9665627566/job/26663290584) of the "NPM publisher" workflow failed during the call from the "BENS release" workflow. While [stand-alone run](https://github.com/blockscout/blockscout-rs/actions/runs/9675593934) works fine, it seems like we need to inherit secrets from a caller workflow [explicitly](https://github.com/blockscout/blockscout-rs/actions/runs/9675593934).

This pull request aims to address the authentication issue and correct errors in the `package.json` file.