### PR TITLE
fix(stats): incorrect last point of previous batch step (force update)

### DIFF
--- a/stats/stats/justfile
+++ b/stats/stats/justfile
@@ -28,7 +28,7 @@ stop-postgres:
     docker kill {{docker-name}}
 
 test *args:
-    cargo test {{args}} -- --include-ignored
+    cargo test {{args}} -- --include-ignored --nocapture
 
 test-with-db *args:
     # remove db from previous run (if failed)

--- a/stats/stats/src/charts/counters/mock.rs
+++ b/stats/stats/src/charts/counters/mock.rs
@@ -7,9 +7,9 @@ use crate::{
             local_db::DirectPointLocalDbChartSource,
             remote_db::{QueryBehaviour, RemoteDatabaseSource},
         },
+        types::Get,
         UpdateContext,
     },
-    tests::types::Get,
     ChartProperties, DateValueString, Named, UpdateError,
 };
 

--- a/stats/stats/src/charts/counters/mock.rs
+++ b/stats/stats/src/charts/counters/mock.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, ops::RangeInclusive};
+use std::{marker::PhantomData, ops::Range};
 
 use crate::{
     charts::db_interaction::types::DateValue,
@@ -31,7 +31,7 @@ where
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        _range: Option<RangeInclusive<DateTimeUtc>>,
+        _range: Option<Range<DateTimeUtc>>,
     ) -> Result<Self::Output, UpdateError> {
         if cx.time >= PointDateTime::get() {
             Ok(DateValueString::from_parts(

--- a/stats/stats/src/charts/counters/total_blocks.rs
+++ b/stats/stats/src/charts/counters/total_blocks.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     data_source::{
@@ -29,7 +29,7 @@ impl QueryBehaviour for TotalBlocksQueryBehaviour {
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        _range: Option<RangeInclusive<DateTimeUtc>>,
+        _range: Option<Range<DateTimeUtc>>,
     ) -> Result<Self::Output, UpdateError> {
         let data = blocks::Entity::find()
             .select_only()

--- a/stats/stats/src/charts/counters/total_contracts.rs
+++ b/stats/stats/src/charts/counters/total_contracts.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     data_source::{
@@ -21,7 +21,7 @@ impl QueryBehaviour for TotalContractsQueryBehaviour {
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        _range: Option<RangeInclusive<DateTimeUtc>>,
+        _range: Option<Range<DateTimeUtc>>,
     ) -> Result<Self::Output, UpdateError> {
         let value = addresses::Entity::find()
             .filter(addresses::Column::ContractCode.is_not_null())

--- a/stats/stats/src/charts/lines/active_accounts.rs
+++ b/stats/stats/src/charts/lines/active_accounts.rs
@@ -1,6 +1,6 @@
 //! Active accounts on each day.
 
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     data_source::kinds::{
@@ -17,7 +17,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct ActiveAccountsStatement;
 
 impl StatementFromRange for ActiveAccountsStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/average_block_rewards.rs
+++ b/stats/stats/src/charts/lines/average_block_rewards.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueDouble,
@@ -19,7 +19,7 @@ const ETH: i64 = 1_000_000_000_000_000_000;
 pub struct AverageBlockRewardsQuery;
 
 impl StatementFromRange for AverageBlockRewardsQuery {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/average_block_size.rs
+++ b/stats/stats/src/charts/lines/average_block_size.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     data_source::kinds::{
@@ -15,7 +15,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct AverageBlockSizeStatement;
 
 impl StatementFromRange for AverageBlockSizeStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/average_gas_limit.rs
+++ b/stats/stats/src/charts/lines/average_gas_limit.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     data_source::kinds::{
@@ -15,7 +15,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct AverageGasLimitStatement;
 
 impl StatementFromRange for AverageGasLimitStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/average_gas_price.rs
+++ b/stats/stats/src/charts/lines/average_gas_price.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueDouble,
@@ -19,7 +19,7 @@ const GWEI: i64 = 1_000_000_000;
 pub struct AverageGasPriceStatement;
 
 impl StatementFromRange for AverageGasPriceStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/average_txn_fee.rs
+++ b/stats/stats/src/charts/lines/average_txn_fee.rs
@@ -1,6 +1,6 @@
 //! Average fee per transaction
 
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueDouble,
@@ -21,7 +21,7 @@ const ETHER: i64 = i64::pow(10, 18);
 pub struct AverageTxnFeeStatement;
 
 impl StatementFromRange for AverageTxnFeeStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/gas_used_growth.rs
+++ b/stats/stats/src/charts/lines/gas_used_growth.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueDecimal,
@@ -17,7 +17,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct GasUsedPartialStatement;
 
 impl StatementFromRange for GasUsedPartialStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/mock.rs
+++ b/stats/stats/src/charts/lines/mock.rs
@@ -4,10 +4,10 @@ use crate::{
             local_db::DirectVecLocalDbChartSource,
             remote_db::{QueryBehaviour, RemoteDatabaseSource},
         },
+        types::Get,
         UpdateContext,
     },
     missing_date::fit_into_range,
-    tests::types::Get,
     ChartProperties, DateValueString, MissingDatePolicy, Named, UpdateError,
 };
 

--- a/stats/stats/src/charts/lines/mock.rs
+++ b/stats/stats/src/charts/lines/mock.rs
@@ -15,11 +15,7 @@ use chrono::{Duration, NaiveDate};
 use entity::sea_orm_active_enums::ChartType;
 use rand::{distributions::uniform::SampleUniform, rngs::StdRng, Rng, SeedableRng};
 use sea_orm::prelude::*;
-use std::{
-    marker::PhantomData,
-    ops::{Range, RangeInclusive},
-    str::FromStr,
-};
+use std::{marker::PhantomData, ops::Range, str::FromStr};
 
 fn generate_intervals(mut start: NaiveDate, end: NaiveDate) -> Vec<NaiveDate> {
     let mut times = vec![];
@@ -64,16 +60,16 @@ where
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        range: Option<RangeInclusive<DateTimeUtc>>,
+        range: Option<Range<DateTimeUtc>>,
     ) -> Result<Vec<DateValueString>, UpdateError> {
         let date_range_start = if let Some(r) = range.clone() {
-            *r.start()
+            r.start
         } else {
             DateTimeUtc::MIN_UTC
         };
         let mut date_range_end = cx.time;
         if let Some(r) = range {
-            date_range_end = date_range_end.min(*r.end())
+            date_range_end = date_range_end.min(r.end)
         }
         let full_data = mocked_lines(ValueRange::get());
         let data = fit_into_range(

--- a/stats/stats/src/charts/lines/native_coin_supply.rs
+++ b/stats/stats/src/charts/lines/native_coin_supply.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueDouble,
@@ -19,11 +19,11 @@ const ETH: i64 = 1_000_000_000_000_000_000;
 pub struct NativeCoinSupplyStatement;
 
 impl StatementFromRange for NativeCoinSupplyStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
-        let day_range: Option<RangeInclusive<NaiveDate>> = range.map(|r| {
-            let (start, end) = r.into_inner();
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
+        let day_range: Option<Range<NaiveDate>> = range.map(|r| {
+            let Range { start, end } = r;
             // chart is off anyway, so shouldn't be a big deal
-            start.date_naive()..=end.date_naive()
+            start.date_naive()..end.date_naive()
         });
         // query uses date, therefore `sql_with_range_filter_opt` does not quite fit
         // (making it parameter-agnostic seems not straightforward, let's keep it as-is)
@@ -49,7 +49,7 @@ impl StatementFromRange for NativeCoinSupplyStatement {
                     ) as intermediate
                     WHERE value is not NULL;
                 ",
-                vec![ETH.into(), (*range.start()).into(), (*range.end()).into()],
+                vec![ETH.into(), range.start.into(), range.end.into()],
             ),
             None => Statement::from_sql_and_values(
                 DbBackend::Postgres,

--- a/stats/stats/src/charts/lines/new_accounts.rs
+++ b/stats/stats/src/charts/lines/new_accounts.rs
@@ -115,6 +115,7 @@ pub type NewAccounts = LocalDbChartSource<
         PassVecStep,
         // see `NewAccountsRemote` docs
         BatchMax,
+        DefaultQueryVec<Properties>,
         Properties,
     >,
     DefaultQueryVec<Properties>,

--- a/stats/stats/src/charts/lines/new_accounts.rs
+++ b/stats/stats/src/charts/lines/new_accounts.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueInt,
@@ -30,13 +30,13 @@ use sea_orm::{prelude::*, DbBackend, FromQueryResult, Statement};
 pub struct NewAccountsStatement;
 
 impl StatementFromRange for NewAccountsStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         // `MIN_UTC` does not fit into postgres' timestamp. Unix epoch start should be enough
         let min_timestamp = DateTimeUtc::UNIX_EPOCH;
         // All transactions from the beginning must be considered to calculate new accounts correctly.
         // E.g. if account was first active both before `range.start()` and within the range,
         // we don't want to count it within the range (as it's not a *new* account).
-        let range = range.map(|r| (min_timestamp..=r.into_inner().1));
+        let range = range.map(|r| (min_timestamp..r.end));
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"
@@ -69,7 +69,7 @@ impl QueryBehaviour for NewAccountsQueryBehaviour {
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        range: Option<RangeInclusive<DateTimeUtc>>,
+        range: Option<Range<DateTimeUtc>>,
     ) -> Result<Vec<DateValueString>, UpdateError> {
         let query = NewAccountsStatement::get_statement(range.clone());
         let mut data = DateValueString::find_by_statement(query)
@@ -79,7 +79,7 @@ impl QueryBehaviour for NewAccountsQueryBehaviour {
         // make sure that it's sorted
         data.sort_by_key(|d| d.date);
         if let Some(range) = range {
-            let range = range.start().date_naive()..=range.end().date_naive();
+            let range = range.start.date_naive()..=range.end.date_naive();
             trim_out_of_range_sorted(&mut data, range);
         }
         Ok(data)

--- a/stats/stats/src/charts/lines/new_blocks.rs
+++ b/stats/stats/src/charts/lines/new_blocks.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     data_source::kinds::{
@@ -14,7 +14,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct NewBlocksStatement;
 
 impl StatementFromRange for NewBlocksStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/new_contracts.rs
+++ b/stats/stats/src/charts/lines/new_contracts.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueInt,
@@ -16,7 +16,7 @@ use sea_orm::{prelude::DateTimeUtc, DbBackend, Statement};
 pub struct NewContractsStatement;
 
 impl StatementFromRange for NewContractsStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/new_native_coin_transfers.rs
+++ b/stats/stats/src/charts/lines/new_native_coin_transfers.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueInt,
@@ -16,7 +16,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct NewNativeCoinTransfersStatement;
 
 impl StatementFromRange for NewNativeCoinTransfersStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/new_txns.rs
+++ b/stats/stats/src/charts/lines/new_txns.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueInt,
@@ -16,7 +16,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct NewTxnsStatement;
 
 impl StatementFromRange for NewTxnsStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/new_verified_contracts.rs
+++ b/stats/stats/src/charts/lines/new_verified_contracts.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueInt,
@@ -16,7 +16,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct NewVerifiedContractsStatement;
 
 impl StatementFromRange for NewVerifiedContractsStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/txns_fee.rs
+++ b/stats/stats/src/charts/lines/txns_fee.rs
@@ -1,6 +1,6 @@
 //! Total transaction fees for an interval
 
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueDouble,
@@ -20,7 +20,7 @@ const ETHER: i64 = i64::pow(10, 18);
 pub struct TxnsFeeStatement;
 
 impl StatementFromRange for TxnsFeeStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/charts/lines/txns_success_rate.rs
+++ b/stats/stats/src/charts/lines/txns_success_rate.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use crate::{
     charts::db_interaction::types::DateValueDouble,
@@ -16,7 +16,7 @@ use sea_orm::{prelude::*, DbBackend, Statement};
 pub struct TxnsSuccessRateStatement;
 
 impl StatementFromRange for TxnsSuccessRateStatement {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/data_source/kinds/auxiliary/cumulative.rs
+++ b/stats/stats/src/data_source/kinds/auxiliary/cumulative.rs
@@ -42,7 +42,7 @@ where
 
     async fn query_data(
         cx: &crate::data_source::UpdateContext<'_>,
-        range: Option<std::ops::RangeInclusive<sea_orm::prelude::DateTimeUtc>>,
+        range: Option<std::ops::Range<sea_orm::prelude::DateTimeUtc>>,
         dependency_data_fetch_timer: &mut blockscout_metrics_tools::AggregateTimer,
     ) -> Result<Self::Output, crate::UpdateError> {
         let delta_data = Delta::query_data(cx, range, dependency_data_fetch_timer).await?;

--- a/stats/stats/src/data_source/kinds/data_manipulation/delta.rs
+++ b/stats/stats/src/data_source/kinds/data_manipulation/delta.rs
@@ -6,7 +6,7 @@
 use std::{
     fmt::Display,
     marker::PhantomData,
-    ops::{RangeInclusive, SubAssign},
+    ops::{Range, SubAssign},
     str::FromStr,
 };
 
@@ -60,16 +60,16 @@ where
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        range: Option<RangeInclusive<DateTimeUtc>>,
+        range: Option<Range<DateTimeUtc>>,
         dependency_data_fetch_timer: &mut AggregateTimer,
     ) -> Result<Self::Output, UpdateError> {
         let request_range = range.clone().map(|r| {
             let start = r
-                .start()
+                .start
                 .checked_sub_signed(TimeDelta::days(1))
                 .unwrap_or(DateTime::<Utc>::MAX_UTC);
-            let end = *r.end();
-            start..=end
+            let end = r.end;
+            start..end
         });
         let cum_data: Vec<DV> =
             D::query_data(cx, request_range, dependency_data_fetch_timer).await?;

--- a/stats/stats/src/data_source/kinds/data_manipulation/last_point.rs
+++ b/stats/stats/src/data_source/kinds/data_manipulation/last_point.rs
@@ -2,7 +2,7 @@
 //!
 //! Takes last data point from some other (vector) source
 
-use std::{marker::PhantomData, ops::RangeInclusive};
+use std::{marker::PhantomData, ops::Range};
 
 use blockscout_metrics_tools::AggregateTimer;
 use chrono::{DateTime, Utc};
@@ -47,12 +47,12 @@ where
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        _range: Option<RangeInclusive<DateTimeUtc>>,
+        _range: Option<Range<DateTimeUtc>>,
         dependency_data_fetch_timer: &mut AggregateTimer,
     ) -> Result<Self::Output, UpdateError> {
         let data = D::query_data(
             cx,
-            Some(day_start(cx.time.date_naive())..=cx.time),
+            Some(day_start(cx.time.date_naive())..cx.time),
             dependency_data_fetch_timer,
         )
         .await?;

--- a/stats/stats/src/data_source/kinds/data_manipulation/map/mod.rs
+++ b/stats/stats/src/data_source/kinds/data_manipulation/map/mod.rs
@@ -1,7 +1,7 @@
 //! `map` for a data source, i.e. applies a function to the output
 //! of some other source.
 
-use std::{marker::PhantomData, ops::RangeInclusive};
+use std::{marker::PhantomData, ops::Range};
 
 use blockscout_metrics_tools::AggregateTimer;
 use chrono::Utc;
@@ -54,7 +54,7 @@ where
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        range: Option<RangeInclusive<DateTimeUtc>>,
+        range: Option<Range<DateTimeUtc>>,
         dependency_data_fetch_timer: &mut AggregateTimer,
     ) -> Result<Self::Output, UpdateError> {
         let inner_data =

--- a/stats/stats/src/data_source/kinds/data_manipulation/sum_point.rs
+++ b/stats/stats/src/data_source/kinds/data_manipulation/sum_point.rs
@@ -4,7 +4,7 @@
 
 use std::{
     marker::PhantomData,
-    ops::{AddAssign, RangeInclusive},
+    ops::{AddAssign, Range},
 };
 
 use blockscout_metrics_tools::AggregateTimer;
@@ -56,7 +56,7 @@ where
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        _range: Option<RangeInclusive<DateTimeUtc>>,
+        _range: Option<Range<DateTimeUtc>>,
         dependency_data_fetch_timer: &mut AggregateTimer,
     ) -> Result<Self::Output, UpdateError> {
         // it's possible to not request full data range and use last accurate point;

--- a/stats/stats/src/data_source/kinds/local_db/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/mod.rs
@@ -69,7 +69,14 @@ pub type BatchLocalDbChartSourceWithDefaultParams<MainDep, ResolutionDep, BatchS
         MainDep,
         ResolutionDep,
         DefaultCreate<ChartProps>,
-        BatchUpdate<MainDep, ResolutionDep, BatchStep, Batch30Days, ChartProps>,
+        BatchUpdate<
+            MainDep,
+            ResolutionDep,
+            BatchStep,
+            Batch30Days,
+            DefaultQueryVec<ChartProps>,
+            ChartProps,
+        >,
         DefaultQueryVec<ChartProps>,
         ChartProps,
     >;
@@ -91,7 +98,14 @@ pub type CumulativeLocalDbChartSource<DeltaDep, C> = LocalDbChartSource<
     PartialCumulative<DeltaDep>,
     (),
     DefaultCreate<C>,
-    BatchUpdate<PartialCumulative<DeltaDep>, (), AddLastValueStep<C>, Batch30Days, C>,
+    BatchUpdate<
+        PartialCumulative<DeltaDep>,
+        (),
+        AddLastValueStep<C>,
+        Batch30Days,
+        DefaultQueryVec<C>,
+        C,
+    >,
     DefaultQueryVec<C>,
     C,
 >;
@@ -102,7 +116,7 @@ pub type DirectVecLocalDbChartSource<Dependency, C> = LocalDbChartSource<
     Dependency,
     (),
     DefaultCreate<C>,
-    BatchUpdate<Dependency, (), PassVecStep, Batch30Days, C>,
+    BatchUpdate<Dependency, (), PassVecStep, Batch30Days, DefaultQueryVec<C>, C>,
     DefaultQueryVec<C>,
     C,
 >;

--- a/stats/stats/src/data_source/kinds/local_db/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/mod.rs
@@ -9,7 +9,7 @@
 //! Charts are intended to be such persisted sources,
 //! because their data is directly retreived from the database (on requests).
 
-use std::{marker::PhantomData, ops::RangeInclusive, time::Duration};
+use std::{marker::PhantomData, ops::Range, time::Duration};
 
 use blockscout_metrics_tools::AggregateTimer;
 use chrono::{DateTime, Utc};
@@ -228,7 +228,7 @@ where
 
     async fn query_data(
         cx: &UpdateContext<'_>,
-        range: Option<RangeInclusive<DateTimeUtc>>,
+        range: Option<Range<DateTimeUtc>>,
         dependency_data_fetch_timer: &mut AggregateTimer,
     ) -> Result<Self::Output, UpdateError> {
         let _timer = dependency_data_fetch_timer.start_interval();

--- a/stats/stats/src/data_source/kinds/local_db/parameter_traits.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameter_traits.rs
@@ -1,4 +1,4 @@
-use std::{future::Future, marker::Send, ops::RangeInclusive};
+use std::{future::Future, marker::Send, ops::Range};
 
 use blockscout_metrics_tools::AggregateTimer;
 use chrono::{DateTime, Utc};
@@ -60,6 +60,6 @@ pub trait QueryBehaviour {
     /// Retrieve chart data from local storage.
     fn query_data(
         cx: &UpdateContext<'_>,
-        range: Option<RangeInclusive<DateTimeUtc>>,
+        range: Option<Range<DateTimeUtc>>,
     ) -> impl Future<Output = Result<Self::Output, UpdateError>> + Send;
 }

--- a/stats/stats/src/data_source/kinds/local_db/parameters/query.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/query.rs
@@ -23,7 +23,7 @@ impl<C: ChartProperties> QueryBehaviour for DefaultQueryVec<C> {
     ) -> Result<Self::Output, UpdateError> {
         let (start, end) = range.map(|r| (r.start, r.end)).unzip();
         // Currently we store data with date precision. Update-time relevance for local charts
-        // is achieved while requestind remote source data
+        // is achieved while requesting remote source data
         let start = start.map(|s| s.date_naive());
         let end = end.map(|s| {
             // the `end` point is excluded from the range, meaning

--- a/stats/stats/src/data_source/kinds/local_db/parameters/query.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/query.rs
@@ -25,7 +25,13 @@ impl<C: ChartProperties> QueryBehaviour for DefaultQueryVec<C> {
         // Currently we store data with date precision. Update-time relevance for local charts
         // is achieved while requestind remote source data
         let start = start.map(|s| s.date_naive());
-        let end = end.map(|s| s.date_naive());
+        let end = end.map(|s| {
+            // the `end` point is excluded from the range, meaning
+            // inclusive range will be until `end-1`
+            s.checked_sub_signed(chrono::Duration::nanoseconds(1))
+                .unwrap_or(DateTimeUtc::MIN_UTC)
+                .date_naive()
+        });
         let values: Vec<DateValueString> = get_line_chart_data(
             cx.db,
             C::NAME,

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/mod.rs
@@ -273,7 +273,6 @@ mod tests {
             sync::{Arc, Mutex, OnceLock},
         };
 
-        use blockscout_metrics_tools::AggregateTimer;
         use chrono::{DateTime, Days, Utc};
         use entity::sea_orm_active_enums::ChartType;
         use pretty_assertions::assert_eq;
@@ -288,7 +287,6 @@ mod tests {
                     LocalDbChartSource,
                 },
                 types::Get,
-                DataSource, UpdateContext, UpdateParameters,
             },
             gettable_const,
             lines::AccountsGrowth,

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameter_traits.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameter_traits.rs
@@ -5,11 +5,6 @@ use sea_orm::DatabaseConnection;
 
 use crate::{DateValueString, UpdateError};
 
-pub trait BatchSizeUpperBound {
-    /// Upper bound of batch interval
-    fn batch_max_size() -> chrono::Duration;
-}
-
 pub trait BatchStepBehaviour<MainInput, ResolutionInput>
 where
     MainInput: Send,

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameter_traits.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameter_traits.rs
@@ -18,7 +18,7 @@ where
         chart_id: i32,
         update_time: DateTime<Utc>,
         min_blockscout_block: i64,
-        last_accurate_point: Option<DateValueString>,
+        last_accurate_point: DateValueString,
         main_data: MainInput,
         resolution_data: ResolutionInput,
     ) -> impl Future<Output = Result<usize, UpdateError>> + std::marker::Send;

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/cumulative.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/cumulative.rs
@@ -32,21 +32,19 @@ where
         chart_id: i32,
         update_time: DateTime<Utc>,
         min_blockscout_block: i64,
-        last_accurate_point: Option<DateValueString>,
+        last_accurate_point: DateValueString,
         main_data: Vec<DV>,
         _resolution_data: (),
     ) -> Result<usize, UpdateError> {
         let partial_sum = last_accurate_point
-            .map(|p| {
-                p.value.parse::<DV::Value>().map_err(|e| {
-                    UpdateError::Internal(format!(
-                        "failed to parse value in chart '{}': {e}",
-                        ChartProps::NAME
-                    ))
-                })
-            })
-            .transpose()?;
-        let partial_sum = partial_sum.unwrap_or(DV::Value::zero());
+            .value
+            .parse::<DV::Value>()
+            .map_err(|e| {
+                UpdateError::Internal(format!(
+                    "failed to parse value in chart '{}': {e}",
+                    ChartProps::NAME
+                ))
+            })?;
         let main_data = main_data
             .into_iter()
             .map(|dv| {
@@ -60,7 +58,7 @@ where
             chart_id,
             update_time,
             min_blockscout_block,
-            None, // ignored anyway
+            last_accurate_point,
             main_data,
             (),
         )

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mock.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mock.rs
@@ -15,7 +15,7 @@ pub struct StepInput<MI, RI> {
     pub chart_id: i32,
     pub update_time: DateTime<Utc>,
     pub min_blockscout_block: i64,
-    pub last_accurate_point: Option<DateValueString>,
+    pub last_accurate_point: DateValueString,
     pub main_data: MI,
     pub resolution_data: RI,
 }
@@ -37,7 +37,7 @@ where
         chart_id: i32,
         update_time: DateTime<Utc>,
         min_blockscout_block: i64,
-        last_accurate_point: Option<DateValueString>,
+        last_accurate_point: DateValueString,
         main_data: Vec<DateValueString>,
         resolution_data: (),
     ) -> Result<usize, UpdateError> {

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mock.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mock.rs
@@ -1,0 +1,63 @@
+use std::marker::PhantomData;
+
+use chrono::{DateTime, Utc};
+use sea_orm::DatabaseConnection;
+
+use crate::{
+    data_source::kinds::local_db::parameters::update::batching::parameter_traits::BatchStepBehaviour,
+    tests::recorder::Recorder, DateValueString, UpdateError,
+};
+
+use super::PassVecStep;
+
+#[derive(Debug, Clone)]
+pub struct StepInput<MI, RI> {
+    pub chart_id: i32,
+    pub update_time: DateTime<Utc>,
+    pub min_blockscout_block: i64,
+    pub last_accurate_point: Option<DateValueString>,
+    pub main_data: MI,
+    pub resolution_data: RI,
+}
+
+/// Allows to inspect values passed to each step call;
+/// does nothind regarding side effects
+#[derive(Default)]
+pub struct RecordingPassStep<StepsRecorder>(PhantomData<StepsRecorder>)
+where
+    StepsRecorder: Recorder;
+
+impl<StepsRecorder> BatchStepBehaviour<Vec<DateValueString>, ()>
+    for RecordingPassStep<StepsRecorder>
+where
+    StepsRecorder: Recorder<Data = StepInput<Vec<DateValueString>, ()>>,
+{
+    async fn batch_update_values_step_with(
+        db: &DatabaseConnection,
+        chart_id: i32,
+        update_time: DateTime<Utc>,
+        min_blockscout_block: i64,
+        last_accurate_point: Option<DateValueString>,
+        main_data: Vec<DateValueString>,
+        resolution_data: (),
+    ) -> Result<usize, UpdateError> {
+        StepsRecorder::record(StepInput {
+            chart_id,
+            update_time,
+            min_blockscout_block,
+            last_accurate_point: last_accurate_point.clone(),
+            main_data: main_data.clone(),
+            resolution_data,
+        });
+        PassVecStep::batch_update_values_step_with(
+            db,
+            chart_id,
+            update_time,
+            min_blockscout_block,
+            last_accurate_point,
+            main_data,
+            resolution_data,
+        )
+        .await
+    }
+}

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mod.rs
@@ -1,29 +1,20 @@
 use chrono::{DateTime, Utc};
 use sea_orm::DatabaseConnection;
 
-use crate::{charts::db_interaction::write::insert_data_many, DateValueString, UpdateError};
+use crate::{
+    charts::db_interaction::write::insert_data_many, gettable_const, DateValueString, UpdateError,
+};
 
-use super::parameter_traits::{BatchSizeUpperBound, BatchStepBehaviour};
+use super::parameter_traits::BatchStepBehaviour;
 
 mod cumulative;
+#[cfg(any(feature = "test-utils", test))]
+pub mod mock;
 
 pub use cumulative::*;
 
-pub struct Batch30Days;
-
-impl BatchSizeUpperBound for Batch30Days {
-    fn batch_max_size() -> chrono::Duration {
-        chrono::Duration::days(30)
-    }
-}
-
-pub struct BatchMax;
-
-impl BatchSizeUpperBound for BatchMax {
-    fn batch_max_size() -> chrono::Duration {
-        chrono::Duration::max_value()
-    }
-}
+gettable_const!(Batch30Days: chrono::Duration = chrono::Duration::days(30));
+gettable_const!(BatchMax: chrono::Duration = chrono::Duration::max_value());
 
 /// Pass the vector data from main dependency right into the database
 pub struct PassVecStep;

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/parameters/mod.rs
@@ -25,7 +25,7 @@ impl BatchStepBehaviour<Vec<DateValueString>, ()> for PassVecStep {
         chart_id: i32,
         _update_time: DateTime<Utc>,
         min_blockscout_block: i64,
-        _last_accurate_point: Option<DateValueString>,
+        _last_accurate_point: DateValueString,
         main_data: Vec<DateValueString>,
         _resolution_data: (),
     ) -> Result<usize, UpdateError> {

--- a/stats/stats/src/data_source/source.rs
+++ b/stats/stats/src/data_source/source.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, future::Future, marker::Send, ops::RangeInclusive};
+use std::{collections::HashSet, future::Future, marker::Send, ops::Range};
 
 use blockscout_metrics_tools::AggregateTimer;
 use chrono::Utc;
@@ -165,7 +165,7 @@ pub trait DataSource {
     /// to call [`DataSource::update_recursively`] beforehand.
     fn query_data(
         cx: &UpdateContext<'_>,
-        range: Option<RangeInclusive<DateTimeUtc>>,
+        range: Option<Range<DateTimeUtc>>,
         dependency_data_fetch_timer: &mut AggregateTimer,
     ) -> impl Future<Output = Result<Self::Output, UpdateError>> + Send;
 }
@@ -207,7 +207,7 @@ impl DataSource for () {
 
     async fn query_data(
         _cx: &UpdateContext<'_>,
-        _range: Option<RangeInclusive<DateTimeUtc>>,
+        _range: Option<Range<DateTimeUtc>>,
         _remote_fetch_timer: &mut AggregateTimer,
     ) -> Result<Self::Output, UpdateError> {
         Ok(())
@@ -246,7 +246,7 @@ macro_rules! impl_data_source_for_tuple {
 
             async fn query_data(
                 cx: &UpdateContext<'_>,
-                range: Option<RangeInclusive<DateTimeUtc>>,
+                range: Option<Range<DateTimeUtc>>,
                 remote_fetch_timer: &mut AggregateTimer,
             ) -> Result<Self::Output, UpdateError> {
                 Ok((

--- a/stats/stats/src/data_source/tests.rs
+++ b/stats/stats/src/data_source/tests.rs
@@ -119,7 +119,7 @@ impl BatchStepBehaviour<Vec<DateValueString>, ()> for ContractsGrowthCustomBatch
         _chart_id: i32,
         _update_time: DateTime<Utc>,
         _min_blockscout_block: i64,
-        _last_accurate_point: Option<DateValueString>,
+        _last_accurate_point: DateValueString,
         _main_data: Vec<DateValueString>,
         _resolution_data: (),
     ) -> Result<usize, UpdateError> {

--- a/stats/stats/src/data_source/tests.rs
+++ b/stats/stats/src/data_source/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, ops::RangeInclusive, str::FromStr, sync::Arc};
+use std::{collections::HashSet, ops::Range, str::FromStr, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use entity::sea_orm_active_enums::ChartType;
@@ -30,7 +30,7 @@ use crate::{
 pub struct NewContractsQuery;
 
 impl StatementFromRange for NewContractsQuery {
-    fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
             r#"

--- a/stats/stats/src/data_source/types.rs
+++ b/stats/stats/src/data_source/types.rs
@@ -31,3 +31,19 @@ impl<'a> UpdateContext<'a> {
         }
     }
 }
+
+pub trait Get<T> {
+    fn get() -> T;
+}
+
+#[macro_export]
+macro_rules! gettable_const {
+    ($name:ident: $type:ty = $value:expr) => {
+        pub struct $name;
+        impl $crate::data_source::types::Get<$type> for $name {
+            fn get() -> $type {
+                $value
+            }
+        }
+    };
+}

--- a/stats/stats/src/tests/mod.rs
+++ b/stats/stats/src/tests/mod.rs
@@ -3,5 +3,5 @@
 pub mod init_db;
 pub mod mock_blockscout;
 pub mod point_construction;
+pub mod recorder;
 pub mod simple_test;
-pub mod types;

--- a/stats/stats/src/tests/recorder.rs
+++ b/stats/stats/src/tests/recorder.rs
@@ -1,0 +1,32 @@
+use std::{
+    marker::PhantomData,
+    ops::Deref,
+    sync::{Arc, Mutex},
+};
+
+use crate::data_source::types::Get;
+
+pub trait Recorder {
+    type Data;
+    fn record(next: Self::Data);
+    fn get_records() -> Vec<Self::Data>;
+}
+
+pub struct InMemoryRecorder<Data, InMemoryStorage>(PhantomData<(Data, InMemoryStorage)>)
+where
+    InMemoryStorage: Get<Arc<Mutex<Vec<Data>>>>;
+
+impl<Data, InMemoryStorage> Recorder for InMemoryRecorder<Data, InMemoryStorage>
+where
+    Data: Clone,
+    InMemoryStorage: Get<Arc<Mutex<Vec<Data>>>>,
+{
+    type Data = Data;
+    fn record(next: Data) {
+        InMemoryStorage::get().lock().unwrap().push(next)
+    }
+
+    fn get_records() -> Vec<Data> {
+        InMemoryStorage::get().lock().unwrap().deref().to_vec()
+    }
+}

--- a/stats/stats/src/tests/simple_test.rs
+++ b/stats/stats/src/tests/simple_test.rs
@@ -11,7 +11,7 @@ use pretty_assertions::assert_eq;
 use sea_orm::DatabaseConnection;
 use std::str::FromStr;
 
-fn map_str_tuple_to_owned(l: Vec<(&str, &str)>) -> Vec<(String, String)> {
+pub fn map_str_tuple_to_owned(l: Vec<(&str, &str)>) -> Vec<(String, String)> {
     l.into_iter()
         .map(|t| (t.0.to_string(), t.1.to_string()))
         .collect()

--- a/stats/stats/src/tests/simple_test.rs
+++ b/stats/stats/src/tests/simple_test.rs
@@ -80,10 +80,13 @@ pub async fn dirty_force_update_and_check<C: DataSource + ChartProperties>(
     db: &DatabaseConnection,
     blockscout: &DatabaseConnection,
     expected: Vec<(&str, &str)>,
+    update_time_override: Option<DateTime<Utc>>,
 ) {
     let _ = tracing_subscriber::fmt::try_init();
     let expected = map_str_tuple_to_owned(expected);
-    let current_time = DateTime::from_str("2023-03-01T12:00:00Z").unwrap();
+    // some later time so that the update is not skipped
+    let current_time =
+        update_time_override.unwrap_or(DateTime::from_str("2023-03-01T12:00:01Z").unwrap());
     let approximate_trailing_points = C::approximate_trailing_points();
 
     let parameters = UpdateParameters {

--- a/stats/stats/src/tests/simple_test.rs
+++ b/stats/stats/src/tests/simple_test.rs
@@ -90,8 +90,8 @@ pub async fn dirty_force_update_and_check<C: DataSource + ChartProperties>(
     let approximate_trailing_points = C::approximate_trailing_points();
 
     let parameters = UpdateParameters {
-        db: db,
-        blockscout: blockscout,
+        db,
+        blockscout,
         update_time_override: Some(current_time),
         force_full: true,
     };
@@ -99,7 +99,7 @@ pub async fn dirty_force_update_and_check<C: DataSource + ChartProperties>(
     C::update_recursively(&cx).await.unwrap();
     assert_eq!(
         &get_chart::<C>(
-            &db,
+            db,
             None,
             None,
             C::missing_date_policy(),

--- a/stats/stats/src/tests/types.rs
+++ b/stats/stats/src/tests/types.rs
@@ -1,3 +1,0 @@
-pub trait Get<T> {
-    fn get() -> T;
-}

--- a/stats/stats/src/update_group.rs
+++ b/stats/stats/src/update_group.rs
@@ -155,7 +155,7 @@ pub trait UpdateGroup: core::fmt::Debug {
 /// # };
 /// # use chrono::NaiveDate;
 /// # use entity::sea_orm_active_enums::ChartType;
-/// # use std::ops::RangeInclusive;
+/// # use std::ops::Range;
 /// # use sea_orm::prelude::DateTimeUtc;
 /// # use sea_orm::Statement;
 ///

--- a/stats/stats/src/update_group.rs
+++ b/stats/stats/src/update_group.rs
@@ -162,7 +162,7 @@ pub trait UpdateGroup: core::fmt::Debug {
 /// struct DummyRemoteStatement;
 ///
 /// impl StatementFromRange for DummyRemoteStatement {
-///     fn get_statement(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+///     fn get_statement(range: Option<Range<DateTimeUtc>>) -> Statement {
 ///         todo!()
 ///     }
 /// }

--- a/stats/stats/src/utils.rs
+++ b/stats/stats/src/utils.rs
@@ -1,6 +1,6 @@
 //! Common utilities used across statistics
 
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use chrono::{NaiveDate, NaiveTime};
 use sea_orm::{prelude::DateTimeUtc, Value};
@@ -19,7 +19,7 @@ pub fn day_start(date: NaiveDate) -> DateTimeUtc {
 /// Vec should be appended to the args.
 /// String should be inserted in places for filter.
 pub(crate) fn produce_filter_and_values(
-    range: Option<RangeInclusive<DateTimeUtc>>,
+    range: Option<Range<DateTimeUtc>>,
     filter_by: &str,
     filter_arg_number_start: usize,
 ) -> (String, Vec<Value>) {
@@ -29,10 +29,10 @@ pub(crate) fn produce_filter_and_values(
         (
             format!(
                 " AND
-                {filter_by} <= ${arg_n_2} AND
+                {filter_by} < ${arg_n_2} AND
                 {filter_by} >= ${arg_n_1}"
             ),
-            vec![(*range.start()).into(), (*range.end()).into()],
+            vec![range.start.into(), range.end.into()],
         )
     } else {
         ("".to_owned(), vec![])
@@ -94,7 +94,7 @@ mod test {
         let time_1 = DateTimeUtc::from_timestamp(1234567, 0).unwrap();
         let time_2 = DateTimeUtc::from_timestamp(7654321, 0).unwrap();
         assert_eq!(
-            produce_filter_and_values(Some(time_1..=time_2), "aboba", 123),
+            produce_filter_and_values(Some(time_1..time_2), "aboba", 123),
             (
                 " AND
                 aboba <= $124 AND
@@ -107,7 +107,7 @@ mod test {
 
     const ETH: i64 = 1_000_000_000_000_000_000;
 
-    fn naive_sql_selector(range: Option<RangeInclusive<DateTimeUtc>>) -> Statement {
+    fn naive_sql_selector(range: Option<Range<DateTimeUtc>>) -> Statement {
         match range {
             Some(range) => Statement::from_sql_and_values(
                 DbBackend::Postgres,
@@ -124,7 +124,7 @@ mod test {
                     blocks.timestamp >= $2
                 GROUP BY date
                 "#,
-                vec![ETH.into(), (*range.start()).into(), (*range.end()).into()],
+                vec![ETH.into(), range.start.into(), range.end.into()],
             ),
             None => Statement::from_sql_and_values(
                 DbBackend::Postgres,
@@ -173,7 +173,7 @@ mod test {
     fn sql_with_range_filter_some_works() {
         let range = Some(
             DateTimeUtc::from_timestamp(1234567, 0).unwrap()
-                ..=DateTimeUtc::from_timestamp(7654321, 0).unwrap(),
+                ..DateTimeUtc::from_timestamp(7654321, 0).unwrap(),
         );
         assert_eq!(
             compact_sql(naive_sql_selector(range.clone())),

--- a/stats/stats/src/utils.rs
+++ b/stats/stats/src/utils.rs
@@ -97,7 +97,7 @@ mod test {
             produce_filter_and_values(Some(time_1..time_2), "aboba", 123),
             (
                 " AND
-                aboba <= $124 AND
+                aboba < $124 AND
                 aboba >= $123"
                     .to_string(),
                 vec![time_1.into(), time_2.into()]
@@ -120,7 +120,7 @@ mod test {
                 WHERE 
                     blocks.timestamp != to_timestamp(0) AND 
                     blocks.consensus = true AND
-                    blocks.timestamp <= $3 AND
+                    blocks.timestamp < $3 AND
                     blocks.timestamp >= $2
                 GROUP BY date
                 "#,


### PR DESCRIPTION
* fix(stats): Fixed last point of previous batch step being retrieved incorrectly when forcing reupdate of an existing data. Also added regression on this bug to prevent it in the future.
* fix(stats): In the meantime fixed a small overlapping between batch steps (1 ns due to using `RangeInclusive`): end of batch step range is now not included (`Range` instead of `RangeInclusive`). Relevant code is changed accordingly.