### PR TITLE
test(stats): repeated update trigger within one run

### DIFF
--- a/stats/stats/src/data_source/kinds/local_db/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/mod.rs
@@ -298,7 +298,7 @@ mod tests {
         };
 
         use blockscout_metrics_tools::AggregateTimer;
-        use chrono::{DateTime, Days, Utc};
+        use chrono::{DateTime, Days, TimeDelta, Utc};
         use entity::sea_orm_active_enums::ChartType;
         use tokio::sync::Mutex;
 
@@ -446,6 +446,11 @@ mod tests {
             UpdateSingleTriggerAsserter::reset_triggers().await;
 
             let next_next_time = next_time.checked_add_days(Days::new(1)).unwrap();
+            // it also works with high-precision timestamps
+            //
+            // regression: had a bug where due to postgres having resolution of 1 microsecond stored a different
+            // timestamp to the one provided
+            let next_next_time = next_next_time + TimeDelta::nanoseconds(1);
             let parameters = UpdateParameters {
                 db: &db,
                 blockscout: &blockscout,

--- a/stats/stats/src/data_source/kinds/local_db/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/mod.rs
@@ -425,7 +425,6 @@ mod tests {
                 .into_iter()
                 .map(|id| (id.to_owned(), Arc::new(Mutex::new(()))))
                 .collect();
-            dbg!(&mutexes);
             let group = SyncUpdateGroup::new(&mutexes, Arc::new(TestUpdateGroup)).unwrap();
             group
                 .create_charts_with_mutexes(&db, Some(current_time), &enabled)

--- a/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/update/batching/mod.rs
@@ -307,7 +307,9 @@ mod tests {
         type SharedInputsStorage = Arc<Mutex<Vec<VecStringStepInput>>>;
 
         // `OnceLock` in order to return the same instance each time
-        gettable_const!(ThisInputs: SharedInputsStorage = OnceLock::new().get_or_init(|| Arc::new(Mutex::new(vec![]))).clone());
+        static INPUTS: OnceLock<SharedInputsStorage> = OnceLock::new();
+
+        gettable_const!(ThisInputs: SharedInputsStorage = INPUTS.get_or_init(|| Arc::new(Mutex::new(vec![]))).clone());
         gettable_const!(Batch1Day: chrono::Duration = chrono::Duration::days(1));
 
         type ThisRecordingStep =


### PR DESCRIPTION
should test #964
but is not reproduced locally for some reason (in staging logs the problem is clearly observed)