### PR TITLE
fix(user-ops-indexer): add missing index by transaction hash

### DIFF
--- a/user-ops-indexer/user-ops-indexer-migration/src/lib.rs
+++ b/user-ops-indexer/user-ops-indexer-migration/src/lib.rs
@@ -3,6 +3,7 @@ use sea_orm_migration::sea_orm::{Statement, TransactionTrait};
 mod m20220101_000001_initial_tables;
 mod m20231117_093738_add_indexes;
 mod m20240206_150422_add_entrypoint_version;
+mod m20240717_111524_add_transaction_hash_index;
 
 pub struct Migrator;
 
@@ -13,6 +14,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20220101_000001_initial_tables::Migration),
             Box::new(m20231117_093738_add_indexes::Migration),
             Box::new(m20240206_150422_add_entrypoint_version::Migration),
+            Box::new(m20240717_111524_add_transaction_hash_index::Migration),
         ]
     }
     fn migration_table_name() -> DynIden {

--- a/user-ops-indexer/user-ops-indexer-migration/src/m20240717_111524_add_transaction_hash_index.rs
+++ b/user-ops-indexer/user-ops-indexer-migration/src/m20240717_111524_add_transaction_hash_index.rs
@@ -1,0 +1,21 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            CREATE INDEX user_operations_transaction_hash_index ON user_operations (transaction_hash);
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            DROP INDEX user_operations_transaction_hash_index;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+}


### PR DESCRIPTION
There is an index missing for querying user operations from a particular transaction hash