### PR TITLE
fix(stats): update charts metadata

### DIFF
--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -65,7 +65,7 @@
         },
         "accounts_growth": {
             "title": "Accounts growth",
-            "description": "Cumulative accounts number per period"
+            "description": "Cumulative accounts number"
         },
         "new_accounts": {
             "title": "New accounts",
@@ -73,17 +73,17 @@
         },
         "average_txn_fee": {
             "title": "Average transaction fee",
-            "description": "The average amount in {{native_coin_symbol}} spent per transaction",
+            "description": "The average amount in {{native_coin_symbol}} spent for transaction per period",
             "units": "{{native_coin_symbol}}"
         },
         "txns_fee": {
             "title": "Transactions fees",
-            "description": "Amount of tokens paid as fees",
+            "description": "Amount of tokens paid as fees per period",
             "units": "{{native_coin_symbol}}"
         },
         "new_txns": {
             "title": "New transactions",
-            "description": "New transactions number"
+            "description": "New transactions number per period"
         },
         "txns_growth": {
             "title": "Transactions growth",
@@ -95,16 +95,16 @@
         },
         "new_blocks": {
             "title": "New blocks",
-            "description": "New blocks number"
+            "description": "New blocks number per period"
         },
         "average_block_size": {
             "title": "Average block size",
-            "description": "Average size of blocks in bytes",
+            "description": "Average size of blocks per period",
             "units": "Bytes"
         },
         "average_block_rewards": {
             "title": "Average block rewards",
-            "description": "Average amount of distributed reward in tokens per period",
+            "description": "Average amount of distributed rewards in tokens per period",
             "units": "{{native_coin_symbol}}"
         },
         "new_native_coin_transfers": {
@@ -114,7 +114,7 @@
         "native_coin_holders_growth": {
             "enabled": false,
             "title": "{{native_coin_symbol}} holders growth",
-            "description": "Cumulative token holders number for the period"
+            "description": "Cumulative number of token holders"
         },
         "new_native_coin_holders": {
             "enabled": false,
@@ -124,37 +124,37 @@
         "native_coin_supply": {
             "enabled": false,
             "title": "{{native_coin_symbol}} circulating supply",
-            "description": "Amount of token circulating supply for the period",
+            "description": "Amount of token circulating supply per period",
             "units": "{{native_coin_symbol}}"
         },
         "average_gas_limit": {
             "title": "Average gas limit",
-            "description": "Average gas limit per block for the period"
+            "description": "Average block gas limit per period"
         },
         "gas_used_growth": {
             "title": "Gas used growth",
-            "description": "Cumulative gas used for the period"
+            "description": "Cumulative gas used"
         },
         "average_gas_price": {
             "title": "Average gas price",
-            "description": "Average gas price for the period (Gwei)",
+            "description": "Average gas price per period",
             "units": "Gwei"
         },
         "new_verified_contracts": {
             "title": "New verified contracts",
-            "description": "New verified contracts number for the period"
+            "description": "New verified contracts number per period"
         },
         "verified_contracts_growth": {
             "title": "Verified contracts growth",
-            "description": "Cumulative number verified contracts for the period"
+            "description": "Cumulative number of verified contracts"
         },
         "new_contracts": {
             "title": "New contracts",
-            "description": "New contracts number for the period"
+            "description": "New contracts number per period"
         },
         "contracts_growth": {
             "title": "Contracts growth",
-            "description": "Cumulative number of contracts for the period"
+            "description": "Cumulative number of contracts"
         }
     }
 }

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -69,7 +69,7 @@
         },
         "new_accounts": {
             "title": "New accounts",
-            "description": "New accounts number per day"
+            "description": "New accounts number per period"
         },
         "average_txn_fee": {
             "title": "Average transaction fee",
@@ -91,7 +91,7 @@
         },
         "txns_success_rate": {
             "title": "Transactions success rate",
-            "description": "Successful transactions rate per day"
+            "description": "Successful transactions rate per period"
         },
         "new_blocks": {
             "title": "New blocks",
@@ -104,7 +104,7 @@
         },
         "average_block_rewards": {
             "title": "Average block rewards",
-            "description": "Average amount of distributed reward in tokens per day",
+            "description": "Average amount of distributed reward in tokens per period",
             "units": "{{native_coin_symbol}}"
         },
         "new_native_coin_transfers": {
@@ -119,7 +119,7 @@
         "new_native_coin_holders": {
             "enabled": false,
             "title": "New {{native_coin_symbol}} holders",
-            "description": "New token holders number per day"
+            "description": "New token holders number per period"
         },
         "native_coin_supply": {
             "enabled": false,

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -64,8 +64,8 @@
             "description": "Active accounts number per period"
         },
         "accounts_growth": {
-            "title": "Accounts growth",
-            "description": "Cumulative number of accounts"
+            "title": "Number of accounts",
+            "description": "Cumulative account growth over time"
         },
         "new_accounts": {
             "title": "New accounts",
@@ -78,7 +78,7 @@
         },
         "txns_fee": {
             "title": "Transaction fees",
-            "description": "Amount of tokens paid as fees per period",
+            "description": "Sum of {{native_coin_symbol}} spent on gas fees",
             "units": "{{native_coin_symbol}}"
         },
         "new_txns": {
@@ -86,12 +86,12 @@
             "description": "Number of new transactions"
         },
         "txns_growth": {
-            "title": "Transactions growth",
-            "description": "Cumulative number of transactions"
+            "title": "Number of transactions",
+            "description": "Cumulative transaction growth over time"
         },
         "txns_success_rate": {
             "title": "Transaction success rate",
-            "description": "Successful transactions rate per period"
+            "description": "Success rate for all included transactions"
         },
         "new_blocks": {
             "title": "New blocks",
@@ -99,12 +99,12 @@
         },
         "average_block_size": {
             "title": "Average block size",
-            "description": "Average size of blocks per period",
+            "description": "Space (in bytes) taken up by all block fields",
             "units": "Bytes"
         },
         "average_block_rewards": {
             "title": "Average block rewards",
-            "description": "Average amount of distributed rewards in tokens per period",
+            "description": "Average amount of reward",
             "units": "{{native_coin_symbol}}"
         },
         "new_native_coin_transfers": {
@@ -119,7 +119,7 @@
         "new_native_coin_holders": {
             "enabled": false,
             "title": "New {{native_coin_symbol}} holders",
-            "description": "New token holders number per period"
+            "description": "Number of new accounts holding {{native_coin_symbol}}"
         },
         "native_coin_supply": {
             "enabled": false,
@@ -129,15 +129,15 @@
         },
         "average_gas_limit": {
             "title": "Average gas limit",
-            "description": "Average block gas limit per period"
+            "description": "Average block gas limit"
         },
         "gas_used_growth": {
             "title": "Total gas usage",
-            "description": "Cumulative gas used"
+            "description": "Cumulative gas used over time"
         },
         "average_gas_price": {
             "title": "Average gas price",
-            "description": "Average gas price per period",
+            "description": "Average price (Gwei) per unit of gas",
             "units": "Gwei"
         },
         "new_verified_contracts": {
@@ -145,16 +145,16 @@
             "description": "Number of newly verified contracts"
         },
         "verified_contracts_growth": {
-            "title": "Verified contracts growth",
-            "description": "Cumulative number of verified contracts"
+            "title": "Number of verified contracts",
+            "description": "Cumulative verified contract growth over time"
         },
         "new_contracts": {
             "title": "New contracts",
-            "description": "New contracts number per period"
+            "description": "Number of new contracts in the network"
         },
         "contracts_growth": {
-            "title": "Contracts growth",
-            "description": "Cumulative number of contracts"
+            "title": "Number of contracts",
+            "description": "Cumulative contract growth over time"
         }
     }
 }

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -65,37 +65,37 @@
         },
         "accounts_growth": {
             "title": "Accounts growth",
-            "description": "Cumulative accounts number"
+            "description": "Cumulative number of accounts"
         },
         "new_accounts": {
             "title": "New accounts",
-            "description": "New accounts number per period"
+            "description": "Number of newly added accounts"
         },
         "average_txn_fee": {
             "title": "Average transaction fee",
-            "description": "The average amount in {{native_coin_symbol}} spent for transaction per period",
+            "description": "Average amount of {{native_coin_symbol}} spent on gas fees per transaction",
             "units": "{{native_coin_symbol}}"
         },
         "txns_fee": {
-            "title": "Transactions fees",
+            "title": "Transaction fees",
             "description": "Amount of tokens paid as fees per period",
             "units": "{{native_coin_symbol}}"
         },
         "new_txns": {
             "title": "New transactions",
-            "description": "New transactions number per period"
+            "description": "Number of new transactions"
         },
         "txns_growth": {
             "title": "Transactions growth",
-            "description": "Cumulative transactions number"
+            "description": "Cumulative number of transactions"
         },
         "txns_success_rate": {
-            "title": "Transactions success rate",
+            "title": "Transaction success rate",
             "description": "Successful transactions rate per period"
         },
         "new_blocks": {
             "title": "New blocks",
-            "description": "New blocks number per period"
+            "description": "Number of new blocks added to the chain"
         },
         "average_block_size": {
             "title": "Average block size",
@@ -109,12 +109,12 @@
         },
         "new_native_coin_transfers": {
             "title": "Number of {{native_coin_symbol}} transfers",
-            "description": "Token transfers performed during the period"
+            "description": "Completed token transfers"
         },
         "native_coin_holders_growth": {
             "enabled": false,
-            "title": "{{native_coin_symbol}} holders growth",
-            "description": "Cumulative number of token holders"
+            "title": "{{native_coin_symbol}} holders",
+            "description": "Number of accounts holding {{native_coin_symbol}}"
         },
         "new_native_coin_holders": {
             "enabled": false,
@@ -124,7 +124,7 @@
         "native_coin_supply": {
             "enabled": false,
             "title": "{{native_coin_symbol}} circulating supply",
-            "description": "Amount of token circulating supply per period",
+            "description": "Amount of publicly available {{native_coin_symbol}}",
             "units": "{{native_coin_symbol}}"
         },
         "average_gas_limit": {
@@ -132,7 +132,7 @@
             "description": "Average block gas limit per period"
         },
         "gas_used_growth": {
-            "title": "Gas used growth",
+            "title": "Total gas usage",
             "description": "Cumulative gas used"
         },
         "average_gas_price": {
@@ -142,7 +142,7 @@
         },
         "new_verified_contracts": {
             "title": "New verified contracts",
-            "description": "New verified contracts number per period"
+            "description": "Number of newly verified contracts"
         },
         "verified_contracts_growth": {
             "title": "Verified contracts growth",

--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -108,8 +108,8 @@
             "units": "{{native_coin_symbol}}"
         },
         "new_native_coin_transfers": {
-            "title": "New {{native_coin_symbol}} transfers",
-            "description": "New token transfers number for the period"
+            "title": "Number of {{native_coin_symbol}} transfers",
+            "description": "Token transfers performed during the period"
         },
         "native_coin_holders_growth": {
             "enabled": false,


### PR DESCRIPTION
- commit `107dad8` contains changes requested originally (so it should be set in stone i guess)
- commit `f008cb6` contains fixes to descriptions with introduction of non-day data resolutions (seems pretty straightforward, but open to comments)
- commit `67625c6` contains improvements to consistency of the line chart descriptions (my suggestion, can easily remove if we decide it's unnecessary)