### PR TITLE
fix(launcher): `RequestIdStorage` fixes

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -49,6 +49,7 @@ sea-orm-migration-0_12 = { package = "sea-orm-migration", version = "0.12.2", op
 [dev-dependencies]
 pretty_assertions = "1.4.0"
 tempfile = "3.10.1"
+regex = { version = "1", features = ["std"], default-features = false }
 
 
 [features]

--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.13.0"
+version = "0.13.1"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/launcher/span_builder.rs
+++ b/libs/blockscout-service-launcher/src/launcher/span_builder.rs
@@ -92,8 +92,8 @@ fn handle_error(span: Span, status_code: StatusCode, response_error: &dyn Respon
     // pre-formatting errors is a workaround for https://github.com/tokio-rs/tracing/issues/1565
     let display = format!("{response_error}");
     let debug = format!("{response_error:?}");
-    span.record("exception.message", &tracing::field::display(display));
-    span.record("exception.details", &tracing::field::display(debug));
+    span.record("exception.message", tracing::field::display(display));
+    span.record("exception.details", tracing::field::display(debug));
     let code: i32 = status_code.as_u16().into();
 
     span.record("http.status_code", code);

--- a/libs/blockscout-service-launcher/src/tracing/request_id_layer.rs
+++ b/libs/blockscout-service-launcher/src/tracing/request_id_layer.rs
@@ -186,13 +186,14 @@ mod tests {
     }
 
     fn parse_json(s: &str) -> serde_json::Value {
-        serde_json::from_str::<serde_json::Value>(&s).expect(&format!("failed to parse '{}'", s))
+        serde_json::from_str::<serde_json::Value>(s)
+            .unwrap_or_else(|_| panic!("failed to parse '{}'", s))
     }
 
     fn parse_captured_logs(logs: String) -> Vec<serde_json::Value> {
         logs.split('\n')
             .filter(|l| !l.is_empty())
-            .map(|l| parse_json(l))
+            .map(parse_json)
             .collect()
     }
 

--- a/libs/blockscout-service-launcher/src/tracing/request_id_layer.rs
+++ b/libs/blockscout-service-launcher/src/tracing/request_id_layer.rs
@@ -77,3 +77,187 @@ impl<S: Subscriber + for<'lookup> LookupSpan<'lookup>> Layer<S> for RequestIdSto
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io,
+        sync::{Arc, Mutex, MutexGuard, TryLockError},
+    };
+
+    use pretty_assertions::assert_eq;
+    use regex::Regex;
+    use tracing::subscriber::with_default;
+    use tracing_subscriber::{
+        fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt, Layer,
+    };
+
+    // https://github.com/tokio-rs/tracing/blob/527b4f66a604e7a6baa6aa7536428e3a303ba3c8/tracing-subscriber/src/fmt/format/json.rs#L522
+    struct MockTime;
+
+    impl tracing_subscriber::fmt::time::FormatTime for MockTime {
+        fn format_time(
+            &self,
+            w: &mut tracing_subscriber::fmt::format::Writer<'_>,
+        ) -> std::fmt::Result {
+            write!(w, "fake time")
+        }
+    }
+
+    pub(crate) struct MockWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
+    }
+
+    // https://github.com/tokio-rs/tracing/blob/527b4f66a604e7a6baa6aa7536428e3a303ba3c8/tracing-subscriber/src/fmt/mod.rs#L1249
+    impl MockWriter {
+        pub(crate) fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
+            Self { buf }
+        }
+
+        pub(crate) fn map_error<Guard>(err: TryLockError<Guard>) -> io::Error {
+            match err {
+                TryLockError::WouldBlock => io::Error::from(io::ErrorKind::WouldBlock),
+                TryLockError::Poisoned(_) => io::Error::from(io::ErrorKind::Other),
+            }
+        }
+
+        pub(crate) fn buf(&self) -> io::Result<MutexGuard<'_, Vec<u8>>> {
+            self.buf.try_lock().map_err(Self::map_error)
+        }
+    }
+
+    impl io::Write for MockWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.buf()?.write(buf)
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            self.buf()?.flush()
+        }
+    }
+
+    // https://github.com/tokio-rs/tracing/blob/527b4f66a604e7a6baa6aa7536428e3a303ba3c8/tracing-subscriber/src/fmt/mod.rs#L1281
+    #[derive(Clone, Default)]
+    pub(crate) struct MockMakeWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl MockMakeWriter {
+        pub(crate) fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
+            Self { buf }
+        }
+
+        pub(crate) fn buf(&self) -> MutexGuard<'_, Vec<u8>> {
+            self.buf.lock().unwrap()
+        }
+
+        pub(crate) fn get_string(&self) -> String {
+            let mut buf = self.buf.lock().expect("lock shouldn't be poisoned");
+            let string = std::str::from_utf8(&buf[..])
+                .expect("formatter should not have produced invalid utf-8")
+                .to_owned();
+            buf.clear();
+            string
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MockMakeWriter {
+        type Writer = MockWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            MockWriter::new(self.buf.clone())
+        }
+    }
+
+    // https://github.com/tokio-rs/tracing/blob/527b4f66a604e7a6baa6aa7536428e3a303ba3c8/tracing-subscriber/src/fmt/fmt_subscriber.rs#L1304
+    fn sanitize_timings(s: String) -> String {
+        let re = Regex::new("time\\.(idle|busy)=([0-9.]+)[mµn]s").unwrap();
+        re.replace_all(s.as_str(), "timing").to_string()
+    }
+
+    fn parse_json(s: &str) -> serde_json::Value {
+        serde_json::from_str::<serde_json::Value>(&s).expect(&format!("failed to parse '{}'", s))
+    }
+
+    fn parse_captured_logs(logs: String) -> Vec<serde_json::Value> {
+        logs.split('\n')
+            .filter(|l| !l.is_empty())
+            .map(|l| parse_json(l))
+            .collect()
+    }
+
+    #[test]
+    fn request_id_layer_preserves_fields() {
+        let request_id_layer = super::layer().boxed();
+        let make_writer = MockMakeWriter::default();
+        let json_layer = tracing_subscriber::fmt::layer()
+            .json()
+            .flatten_event(true)
+            .with_current_span(true)
+            .with_span_list(true)
+            .with_writer(make_writer.clone())
+            .with_level(false)
+            .with_ansi(false)
+            .with_timer(MockTime)
+            .with_span_events(FmtSpan::ENTER)
+            .boxed();
+
+        let layers = vec![request_id_layer, json_layer];
+
+        let registry = tracing_subscriber::registry().with(layers);
+
+        with_default(registry, || {
+            let span0_with_request_id =
+                tracing::info_span!("span0_with_request_id", request_id = 322);
+            let _e0 = span0_with_request_id.enter();
+            let span1 = tracing::info_span!("span1", x = 42);
+            let _e = span1.enter();
+        });
+        let actual = sanitize_timings(make_writer.get_string());
+        assert_eq!(
+            vec![
+                parse_json(
+                    r#"{
+                    "timestamp":"fake time",
+                    "message":"enter",
+                    "target":"blockscout_service_launcher::tracing::request_id_layer::tests",
+                    "span":{
+                        "request_id":322,
+                        "name":"span0_with_request_id"
+                    },
+                    "spans":[
+                        {
+                            "request_id":322,
+                            "name":"span0_with_request_id"
+                        }
+                    ]
+                }"#
+                ),
+                parse_json(
+                    r#"{
+                    "timestamp":"fake time",
+                    "message":"enter",
+                    "target":"blockscout_service_launcher::tracing::request_id_layer::tests",
+                    "span":{
+                        "request_id":322,
+                        "x":42,
+                        "name":"span1"
+                    },
+                    "spans":[
+                        {
+                            "request_id":322,
+                            "name":"span0_with_request_id"
+                        },
+                        {
+                            "request_id":322,
+                            "x":42,
+                            "name":"span1"
+                        }
+                    ]
+                }"#
+                )
+            ],
+            parse_captured_logs(actual)
+        );
+    }
+}


### PR DESCRIPTION
- Fix the layer overwriting fields of handled spans (due to setting `extensions` to some value which are prioritized over any fields)
- Add unit test to check it
- Clippy fixes