### PR TITLE
fix(stats): group member warns

### DIFF
--- a/stats/stats-server/src/runtime_setup.rs
+++ b/stats/stats-server/src/runtime_setup.rs
@@ -260,13 +260,16 @@ impl RuntimeSetup {
     /// Check if some dependencies are not present in their respective groups
     /// and make corresponding warn
     fn warn_non_member_charts(groups: &BTreeMap<String, ArcUpdateGroup>) {
-        // it's ok for `newBlocks` to be missed here, because
-        // `newBlocks_*` have their own group `NewBlocksGroup`
+        // Average charts have their 'weight' dependencies absent from
+        // the group because it doesn't make sense to update the weights
+        // if all averages are disabled (for some reason).
+        //
+        // The weights themselves (e.g. `newBlocks`) have their own groups
+        // for this
         let missing_members_allowed: HashMap<String, HashSet<String>> = [
-            (
-                "AverageBlockRewardsGroup",
-                vec!["newBlocks_MONTH", "newBlocks_DAY"],
-            ),
+            // no `MONTH` because the month one is not stored in DB
+            // (== not a chart (== doesn't have mutex))
+            ("AverageBlockRewardsGroup", vec!["newBlockRewards_DAY"]),
             (
                 "AverageBlockSizeGroup",
                 vec!["newBlocks_MONTH", "newBlocks_DAY"],
@@ -275,18 +278,9 @@ impl RuntimeSetup {
                 "AverageGasLimitGroup",
                 vec!["newBlocks_DAY", "newBlocks_MONTH"],
             ),
-            (
-                "AverageGasPriceGroup",
-                vec!["newBlocks_DAY", "newBlocks_MONTH"],
-            ),
-            (
-                "AverageTxnFeeGroup",
-                vec!["newBlocks_MONTH", "newBlocks_DAY"],
-            ),
-            (
-                "TxnsSuccessRateGroup",
-                vec!["newBlocks_DAY", "newBlocks_MONTH"],
-            ),
+            ("AverageGasPriceGroup", vec!["newTxns_DAY", "newTxns_MONTH"]),
+            ("AverageTxnFeeGroup", vec!["newTxns_DAY", "newTxns_MONTH"]),
+            ("TxnsSuccessRateGroup", vec!["newTxns_DAY", "newTxns_MONTH"]),
         ]
         .map(|(group_name, allowed_missing)| {
             (

--- a/stats/stats-server/src/runtime_setup.rs
+++ b/stats/stats-server/src/runtime_setup.rs
@@ -314,7 +314,7 @@ impl RuntimeSetup {
             let empty_set = HashSet::new();
             let group_missing_allowed = missing_members_allowed.get(name).unwrap_or(&empty_set);
             let missing_members = missing_members
-                .difference(&group_missing_allowed)
+                .difference(group_missing_allowed)
                 .collect_vec();
             if !missing_members.is_empty() {
                 tracing::warn!(

--- a/stats/stats-server/src/runtime_setup.rs
+++ b/stats/stats-server/src/runtime_setup.rs
@@ -267,9 +267,12 @@ impl RuntimeSetup {
                 .map(|s| s.to_owned())
                 .collect();
             // we rely on the fact that:
-            // chart names == their mutex ids
-            let members: HashSet<String> =
-                group.list_charts().into_iter().map(|c| c.name).collect();
+            // chart key == their mutex ids
+            let members: HashSet<String> = group
+                .list_charts()
+                .into_iter()
+                .map(|c| c.key.as_string())
+                .collect();
             let missing_members = sync_dependencies.difference(&members).collect_vec();
             if !missing_members.is_empty() {
                 tracing::warn!(


### PR DESCRIPTION
- Fix name of charts used for warning instead of new `key` - fixes all charts triggering the warning.
- Add whitelist to suppress the remaining WARN logs where applicable.