### PR TITLE
fix(stats): swagger in docker

### DIFF
--- a/stats/Dockerfile
+++ b/stats/Dockerfile
@@ -34,4 +34,7 @@ COPY ./config/charts.json ./config/charts.json
 COPY ./config/layout.json ./config/layout.json
 COPY ./config/update_groups.json ./config/update_groups.json
 
+ENV STATS__SWAGGER_FILE=/app/static/stats.swagger.yaml
+COPY ./stats-proto/swagger/stats.swagger.yaml $STATS__SWAGGER_FILE
+
 CMD ["./stats-server"]

--- a/stats/stats-server/src/server.rs
+++ b/stats/stats-server/src/server.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use crate::{
     config::{read_charts_config, read_layout_config, read_update_groups_config},
@@ -25,15 +25,23 @@ const SERVICE_NAME: &str = "stats";
 struct HttpRouter<S: StatsService> {
     stats: Arc<S>,
     health: Arc<HealthService>,
+    swagger_path: PathBuf,
 }
 
 impl<S: StatsService> launcher::HttpRouter for HttpRouter<S> {
     fn register_routes(&self, service_config: &mut actix_web::web::ServiceConfig) {
-        let swagger_file = std::path::PathBuf::from("../stats-proto/swagger/stats.swagger.yaml");
         service_config
             .configure(|config| route_health(config, self.health.clone()))
             .configure(|config| route_stats_service(config, self.stats.clone()))
-            .configure(|config| route_swagger(config, swagger_file, "/api/v1/docs/swagger.yaml"));
+            .configure(|config| {
+                route_swagger(
+                    config,
+                    self.swagger_path.clone(),
+                    // it's ok to not have this endpoint in swagger, as it is
+                    // the swagger itself
+                    "/api/v1/docs/swagger.yaml",
+                )
+            });
     }
 }
 
@@ -103,6 +111,7 @@ pub async fn stats(settings: Settings) -> Result<(), anyhow::Error> {
     let http_router = HttpRouter {
         stats: read_service,
         health: health.clone(),
+        swagger_path: settings.swagger_file,
     };
 
     let launch_settings = LaunchSettings {

--- a/stats/stats-server/src/server.rs
+++ b/stats/stats-server/src/server.rs
@@ -9,6 +9,7 @@ use crate::{
     update_service::UpdateService,
 };
 
+use anyhow::Context;
 use blockscout_endpoint_swagger::route_swagger;
 use blockscout_service_launcher::launcher::{self, LaunchSettings};
 use sea_orm::{ConnectOptions, Database};
@@ -71,11 +72,11 @@ pub async fn stats(settings: Settings) -> Result<(), anyhow::Error> {
         settings.run_migrations,
     )
     .await?;
-    let db = Arc::new(Database::connect(opt).await?);
+    let db = Arc::new(Database::connect(opt).await.context("stats DB")?);
 
     let mut opt = ConnectOptions::new(settings.blockscout_db_url.clone());
     opt.sqlx_logging_level(tracing::log::LevelFilter::Debug);
-    let blockscout = Arc::new(Database::connect(opt).await?);
+    let blockscout = Arc::new(Database::connect(opt).await.context("blockscout DB")?);
 
     let charts = Arc::new(RuntimeSetup::new(
         charts_config,

--- a/stats/stats-server/src/settings.rs
+++ b/stats/stats-server/src/settings.rs
@@ -25,6 +25,8 @@ pub struct Settings {
     pub charts_config: PathBuf,
     pub layout_config: PathBuf,
     pub update_groups_config: PathBuf,
+    /// Location of swagger file to serve
+    pub swagger_file: PathBuf,
 
     pub server: ServerSettings,
     pub metrics: MetricsSettings,
@@ -55,6 +57,7 @@ impl Default for Settings {
             charts_config: PathBuf::from_str("config/charts.json").unwrap(),
             layout_config: PathBuf::from_str("config/layout.json").unwrap(),
             update_groups_config: PathBuf::from_str("config/update_groups.json").unwrap(),
+            swagger_file: PathBuf::from("../stats-proto/swagger/stats.swagger.yaml"),
             blockscout_db_url: Default::default(),
             create_database: Default::default(),
             run_migrations: Default::default(),


### PR DESCRIPTION
Basically this:
```
❯ curl https://stats-sepolia.k8s-dev.blockscout.com/api/v1/docs/swagger.yaml
No such file or directory (os error 2)%
```