### PR TITLE
feat(env-collector): a few improvements for using in stats

### DIFF
--- a/libs/env-collector/Cargo.toml
+++ b/libs/env-collector/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.86"
 config = "0.14.0"
+itertools = "0.13.0"
 json_dotpath = "1.1.0"
 regex = "1.10.4"
 serde = { version = "1.0.203", features = ["derive"] }

--- a/libs/env-collector/README.md
+++ b/libs/env-collector/README.md
@@ -24,7 +24,8 @@ This is a simple tool to collect possible environment variables from `Settings` 
             "<SERVICE_NAME_PREFIX>",
             "README.md",
             "<PATH TO .TOML/.JSON EXAMPLE CONFIG>",
-            &["<ENV_PREFIX_TO_IGNORE>"],
+            &[PrefixFilter::blacklist("<ENV_PREFIX_TO_IGNORE>")],
+            Some("some_postfix"),
         );
     }
     ```
@@ -33,8 +34,8 @@ This is a simple tool to collect possible environment variables from `Settings` 
     ```markdown
     ## Envs
 
-    [anchor]: <> (anchors.envs.start)
-    [anchor]: <> (anchors.envs.end)
+    [anchor]: <> (anchors.envs.start.some_postfix)
+    [anchor]: <> (anchors.envs.end.some_postfix)
     ```
 
 4. (Optional) In your `justfile` add new command to run `check-envs.rs`:

--- a/libs/env-collector/src/lib.rs
+++ b/libs/env-collector/src/lib.rs
@@ -193,7 +193,7 @@ impl Envs {
         let json = serde_json::to_value(&settings).context("failed to convert config to json")?;
         let from_config: Envs = flatten_json(&json, service_prefix)
             .into_iter()
-            .filter(|(key, _)| vars_filter.filter(&key))
+            .filter(|(key, _)| vars_filter.filter(key))
             .map(|(key, value)| {
                 let default_value =
                     default_of_var(&settings, &from_key_to_json_path(&key, service_prefix));
@@ -491,7 +491,7 @@ fn _flat_json(json: &Value, prefix: &str, env_vars: &mut BTreeMap<String, String
         _ => {
             let env_var_name = prefix.to_uppercase();
             let env_var_value = match json {
-                Value::String(s) => format!("\"{}\"", s.to_string()),
+                Value::String(s) => format!("\"{}\"", s),
                 Value::Number(n) => n.to_string(),
                 Value::Bool(b) => b.to_string(),
                 Value::Null => "null".to_string(),

--- a/libs/env-collector/src/lib.rs
+++ b/libs/env-collector/src/lib.rs
@@ -408,7 +408,7 @@ fn try_get_description(_key: &str, value: &str, default: &Option<serde_json::Val
     }
     let default_str = default
         .as_ref()
-        .map(|v| json_value_to_env_value(v))
+        .map(json_value_to_env_value)
         .unwrap_or_default();
 
     // If the value is the same as the default value, we don't need to show it in the description

--- a/libs/env-collector/src/lib.rs
+++ b/libs/env-collector/src/lib.rs
@@ -444,11 +444,17 @@ mod tests {
         pub test2: i32,
         pub test3_set: Option<bool>,
         pub test4_not_set: Option<bool>,
+        #[serde(default = "very_cool_string")]
+        pub string_with_default: String,
         pub database: DatabaseSettings,
     }
 
     fn default_test2() -> i32 {
         1000
+    }
+
+    fn very_cool_string() -> String {
+        "kekek".into()
     }
 
     fn var(
@@ -522,6 +528,12 @@ mod tests {
             ),
             var("TEST_SERVICE__TEST4_NOT_SET", Some("null"), false, ""),
             var(
+                "TEST_SERVICE__STRING_WITH_DEFAULT",
+                Some("kekek"),
+                false,
+                "",
+            ),
+            var(
                 "TEST_SERVICE__DATABASE__CONNECT__URL",
                 None,
                 true,
@@ -546,6 +558,7 @@ mod tests {
 | `TEST_SERVICE__TEST2`                     | false       | e.g. `123`       | `1000`        |
 | `TEST_SERVICE__TEST3_SET`                 | false       | e.g. `false`     | `null`        |
 | `TEST_SERVICE__TEST4_NOT_SET`             | false       |                  | `null`        |
+| `TEST_SERVICE__STRING_WITH_DEFAULT`       | false       |                  | `kekek`       |
 | `TEST_SERVICE__DATABASE__CONNECT__URL`    | true        | e.g. `test-url`  |               |
 [anchor]: <> (anchors.envs.end.cool_postfix)
 "#
@@ -641,6 +654,7 @@ mod tests {
 | `TEST_SERVICE__TEST2` | | e.g. `123` | `1000` |
 | `TEST_SERVICE__TEST3_SET` | | e.g. `false` | `null` |
 | `TEST_SERVICE__TEST4_NOT_SET` | | | `null` |
+| `TEST_SERVICE__STRING_WITH_DEFAULT` | | | `kekek` |
 
 [anchor]: <> (anchors.envs.end)
 "#

--- a/libs/env-collector/src/lib.rs
+++ b/libs/env-collector/src/lib.rs
@@ -199,7 +199,7 @@ impl Envs {
                     default_of_var(&settings, &from_key_to_json_path(&key, service_prefix));
                 let required = default_value.is_none();
                 let description = try_get_description(&key, &value, &default_value);
-                let default_value = default_value.map(|v| v.to_string());
+                let default_value = default_value.map(|v| format!("`{}`", v));
                 let var = EnvVariable {
                     key: key.clone(),
                     required,
@@ -245,7 +245,7 @@ impl Envs {
                     let default_value = if default_value.trim().is_empty() {
                         None
                     } else {
-                        Some(default_value.to_string())
+                        Some(default_value.trim().to_string())
                     };
                     let var = EnvVariable {
                         key: key.to_string(),
@@ -442,7 +442,7 @@ fn serialize_env_vars_to_md_table(vars: Envs) -> String {
         let default_value = env
             .default_value
             .as_ref()
-            .map(|v| format!(" `{v}` "))
+            .map(|v| format!(" {v} "))
             .unwrap_or(" ".to_string());
         result.push_str(&format!(
             "| `{}` |{}|{}|{}|\n",
@@ -465,7 +465,7 @@ fn regex_md_table_row() -> &'static str {
         r"\|\s*`([^|`]*)`\s*",
         r"\|\s*([^|]*)\s*",
         r"\|\s*([^|]*)\s*",
-        r"\|\s*`?([^|`]*)`?\s*",
+        r"\|\s*([^|]*)\s*",
         r#"\|"#
     )
 }
@@ -607,28 +607,33 @@ mod tests {
             var("TEST_SERVICE__TEST", None, true, "e.g. `\"value\"`"),
             var(
                 "TEST_SERVICE__DATABASE__CREATE_DATABASE",
-                Some("false"),
+                Some("`false`"),
                 false,
                 "",
             ),
             var(
                 "TEST_SERVICE__DATABASE__RUN_MIGRATIONS",
-                Some("false"),
+                Some("`false`"),
                 false,
                 "",
             ),
-            var("TEST_SERVICE__TEST2", Some("1000"), false, "e.g. `123`"),
+            var("TEST_SERVICE__TEST2", Some("`1000`"), false, "e.g. `123`"),
             var(
                 "TEST_SERVICE__TEST3_SET",
-                Some("null"),
+                Some("`null`"),
                 false,
                 "e.g. `false`",
             ),
-            var("TEST_SERVICE__TEST4_NOT_SET", Some("null"), false, ""),
-            var("TEST_SERVICE__TEST5_WITH_UNICODE", Some("false"), false, ""),
+            var("TEST_SERVICE__TEST4_NOT_SET", Some("`null`"), false, ""),
+            var(
+                "TEST_SERVICE__TEST5_WITH_UNICODE",
+                Some("`false`"),
+                false,
+                "",
+            ),
             var(
                 "TEST_SERVICE__STRING_WITH_DEFAULT",
-                Some("\"kekek\""),
+                Some("`\"kekek\"`"),
                 false,
                 "",
             ),

--- a/libs/env-collector/src/lib.rs
+++ b/libs/env-collector/src/lib.rs
@@ -418,7 +418,7 @@ fn _flat_json(json: &Value, prefix: &str, env_vars: &mut BTreeMap<String, String
         _ => {
             let env_var_name = prefix.to_uppercase();
             let env_var_value = match json {
-                Value::String(s) => s.to_string(),
+                Value::String(s) => format!("\"{}\"", s.to_string()),
                 Value::Number(n) => n.to_string(),
                 Value::Bool(b) => b.to_string(),
                 Value::Null => "null".to_string(),
@@ -506,7 +506,7 @@ mod tests {
 
     fn default_envs() -> Envs {
         Envs::from(BTreeMap::from_iter(vec![
-            var("TEST_SERVICE__TEST", None, true, "e.g. `value`"),
+            var("TEST_SERVICE__TEST", None, true, "e.g. `\"value\"`"),
             var(
                 "TEST_SERVICE__DATABASE__CREATE_DATABASE",
                 Some("false"),
@@ -529,7 +529,7 @@ mod tests {
             var("TEST_SERVICE__TEST4_NOT_SET", Some("null"), false, ""),
             var(
                 "TEST_SERVICE__STRING_WITH_DEFAULT",
-                Some("kekek"),
+                Some("\"kekek\""),
                 false,
                 "",
             ),
@@ -537,7 +537,7 @@ mod tests {
                 "TEST_SERVICE__DATABASE__CONNECT__URL",
                 None,
                 true,
-                "e.g. `test-url`",
+                "e.g. `\"test-url\"`",
             ),
         ]))
     }
@@ -552,14 +552,14 @@ mod tests {
 
 | Variable                                  | Required    | Description      | Default Value |
 |-------------------------------------------|-------------|------------------|---------------|
-| `TEST_SERVICE__TEST`                      | true        | e.g. `value`     |               |
+| `TEST_SERVICE__TEST`                      | true        | e.g. `"value"`   |               |
 | `TEST_SERVICE__DATABASE__CREATE_DATABASE` | false       |                  | `false`       |
 | `TEST_SERVICE__DATABASE__RUN_MIGRATIONS`  | false       |                  | `false`       |
 | `TEST_SERVICE__TEST2`                     | false       | e.g. `123`       | `1000`        |
 | `TEST_SERVICE__TEST3_SET`                 | false       | e.g. `false`     | `null`        |
 | `TEST_SERVICE__TEST4_NOT_SET`             | false       |                  | `null`        |
-| `TEST_SERVICE__STRING_WITH_DEFAULT`       | false       |                  | `kekek`       |
-| `TEST_SERVICE__DATABASE__CONNECT__URL`    | true        | e.g. `test-url`  |               |
+| `TEST_SERVICE__STRING_WITH_DEFAULT`       | false       |                  | `"kekek"`     |
+| `TEST_SERVICE__DATABASE__CONNECT__URL`    | true        | e.g. `"test-url"`|               |
 [anchor]: <> (anchors.envs.end.cool_postfix)
 "#
     }
@@ -646,15 +646,15 @@ mod tests {
 | Variable | Required | Description | Default value |
 | --- | --- | --- | --- |
 | `SOME_EXTRA_VARS2` | true | | `example_value2` |
-| `TEST_SERVICE__DATABASE__CONNECT__URL` | true | e.g. `test-url` | |
-| `TEST_SERVICE__TEST` | true | e.g. `value` | |
+| `TEST_SERVICE__DATABASE__CONNECT__URL` | true | e.g. `"test-url"` | |
+| `TEST_SERVICE__TEST` | true | e.g. `"value"` | |
 | `SOME_EXTRA_VARS` | | comment should be saved. `kek` | `example_value` |
 | `TEST_SERVICE__DATABASE__CREATE_DATABASE` | | | `false` |
 | `TEST_SERVICE__DATABASE__RUN_MIGRATIONS` | | | `false` |
+| `TEST_SERVICE__STRING_WITH_DEFAULT` | | | `"kekek"` |
 | `TEST_SERVICE__TEST2` | | e.g. `123` | `1000` |
 | `TEST_SERVICE__TEST3_SET` | | e.g. `false` | `null` |
 | `TEST_SERVICE__TEST4_NOT_SET` | | | `null` |
-| `TEST_SERVICE__STRING_WITH_DEFAULT` | | | `kekek` |
 
 [anchor]: <> (anchors.envs.end)
 "#

--- a/libs/env-collector/src/lib.rs
+++ b/libs/env-collector/src/lib.rs
@@ -423,8 +423,11 @@ fn from_key_to_json_path(key: &str, service_prefix: &str) -> String {
 }
 
 fn serialize_env_vars_to_md_table(vars: Envs) -> String {
+    // zero-width spaces in "Required" so that
+    // the word can be broken down and
+    // its colum doesn't take unnecessary space
     let mut result = r#"
-| Variable | Required | Description | Default value |
+| Variable | Req&#x200B;uir&#x200B;ed | Description | Default value |
 | --- | --- | --- | --- |
 "#
     .to_string();
@@ -746,7 +749,7 @@ mod tests {
             r#"
 [anchor]: <> (anchors.envs.start)
 
-| Variable | Required | Description | Default value |
+| Variable | Req&#x200B;uir&#x200B;ed | Description | Default value |
 | --- | --- | --- | --- |
 | `TEST_SERVICE__TEST5_WITH_UNICODE♡♡♡` | | the variable should be matched with `TEST_SERVICE__TEST5_WITH_UNICODE` and the unicode must be saved | `false` |
 | `SOME_EXTRA_VARS` | | comment should be saved. `kek` | `example_value` |


### PR DESCRIPTION
- configurable anchor postfix
- more flexible filtering
- keep user-defined order in the table
- ignore non-ascii symbols in env names (to allow custom formatting with zero-width spaces, for example)
- more compact "Required" column
- more general allowed format for "default value" column