### PR TITLE
fix(stats): slightly incorrect `new_accounts` chart schedule

### DIFF
--- a/stats/config/update_groups.json
+++ b/stats/config/update_groups.json
@@ -4,7 +4,7 @@
         "total_addresses_group": "0 0 */3 * * * *",
         "average_block_time_group": "0 0 15 * * * *",
         "completed_txns_group": "0 5 */3 * * * *",
-        "new_accounts_group": "0 0 5,16,21 * * * *",
+        "new_accounts_group": "0 0 5 * * * *",
         "new_native_coin_transfers_group": "0 0 3,13 * * * *",
         "total_tokens_group": "0 0 18 * * * *",
         "new_txns_group": "0 10 */3 * * * *",


### PR DESCRIPTION
When migrating the update schedules I did not correctly understand how `Cache` worked, so the load on DB from `new_accounts` + `total_accounts` + `accounts_growth` got tripled. This restores the original behaviour, as the load on DB in metrics seems too much