### PR TITLE
fix(user-ops-indexer): stop indexing from already closed ws connections

### DIFF
--- a/user-ops-indexer/Cargo.lock
+++ b/user-ops-indexer/Cargo.lock
@@ -919,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "blockscout-service-launcher"
-version = "0.10.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545355abddfc1617d40529141b7e849feed732328ccf54850f691dc31cf24856"
+checksum = "b5cec0536a1cbb561e98f807bf3b5b913120edaa58f5caaa45d07fb58353e40e"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/user-ops-indexer/Cargo.toml
+++ b/user-ops-indexer/Cargo.toml
@@ -9,4 +9,4 @@ members = [
 ]
 
 [workspace.dependencies]
-blockscout-service-launcher = "0.10.0"
+blockscout-service-launcher = "0.13.2"

--- a/user-ops-indexer/user-ops-indexer-server/src/indexer.rs
+++ b/user-ops-indexer/user-ops-indexer-server/src/indexer.rs
@@ -70,7 +70,12 @@ async fn start_indexer_with_retries<L: IndexerLogic + Sync + Clone + Send + 'sta
         loop {
             match indexer.start().await {
                 Err(err) => {
-                    tracing::error!(error = ?err, version = L::version(), ?delay, "indexer startup failed, retrying");
+                    tracing::error!(
+                        error = ?err,
+                        version = L::version(),
+                        ?delay,
+                        "indexer stream ended with error, retrying"
+                    );
                 }
                 Ok(_) => {
                     if !settings.realtime.enabled {


### PR DESCRIPTION
When WS connection is closed, user-ops-indexer stream should be restarted immediately, without waiting for the whole stream to end.