### PR TITLE
fix: too long db names in tests

### DIFF
--- a/.github/workflows/bens.yml
+++ b/.github/workflows/bens.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: admin
           POSTGRES_USER: graph-node

--- a/.github/workflows/da-indexer.yml
+++ b/.github/workflows/da-indexer.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: admin
           POSTGRES_USER: postgres

--- a/.github/workflows/eth-bytecode-db.yml
+++ b/.github/workflows/eth-bytecode-db.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: admin
           POSTGRES_USER: postgres

--- a/.github/workflows/user-ops-indexer.yml
+++ b/.github/workflows/user-ops-indexer.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: admin
           POSTGRES_USER: postgres

--- a/blockscout-ens/bens-logic/src/test_utils.rs
+++ b/blockscout-ens/bens-logic/src/test_utils.rs
@@ -83,7 +83,7 @@ pub async fn mocked_blockscout_client() -> BlockscoutClient {
     let mock_server = MockServer::start().await;
     for (tx_hash, tx) in TXNS.iter() {
         let mock =
-            Mock::given(method("GET")).and(path(&format!("/api/v2/transactions/{tx_hash:#x}")));
+            Mock::given(method("GET")).and(path(format!("/api/v2/transactions/{tx_hash:#x}")));
         mock.respond_with(ResponseTemplate::new(200).set_body_json(tx))
             .mount(&mock_server)
             .await;

--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -6421,9 +6421,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -6442,9 +6442,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.13.1"
+version = "0.13.2"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/test_database.rs
+++ b/libs/blockscout-service-launcher/src/test_database.rs
@@ -21,7 +21,8 @@ impl TestDbGuard {
             .await
             .expect("Connection to postgres (without database) failed");
         // We use a hash, as the name itself may be quite long and be trimmed.
-        let db_name = format!("_{:x}", keccak_hash::keccak(db_name));
+        // Postgres DB name should be 63 symbols max.
+        let db_name = format!("_{:x}", keccak_hash::keccak(db_name))[..63].to_string();
         let mut guard = TestDbGuard {
             conn_with_db: Arc::new(DatabaseConnection::Disconnected),
             conn_without_db: Arc::new(conn_without_db),

--- a/service-template/.github/workflows/{{project-name}}.yml
+++ b/service-template/.github/workflows/{{project-name}}.yml
@@ -29,7 +29,7 @@ jobs:
     {%- if database %}
     services:
       postgres:
-        image: postgres
+        image: postgres:16
         env:
           POSTGRES_PASSWORD: admin
           POSTGRES_USER: postgres


### PR DESCRIPTION
Current behavior breaks tests on `postgres:17`