### PR TITLE
feat(verifier) support partial commit hash matches for solidity and vyper compilers

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier-server/src/services/common.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/services/common.rs
@@ -1,7 +1,9 @@
 use crate::settings::{FetcherSettings, S3FetcherSettings};
 use cron::Schedule;
 use s3::{creds::Credentials, Bucket, Region};
-use smart_contract_verifier::{Fetcher, FileValidator, ListFetcher, S3Fetcher, Version};
+use smart_contract_verifier::{
+    DetailedVersion, Fetcher, FileValidator, ListFetcher, S3Fetcher, Version,
+};
 use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 pub async fn initialize_fetcher<Ver: Version>(
@@ -69,4 +71,32 @@ fn new_bucket(settings: &S3FetcherSettings) -> anyhow::Result<Arc<Bucket>> {
         )?,
     )?);
     Ok(bucket)
+}
+
+/// Normalizes the requested compiler version by matching it against a list of known compiler versions.
+/// The function takes a [`DetailedVersion`] from the request and attempts to find a corresponding version
+/// from the known list, allowing for cases where the requested commit hash is either a prefix or a longer
+/// version than the known one. If a matching version is found, it is returned; otherwise, a
+/// [`Status::invalid_argument`] error is returned.
+pub fn normalize_request_compiler_version(
+    compilers: &[DetailedVersion],
+    request_compiler_version: &DetailedVersion,
+) -> Result<DetailedVersion, tonic::Status> {
+    let corresponding_known_compiler_version = compilers.iter().find(|&version| {
+        return version.version() == request_compiler_version.version()
+            && version.date() == request_compiler_version.date()
+            && (version
+                .commit()
+                .starts_with(request_compiler_version.commit())
+                || request_compiler_version
+                    .commit()
+                    .starts_with(version.commit()));
+    });
+    if let Some(compiler_version) = corresponding_known_compiler_version {
+        Ok(compiler_version.clone())
+    } else {
+        Err(tonic::Status::invalid_argument(format!(
+            "Compiler version not found: {request_compiler_version}"
+        )))
+    }
 }

--- a/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/src/services/vyper_verifier.rs
@@ -55,35 +55,6 @@ impl VyperVerifierService {
             client: Arc::new(client),
         })
     }
-
-    /// Normalizes the requested compiler version by matching it against a list of known compiler versions.
-    /// The function takes a `DetailedVersion` from the request and attempts to find a corresponding version
-    /// from the known list, allowing for cases where the requested commit hash is either a prefix or a longer
-    /// version than the known one. If a matching version is found, it is returned; otherwise, a
-    /// [`Status::invalid_argument`] error is returned.
-    fn normalize_request_compiler_version(
-        &self,
-        request_compiler_version: &smart_contract_verifier::DetailedVersion,
-    ) -> Result<smart_contract_verifier::DetailedVersion, Status> {
-        let compilers = self.client.compilers().all_versions();
-        let corresponding_known_compiler_version = compilers.iter().find(|&version| {
-            return version.version() == request_compiler_version.version()
-                && version.date() == request_compiler_version.date()
-                && (version
-                    .commit()
-                    .starts_with(request_compiler_version.commit())
-                    || request_compiler_version
-                        .commit()
-                        .starts_with(version.commit()));
-        });
-        if let Some(compiler_version) = corresponding_known_compiler_version {
-            Ok(compiler_version.clone())
-        } else {
-            Err(Status::invalid_argument(format!(
-                "Compiler version not found: {request_compiler_version}"
-            )))
-        }
-    }
 }
 
 #[async_trait::async_trait]
@@ -123,8 +94,10 @@ impl VyperVerifier for VyperVerifierService {
 
         let mut verification_request: vyper::multi_part::VerificationRequest =
             request.try_into()?;
-        verification_request.compiler_version =
-            self.normalize_request_compiler_version(&verification_request.compiler_version)?;
+        verification_request.compiler_version = common::normalize_request_compiler_version(
+            &self.client.compilers().all_versions(),
+            &verification_request.compiler_version,
+        )?;
 
         let result = vyper::multi_part::verify(self.client.clone(), verification_request).await;
 
@@ -203,8 +176,10 @@ impl VyperVerifier for VyperVerifierService {
             }
             request.unwrap()
         };
-        verification_request.compiler_version =
-            self.normalize_request_compiler_version(&verification_request.compiler_version)?;
+        verification_request.compiler_version = common::normalize_request_compiler_version(
+            &self.client.compilers().all_versions(),
+            &verification_request.compiler_version,
+        )?;
 
         let result = vyper::standard_json::verify(self.client.clone(), verification_request).await;
 

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/solidity.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/solidity.rs
@@ -56,7 +56,10 @@ async fn test_setup<T: TestCase>(test_case: &T, bytecode_type: BytecodeType) -> 
         .await
 }
 
-async fn test_success<T: TestCase>(test_case: &T, bytecode_type: BytecodeType) {
+async fn get_verification_response<T: TestCase>(
+    test_case: &T,
+    bytecode_type: BytecodeType,
+) -> VerifyResponse {
     let response = test_setup(test_case, bytecode_type).await;
     if !response.status().is_success() {
         let status = response.status();
@@ -77,6 +80,18 @@ async fn test_success<T: TestCase>(test_case: &T, bytecode_type: BytecodeType) {
         "Verification extra_data is absent"
     );
 
+    assert!(
+        verification_response.source.is_some(),
+        "Verification source is absent"
+    );
+
+    verification_response
+}
+
+fn validate_verification_response<T: TestCase>(
+    test_case: &T,
+    verification_response: VerifyResponse,
+) {
     let source = verification_response
         .source
         .expect("Verification source is absent");
@@ -260,6 +275,11 @@ async fn test_success<T: TestCase>(test_case: &T, bytecode_type: BytecodeType) {
     }
 }
 
+async fn test_success<T: TestCase>(test_case: &T, bytecode_type: BytecodeType) {
+    let verification_response = get_verification_response(test_case, bytecode_type).await;
+    validate_verification_response(test_case, verification_response);
+}
+
 async fn _test_failure<T: TestCase>(
     test_case: &T,
     bytecode_type: BytecodeType,
@@ -370,5 +390,53 @@ mod success_tests {
         let test_case = solidity_types::from_file::<StandardJson>("cancun");
         test_success(&test_case, BytecodeType::CreationInput).await;
         test_success(&test_case, BytecodeType::DeployedBytecode).await;
+    }
+
+    #[tokio::test]
+    async fn flattened_accepts_partially_matching_compiler_version_commit_hashes() {
+        // provided commit hash is a prefix of the one used in the list
+        let initial_test_case = solidity_types::from_file::<Flattened>("simple_storage");
+        let test_case = {
+            let mut test_case = initial_test_case.clone();
+            test_case.compiler_version.pop();
+            test_case
+        };
+        let verification_response =
+            get_verification_response(&test_case, BytecodeType::CreationInput).await;
+        validate_verification_response(&initial_test_case, verification_response);
+
+        // the commit hash from the list is a prefix of the provided one
+        let test_case = {
+            let mut test_case = initial_test_case.clone();
+            test_case.compiler_version.push_str("1234");
+            test_case
+        };
+        let verification_response =
+            get_verification_response(&test_case, BytecodeType::CreationInput).await;
+        validate_verification_response(&initial_test_case, verification_response);
+    }
+
+    #[tokio::test]
+    async fn standard_json_accepts_partially_matching_compiler_version_commit_hashes() {
+        // provided commit hash is a prefix of the one used in the list
+        let initial_test_case = solidity_types::from_file::<StandardJson>("cancun");
+        let test_case = {
+            let mut test_case = initial_test_case.clone();
+            test_case.compiler_version.pop();
+            test_case
+        };
+        let verification_response =
+            get_verification_response(&test_case, BytecodeType::CreationInput).await;
+        validate_verification_response(&initial_test_case, verification_response);
+
+        // the commit hash from the list is a prefix of the provided one
+        let test_case = {
+            let mut test_case = initial_test_case.clone();
+            test_case.compiler_version.push_str("1234");
+            test_case
+        };
+        let verification_response =
+            get_verification_response(&test_case, BytecodeType::CreationInput).await;
+        validate_verification_response(&initial_test_case, verification_response);
     }
 }


### PR DESCRIPTION
That should help to solve the inability to verify Vyper contracts via [titanoboa](https://github.com/vyperlang/titanoboa/tree/master/boa) verification tool due to the following issue https://github.com/vyperlang/vyper/issues/4308