### PR TITLE
fix(verifier): return evm compiler version actually used for successful verification

### DIFF
--- a/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_zksync_solidity/era_solidity_0.8.28.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_zksync_solidity/era_solidity_0.8.28.json
@@ -27,5 +27,7 @@
     },
     "expected_runtime_match_type": "full",
     "expected_runtime_transformations": [],
-    "expected_runtime_values": {}
+    "expected_runtime_values": {},
+
+    "expected_evm_compiler_version": "v0.8.28+commit.acc7d8f9"
 }

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_zksync_solidity/zksolc_1_3_5.json
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/test_cases_zksync_solidity/zksolc_1_3_5.json
@@ -27,5 +27,7 @@
     },
     "expected_runtime_match_type": "full",
     "expected_runtime_transformations": [],
-    "expected_runtime_values": {}
+    "expected_runtime_values": {},
+
+    "expected_evm_compiler_version": "v0.8.17+commit.6c091780"
 }

--- a/smart-contract-verifier/smart-contract-verifier-server/tests/zksync_integration/types.rs
+++ b/smart-contract-verifier/smart-contract-verifier-server/tests/zksync_integration/types.rs
@@ -53,6 +53,7 @@ pub struct StandardJson {
     pub expected_runtime_match_type: Option<String>,
     pub expected_runtime_transformations: Option<Value>,
     pub expected_runtime_values: Option<Value>,
+    pub expected_evm_compiler_version: Option<String>,
 }
 
 impl TestCase for StandardJson {
@@ -87,9 +88,13 @@ impl TestCase for StandardJson {
             success.evm_compiler.as_ref().unwrap().compiler,
             "invalid evm-compiler"
         );
+        let expected_evm_compiler_version = self
+            .expected_evm_compiler_version
+            .as_ref()
+            .unwrap_or(&self.evm_compiler_version);
         assert_eq!(
-            self.evm_compiler_version,
-            success.evm_compiler.as_ref().unwrap().version,
+            expected_evm_compiler_version,
+            &success.evm_compiler.as_ref().unwrap().version,
             "invalid evm-compiler version"
         );
 

--- a/smart-contract-verifier/smart-contract-verifier/src/zksync/implementation.rs
+++ b/smart-contract-verifier/smart-contract-verifier/src/zksync/implementation.rs
@@ -107,7 +107,9 @@ pub async fn verify(
 
     let mut successes = vec![];
     let mut failures = vec![];
+    let mut used_version = evm_compilers.head.version.clone();
     for evm_compiler in evm_compilers {
+        used_version = evm_compiler.version.clone();
         let (zk_compiler_path, evm_compiler_path) = compilers
             .fetch_compilers(&zk_compiler, &evm_compiler)
             .await?;
@@ -136,7 +138,7 @@ pub async fn verify(
         zk_compiler: "zksolc".to_string(),
         zk_compiler_version,
         evm_compiler: "solc".to_string(),
-        evm_compiler_version,
+        evm_compiler_version: used_version,
         language: Language::Solidity,
         compiler_settings: serde_json::to_value(compiler_input.settings)
             .context("compiler settings serialization")?,


### PR DESCRIPTION
Right now the versions used in the request are returned. For example, if user specified a usual v0.8.28+commit.7893614a solidity compiler in the request it will be returned even though era-solidity v0.8.28+commit.acc7d8f9 resulted in successful verification