### PR TITLE
fix(da_indexer): OP integration

### DIFF
--- a/da-indexer/da-indexer-logic/src/celestia/l2_router/optimism.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/l2_router/optimism.rs
@@ -20,10 +20,10 @@ pub struct L2BatchOptimism {
     blobs: Vec<Blob>,
     internal_id: u64,
     l1_timestamp: String,
-    l1_tx_hashes: Vec<String>,
+    l1_transaction_hashes: Vec<String>,
     l2_block_start: u64,
     l2_block_end: u64,
-    tx_count: u64,
+    transaction_count: u64,
 }
 
 pub async fn get_l2_batch(
@@ -74,7 +74,7 @@ pub async fn get_l2_batch(
         l2_batch_id: response.internal_id.to_string(),
         l2_start_block: response.l2_block_start,
         l2_end_block: response.l2_block_end,
-        l2_batch_tx_count: response.tx_count as u32,
+        l2_batch_tx_count: response.transaction_count as u32,
         l2_blockscout_url: Url::parse(&config.l2_blockscout_url)?
             .join(&format!("batches/{}", response.internal_id))?
             .to_string(),

--- a/da-indexer/da-indexer-logic/src/celestia/tests/l2_router.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/tests/l2_router.rs
@@ -139,13 +139,13 @@ async fn create_blockscout_mock() -> MockServer {
                 ],
                 "internal_id": 5,
                 "l1_timestamp": "2023-12-20T10:17:24.000000Z",
-                "l1_tx_hashes": [
+                "l1_transaction_hashes": [
                   "0xf41211e966ec23032dde713d1f775ae5cb07dc5e15951281e6844d74cc02a930",
                   "0x9abc0df13890e8c0818b448b15056ecd96368dc2b4f625c1232285e05e5b3826"
                 ],
                 "l2_block_start": 29996,
                 "l2_block_end": 33082,
-                "tx_count": 1
+                "transaction_count": 1
               }
         )))
         .mount(&mock_server)


### PR DESCRIPTION
The latest Blockscout release included some renamings in the API response used by `l2router`. This PR updates the integration code to reflect these changes.