### PR TITLE
feat(da_indexer): add l2Namespaces endpoint

### DIFF
--- a/da-indexer/da-indexer-logic/src/celestia/l2_router/mod.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/l2_router/mod.rs
@@ -57,6 +57,10 @@ impl L2Router {
             L2Type::Arbitrum => arbitrum::get_l2_batch(config, height, commitment).await,
         }
     }
+
+    pub fn get_namespaces(&self) -> Vec<String> {
+        self.routes.keys().cloned().collect()
+    }
 }
 
 pub fn new_client(config: &L2Config) -> Result<ClientWithMiddleware> {

--- a/da-indexer/da-indexer-proto/proto/v1/api_config_http.yaml
+++ b/da-indexer/da-indexer-proto/proto/v1/api_config_http.yaml
@@ -10,6 +10,9 @@ http:
     - selector: blockscout.daIndexer.v1.CelestiaService.GetL2BatchMetadata
       get: /api/v1/celestia/l2BatchMetadata
 
+    - selector: blockscout.daIndexer.v1.CelestiaService.GetL2Namespaces
+      get: /api/v1/celestia/l2Namespaces
+
     - selector: blockscout.daIndexer.v1.EigenDaService.GetBlob
       get: /api/v1/eigenda/blob
     

--- a/da-indexer/da-indexer-proto/proto/v1/da-indexer.proto
+++ b/da-indexer/da-indexer-proto/proto/v1/da-indexer.proto
@@ -8,6 +8,7 @@ option go_package = "github.com/blockscout/blockscout-rs/da-indexer";
 service CelestiaService {
   rpc GetBlob(GetCelestiaBlobRequest) returns (CelestiaBlob) {}
   rpc GetL2BatchMetadata(CelestiaBlobId) returns (CelestiaL2BatchMetadata) {}
+  rpc GetL2Namespaces(Empty) returns (CelestiaNamespaces) {}
 }
 
 service EigenDaService {
@@ -46,6 +47,12 @@ message CelestiaL2BatchMetadata {
   uint64 l1_tx_timestamp = 8;
   optional uint32 l1_chain_id = 9;
   repeated CelestiaBlobId related_blobs = 10;
+}
+
+message Empty {}
+
+message CelestiaNamespaces {
+  repeated string namespaces = 1;
 }
 
 message GetEigenDaBlobRequest {

--- a/da-indexer/da-indexer-proto/swagger/v1/da-indexer.swagger.yaml
+++ b/da-indexer/da-indexer-proto/swagger/v1/da-indexer.swagger.yaml
@@ -67,6 +67,20 @@ paths:
           type: string
       tags:
         - CelestiaService
+  /api/v1/celestia/l2Namespaces:
+    get:
+      operationId: CelestiaService_GetL2Namespaces
+      responses:
+        "200":
+          description: A successful response.
+          schema:
+            $ref: '#/definitions/v1CelestiaNamespaces'
+        default:
+          description: An unexpected error response.
+          schema:
+            $ref: '#/definitions/rpcStatus'
+      tags:
+        - CelestiaService
   /api/v1/eigenda/blob:
     get:
       operationId: EigenDaService_GetBlob
@@ -206,6 +220,13 @@ definitions:
         items:
           type: object
           $ref: '#/definitions/v1CelestiaBlobId'
+  v1CelestiaNamespaces:
+    type: object
+    properties:
+      namespaces:
+        type: array
+        items:
+          type: string
   v1EigenDaBlob:
     type: object
     properties:

--- a/da-indexer/da-indexer-server/src/services/celestia.rs
+++ b/da-indexer/da-indexer-server/src/services/celestia.rs
@@ -2,7 +2,8 @@ use crate::proto::celestia_service_server::CelestiaService as Celestia;
 use base64::prelude::*;
 use da_indexer_logic::celestia::{l2_router::L2Router, repository::blobs};
 use da_indexer_proto::blockscout::da_indexer::v1::{
-    CelestiaBlob, CelestiaBlobId, CelestiaL2BatchMetadata, GetCelestiaBlobRequest,
+    CelestiaBlob, CelestiaBlobId, CelestiaL2BatchMetadata, CelestiaNamespaces, Empty,
+    GetCelestiaBlobRequest,
 };
 use sea_orm::DatabaseConnection;
 use tonic::{Request, Response, Status};
@@ -102,5 +103,18 @@ impl Celestia for CelestiaService {
             l1_chain_id: l2_batch_metadata.l1_chain_id,
             related_blobs,
         }))
+    }
+
+    async fn get_l2_namespaces(
+        &self,
+        _request: Request<Empty>,
+    ) -> Result<Response<CelestiaNamespaces>, Status> {
+        let l2_router = self
+            .l2_router
+            .as_ref()
+            .ok_or(Status::unimplemented("l2 router is not configured"))?;
+
+        let namespaces = l2_router.get_namespaces();
+        Ok(Response::new(CelestiaNamespaces { namespaces }))
     }
 }


### PR DESCRIPTION
This PR introduces a new endpoint that returns a list of namespaces known to the L2 router. This could be helpful for avoiding unnecessary requests by filtering out unknown namespaces.