### PR TITLE
feat(stats): Back3nd chart5 Migration (Part 2: yesterday's transactions)

### DIFF
--- a/stats/config/charts.json
+++ b/stats/config/charts.json
@@ -38,6 +38,10 @@
             "title": "Total txns",
             "description": "All transactions including pending, dropped, replaced, failed transactions"
         },
+        "yesterday_txns": {
+            "title": "Yesterday transactions",
+            "description": "Number of transactions yesterday (0:00 - 23:59 UTC)"
+        },
         "last_new_contracts": {
             "title": "Number of deployed contracts today",
             "description": "Number of deployed contracts today"

--- a/stats/config/layout.json
+++ b/stats/config/layout.json
@@ -12,7 +12,8 @@
         "total_native_coin_transfers",
         "total_tokens",
         "total_txns",
-        "total_verified_contracts"
+        "total_verified_contracts",
+        "yesterday_txns"
     ],
     "line_chart_categories": [
         {

--- a/stats/config/update_groups.json
+++ b/stats/config/update_groups.json
@@ -6,6 +6,7 @@
         "total_addresses_group": "0 0 */3 * * * *",
         "total_blocks_group": "0 0 */3 * * * *",
         "total_tokens_group": "0 0 18 * * * *",
+        "yesterday_txns_group": "0 8 0 * * * *",
         "active_recurring_accounts_daily_recurrence_60_days_group": "0 0 2 * * * *",
         "active_recurring_accounts_daily_recurrence_90_days_group": "0 20 2 * * * *",
         "active_recurring_accounts_daily_recurrence_120_days_group": "0 40 2 * * * *",

--- a/stats/config/update_groups.json
+++ b/stats/config/update_groups.json
@@ -1,7 +1,7 @@
 {
     "schedules": {
         "active_accounts_group": "0 0 4 * * * *",
-        "average_block_time_group": "0 0 15 * * * *",
+        "average_block_time_group": "0 */10 * * * * *",
         "completed_txns_group": "0 5 */3 * * * *",
         "total_addresses_group": "0 0 */3 * * * *",
         "total_blocks_group": "0 0 */3 * * * *",

--- a/stats/stats-server/src/runtime_setup.rs
+++ b/stats/stats-server/src/runtime_setup.rs
@@ -221,6 +221,7 @@ impl RuntimeSetup {
             Arc::new(TotalAddressesGroup),
             Arc::new(TotalBlocksGroup),
             Arc::new(TotalTokensGroup),
+            Arc::new(YesterdayTxnsGroup),
             Arc::new(ActiveRecurringAccountsDailyRecurrence60DaysGroup),
             Arc::new(ActiveRecurringAccountsMonthlyRecurrence60DaysGroup),
             Arc::new(ActiveRecurringAccountsWeeklyRecurrence60DaysGroup),

--- a/stats/stats-server/tests/it/counters.rs
+++ b/stats/stats-server/tests/it/counters.rs
@@ -58,6 +58,7 @@ async fn test_counters_ok() {
         "totalTokens",
         "totalTxns",
         "totalVerifiedContracts",
+        "yesterdayTxns",
     ]
     .into_iter()
     .collect();

--- a/stats/stats-server/tests/it/counters.rs
+++ b/stats/stats-server/tests/it/counters.rs
@@ -12,7 +12,7 @@ use stats::tests::{
 use stats_proto::blockscout::stats::v1::Counters;
 use stats_server::{stats, Settings};
 
-use std::{collections::HashSet, path::PathBuf, str::FromStr};
+use std::{path::PathBuf, str::FromStr};
 
 #[tokio::test]
 #[ignore = "needs database"]
@@ -42,20 +42,21 @@ async fn test_counters_ok() {
         assert!(!counter.description.is_empty());
         assert!(!counter.title.is_empty());
     }
-    let counter_names: HashSet<_> = counters.counters.iter().map(|c| c.id.as_str()).collect();
-    let expected_counter_names: HashSet<_> = [
-        "totalBlocks",
-        "totalAddresses",
+    // Also check the order set in layout
+    let counter_names: Vec<_> = counters.counters.iter().map(|c| c.id.as_str()).collect();
+    let expected_counter_names: Vec<_> = [
         "averageBlockTime",
         "completedTxns",
-        "totalTxns",
-        "totalAccounts",
-        "totalTokens",
-        // "totalNativeCoinHolders",
-        "totalNativeCoinTransfers",
         "lastNewContracts",
         "lastNewVerifiedContracts",
+        "totalAccounts",
+        "totalAddresses",
+        "totalBlocks",
         "totalContracts",
+        // "totalNativeCoinHolders",
+        "totalNativeCoinTransfers",
+        "totalTokens",
+        "totalTxns",
         "totalVerifiedContracts",
     ]
     .into_iter()

--- a/stats/stats/src/charts/counters/mod.rs
+++ b/stats/stats/src/charts/counters/mod.rs
@@ -11,6 +11,7 @@ mod total_native_coin_transfers;
 mod total_tokens;
 mod total_txns;
 mod total_verified_contracts;
+mod yesterday_txns;
 
 #[cfg(test)]
 mod mock;
@@ -28,6 +29,7 @@ pub use total_native_coin_transfers::TotalNativeCoinTransfers;
 pub use total_tokens::TotalTokens;
 pub use total_txns::TotalTxns;
 pub use total_verified_contracts::TotalVerifiedContracts;
+pub use yesterday_txns::YesterdayTxns;
 
 #[cfg(test)]
 pub use mock::MockCounter;

--- a/stats/stats/src/charts/counters/yesterday_txns.rs
+++ b/stats/stats/src/charts/counters/yesterday_txns.rs
@@ -1,0 +1,94 @@
+use std::ops::Range;
+
+use crate::{
+    data_source::{
+        kinds::{
+            local_db::DirectPointLocalDbChartSource,
+            remote_db::{RemoteDatabaseSource, RemoteQueryBehaviour, StatementFromRange},
+        },
+        UpdateContext,
+    },
+    lines::NewTxnsStatement,
+    types::TimespanValue,
+    utils::day_start,
+    ChartProperties, MissingDatePolicy, Named, UpdateError,
+};
+use chrono::{DateTime, Days, NaiveDate, Utc};
+use entity::sea_orm_active_enums::ChartType;
+use sea_orm::FromQueryResult;
+
+pub struct YesterdayTxnsQuery;
+
+impl RemoteQueryBehaviour for YesterdayTxnsQuery {
+    type Output = TimespanValue<NaiveDate, String>;
+
+    async fn query_data(
+        cx: &UpdateContext<'_>,
+        _range: Option<Range<DateTime<Utc>>>,
+    ) -> Result<Self::Output, UpdateError> {
+        let today = cx.time.date_naive();
+        let yesterday = today
+            .checked_sub_days(Days::new(1))
+            .ok_or(UpdateError::Internal(
+                "Update time is incorrect: ~ minimum possible date".into(),
+            ))?;
+        let yesterday_range = day_start(&yesterday)..day_start(&today);
+        let query = NewTxnsStatement::get_statement(
+            Some(yesterday_range),
+            &cx.blockscout_applied_migrations,
+        );
+        let data = Self::Output::find_by_statement(query)
+            .one(cx.blockscout)
+            .await
+            .map_err(UpdateError::BlockscoutDB)?
+            // no transactions for yesterday
+            .unwrap_or(TimespanValue::with_zero_value(yesterday));
+        Ok(data)
+    }
+}
+
+pub type YesterdayTxnsRemote = RemoteDatabaseSource<YesterdayTxnsQuery>;
+
+pub struct Properties;
+
+impl Named for Properties {
+    fn name() -> String {
+        "yesterdayTxns".into()
+    }
+}
+
+impl ChartProperties for Properties {
+    type Resolution = NaiveDate;
+
+    fn chart_type() -> ChartType {
+        ChartType::Counter
+    }
+    fn missing_date_policy() -> MissingDatePolicy {
+        MissingDatePolicy::FillPrevious
+    }
+}
+
+pub type YesterdayTxns = DirectPointLocalDbChartSource<YesterdayTxnsRemote, Properties>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tests::{point_construction::dt, simple_test::simple_test_counter};
+
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn update_yesterday_txns_1() {
+        simple_test_counter::<YesterdayTxns>("update_yesterday_txns_1", "0", None).await;
+    }
+
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn update_yesterday_txns_2() {
+        simple_test_counter::<YesterdayTxns>(
+            "update_yesterday_txns_2",
+            "12",
+            Some(dt("2022-11-11T00:00:00")),
+        )
+        .await;
+    }
+}

--- a/stats/stats/src/charts/lines/mod.rs
+++ b/stats/stats/src/charts/lines/mod.rs
@@ -88,6 +88,7 @@ pub use new_native_coin_transfers::{
     NewNativeCoinTransfers, NewNativeCoinTransfersInt, NewNativeCoinTransfersMonthly,
     NewNativeCoinTransfersWeekly, NewNativeCoinTransfersYearly,
 };
+pub(crate) use new_txns::NewTxnsStatement;
 pub use new_txns::{NewTxns, NewTxnsInt, NewTxnsMonthly, NewTxnsWeekly, NewTxnsYearly};
 pub use new_verified_contracts::{
     NewVerifiedContracts, NewVerifiedContractsMonthly, NewVerifiedContractsWeekly,

--- a/stats/stats/src/update_groups.rs
+++ b/stats/stats/src/update_groups.rs
@@ -23,6 +23,7 @@ singleton_groups!(
     TotalAddresses,
     TotalBlocks,
     TotalTokens,
+    YesterdayTxns,
     // Each of the `ActiveRecurringAccounts*` charts includes quite heavy SQL query,
     // thus it's better to have granular control on update times.
     ActiveRecurringAccountsDailyRecurrence60Days,


### PR DESCRIPTION
It is the sequel to [The Migration of The Backend charts](#1117) and the second installment in the Migrate Backend Charts franchise. In the PR counter for yesterday transactions is added.