### PR TITLE
feat(launcher): proper servers shutdown

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.17.0"
+version = "0.18.0"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -25,16 +25,17 @@ opentelemetry-jaeger = { version = "0.18", features = ["rt-tokio"], optional = t
 prometheus = { version = "0.13", optional = true }
 reqwest = { version = "0.12", features = ["json"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
-serde_json = {version = "1", optional = true }
-serde_with = {version = "3", optional = true }
+serde_json = { version = "1", optional = true }
+serde_with = { version = "3", optional = true }
 tokio = { version = "1", optional = true }
+tokio-util = { version = "0.7.13", optional = true }
 tonic = { version = "0.12", optional = true }
 tracing = { version = "0.1", optional = true }
 tracing-actix-web = { package = "blockscout-tracing-actix-web", version = "0.8.0", optional = true }
 tracing-opentelemetry = { version = "0.19", optional = true }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"], optional = true }
 url = { version = "2.3.1", optional = true }
-uuid = {version = "1", features = ["v4"], optional = true}
+uuid = { version = "1", features = ["v4"], optional = true }
 
 # Dependencies required for database initialization
 
@@ -69,6 +70,7 @@ launcher = [
     "dep:prometheus",
     "dep:serde",
     "dep:tokio",
+    "dep:tokio-util",
     "dep:tonic",
     "dep:tracing",
     "dep:tracing-actix-web",

--- a/libs/blockscout-service-launcher/src/launcher/metrics.rs
+++ b/libs/blockscout-service-launcher/src/launcher/metrics.rs
@@ -3,7 +3,7 @@ use actix_web_prom::{PrometheusMetrics, PrometheusMetricsBuilder};
 use std::{collections::HashMap, net::SocketAddr};
 use tokio_util::sync::CancellationToken;
 
-use crate::launcher::launch::stop_actix_server_on_cancel;
+use crate::launcher::launch::{stop_actix_server_on_cancel, SHUTDOWN_TIMEOUT_SEC};
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -43,6 +43,7 @@ impl Metrics {
     ) -> actix_web::dev::Server {
         tracing::info!(addr = ?addr, "starting metrics server");
         let server = HttpServer::new(move || App::new().wrap(self.metrics_middleware.clone()))
+            .shutdown_timeout(SHUTDOWN_TIMEOUT_SEC)
             .bind(addr)
             .unwrap()
             .run();

--- a/libs/blockscout-service-launcher/src/launcher/metrics.rs
+++ b/libs/blockscout-service-launcher/src/launcher/metrics.rs
@@ -1,6 +1,9 @@
 use actix_web::{App, HttpServer};
 use actix_web_prom::{PrometheusMetrics, PrometheusMetricsBuilder};
 use std::{collections::HashMap, net::SocketAddr};
+use tokio_util::sync::CancellationToken;
+
+use crate::launcher::launch::stop_actix_server_on_cancel;
 
 #[derive(Clone)]
 pub struct Metrics {
@@ -33,11 +36,19 @@ impl Metrics {
         &self.http_middleware
     }
 
-    pub fn run_server(self, addr: SocketAddr) -> actix_web::dev::Server {
+    pub fn run_server(
+        self,
+        addr: SocketAddr,
+        shutdown: Option<CancellationToken>,
+    ) -> actix_web::dev::Server {
         tracing::info!(addr = ?addr, "starting metrics server");
-        HttpServer::new(move || App::new().wrap(self.metrics_middleware.clone()))
+        let server = HttpServer::new(move || App::new().wrap(self.metrics_middleware.clone()))
             .bind(addr)
             .unwrap()
-            .run()
+            .run();
+        if let Some(shutdown) = shutdown {
+            tokio::spawn(stop_actix_server_on_cancel(server.handle(), shutdown, true));
+        }
+        server
     }
 }


### PR DESCRIPTION
Currently there's no mechanism to properly (gracefully?) shutdown servers.

In my case, this led to a confusion where tasks were aborted but http server continued to operate, and it resulted in tests not failing whilst service in prod was shutting down. Implemented shutdown mechanism should equalize stopping service process to stopping main service loop (to some extent).