### PR TITLE
fix(bens): no `addr2name` table

### DIFF
--- a/blockscout-ens/bens-logic/src/subgraph/offchain/resolve.rs
+++ b/blockscout-ens/bens-logic/src/subgraph/offchain/resolve.rs
@@ -1,6 +1,6 @@
 use super::ResolveResult;
 use crate::{
-    protocols::{DomainNameOnProtocol, ProtocolSpecific},
+    protocols::{AddressResolveTechnique, DomainNameOnProtocol, ProtocolSpecific},
     subgraph::{
         offchain::{d3, ens},
         sql,
@@ -28,8 +28,10 @@ pub async fn offchain_resolve(
                 "found domain with offchain resolution, save it"
             );
             sql::create_or_update_domain(db, result.domain, protocol).await?;
-            if let Some(reverse_record) = result.maybe_reverse_record {
-                sql::create_or_update_reverse_record(db, reverse_record, protocol).await?;
+            if protocol.info.address_resolve_technique == AddressResolveTechnique::Addr2Name {
+                if let Some(reverse_record) = result.maybe_reverse_record {
+                    sql::create_or_update_reverse_record(db, reverse_record, protocol).await?;
+                }
             }
         }
         cached::Return {

--- a/blockscout-ens/justfile
+++ b/blockscout-ens/justfile
@@ -43,9 +43,10 @@ stop-test-postgres:
     just docker-name="{{docker-name}}-test" stop-postgres
 
 test *args:
-    SQLX_OFFLINE=true RUST_LOG=info cargo test {{args}}
+    SQLX_OFFLINE=true RUST_LOG=info cargo test {{args}} -- --nocapture
 
 test-with-db *args:
+    -just                                                                          stop-test-postgres 2> /dev/null
     -just db-port="{{test-db-port}}" db-name="" docker-name="{{docker-name}}-test" start-postgres
     just db-port="{{test-db-port}}" db-name=""                                     test {{args}}
 


### PR DESCRIPTION
Service tries to save data into `addr2name` table for non-`d3 connect` protocols, for which the `addr2name` table is not being initialized.

This likely is the reason for errors during first lookup for offchain-resolved domains.