### PR TITLE
feat(launcher): add test database initialization helping macros

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -89,6 +89,7 @@ tracing = [
 database = [
     "dep:anyhow",
     "dep:cfg-if",
+    "dep:serde",
     "dep:tracing",
     "dep:url",
 ]

--- a/libs/blockscout-service-launcher/src/test_database.rs
+++ b/libs/blockscout-service-launcher/src/test_database.rs
@@ -100,3 +100,31 @@ impl Deref for TestDbGuard {
         &self.conn_with_db
     }
 }
+
+#[macro_export]
+macro_rules! database_name {
+    () => {
+        format!("{}_{}_{}", file!(), line!(), column!())
+    };
+    ($custom_suffix:expr) => {
+        format!("{}_{}_{}_{}", file!(), line!(), column!(), $custom_suffix)
+    };
+}
+pub use database_name;
+
+#[macro_export]
+macro_rules! database {
+    ($migration_crate:ident) => {{
+        $crate::test_database::TestDbGuard::new::<$migration_crate::Migrator>(
+            &$crate::test_database::database_name!(),
+        )
+        .await
+    }};
+    ($migration_crate:ident, $custom_suffix:expr) => {{
+        $crate::test_database::TestDbGuard::new::<$migration_crate::Migrator>(
+            $crate::test_database::database_name!($custom_suffix),
+        )
+        .await
+    }};
+}
+pub use database;


### PR DESCRIPTION
Can be used inside test in the following way:

```
use blockscout_service_launcher::test_database::database;
...
#[tokio::test]
async fn test() {
    let db_guard = database!(service_migration_crate);
    ...
}
```