### PR TITLE
feat(stats): The Migration of The Backend charts: Total Counters

### DIFF
--- a/stats/Cargo.lock
+++ b/stats/Cargo.lock
@@ -991,6 +991,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9718806c4a2fe9e8a56fd736f97b340dd10ed1be8ed733ed50449f351dc33cae"
+dependencies = [
+ "ahash 0.8.11",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown 0.14.5",
+ "once_cell",
+ "thiserror",
+ "tokio",
+ "web-time",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f42a145ed2d10dce2191e1dcf30cfccfea9026660e143662ba5eec4017d5daa"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
+
+[[package]]
 name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4717,6 +4753,7 @@ dependencies = [
  "blockscout-db",
  "blockscout-metrics-tools",
  "blockscout-service-launcher",
+ "cached",
  "chrono",
  "entity",
  "futures",
@@ -4735,6 +4772,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "trait-variant",
  "tynm",
  "url",
  "wiremock",
@@ -5331,6 +5369,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5606,6 +5655,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/stats/Cargo.toml
+++ b/stats/Cargo.toml
@@ -12,7 +12,9 @@ members = [
 [workspace.dependencies]
 blockscout-client = { git = "https://github.com/blockscout/blockscout-rs/", rev = "506b821" }
 blockscout-service-launcher = { version = "0.13.1" }
+cached = "0.54"
 rstest = "0.23.0"
+trait-variant = "0.1.2"
 wiremock = "0.6.2"
 
 # todo: update version after https://github.com/chronotope/chrono/pull/1600

--- a/stats/stats/Cargo.toml
+++ b/stats/stats/Cargo.toml
@@ -14,6 +14,10 @@ sea-orm = { version = "0.12", features = [
 tokio = "1"
 thiserror = "1.0"
 chrono = "0.4"
+cached = { workspace = true, features = [
+    "async"
+] }
+trait-variant = { workspace = true }
 paste = "1.0"
 portrait = "0.3.0"
 async-trait = "0.1"

--- a/stats/stats/src/charts/db_interaction/read.rs
+++ b/stats/stats/src/charts/db_interaction/read.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use sea_orm::{
     sea_query::{self, Expr},
     ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, DbErr, EntityTrait,
-    FromQueryResult, QueryFilter, QueryOrder, QuerySelect, Statement, TryGetableMany,
+    FromQueryResult, QueryFilter, QueryOrder, QuerySelect, Statement,
 };
 use std::{collections::HashMap, fmt::Debug, ops::Range};
 use thiserror::Error;

--- a/stats/stats/src/data_source/kinds/local_db/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/mod.rs
@@ -22,7 +22,7 @@ use parameters::{
         },
         point::PassPoint,
     },
-    DefaultCreate, DefaultQueryLast, DefaultQueryVec,
+    DefaultCreate, DefaultQueryLast, DefaultQueryVec, QueryLastWithEstimationFallback,
 };
 use sea_orm::{prelude::DateTimeUtc, DatabaseConnection, DbErr};
 
@@ -111,6 +111,15 @@ pub type DirectPointLocalDbChartSource<Dependency, C> = LocalDbChartSource<
     DefaultCreate<C>,
     PassPoint<Dependency>,
     DefaultQueryLast<C>,
+    C,
+>;
+
+pub type DirectPointLocalDbChartSourceWithEstimate<Dependency, Estimate, C> = LocalDbChartSource<
+    Dependency,
+    (),
+    DefaultCreate<C>,
+    PassPoint<Dependency>,
+    QueryLastWithEstimationFallback<Estimate, C>,
     C,
 >;
 

--- a/stats/stats/src/data_source/kinds/local_db/parameters/mod.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/mod.rs
@@ -3,4 +3,6 @@ mod query;
 pub mod update;
 
 pub use create::DefaultCreate;
-pub use query::{DefaultQueryLast, DefaultQueryVec};
+pub use query::{
+    DefaultQueryLast, DefaultQueryVec, QueryLastWithEstimationFallback, ValueEstimation,
+};

--- a/stats/stats/src/data_source/kinds/local_db/parameters/query.rs
+++ b/stats/stats/src/data_source/kinds/local_db/parameters/query.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, marker::PhantomData, ops::Range};
 
-use sea_orm::prelude::DateTimeUtc;
+use sea_orm::{prelude::DateTimeUtc, DatabaseConnection};
 
 use crate::{
     charts::db_interaction::read::get_counter_data,
@@ -90,9 +90,21 @@ impl<C: ChartProperties> QueryBehaviour for DefaultQueryLast<C> {
     }
 }
 
-pub struct QueryLastWithEstimationFallback<C: ChartProperties>(PhantomData<C>);
+#[trait_variant::make(Send)]
+pub trait ValueEstimation {
+    async fn estimate(blockscout: &DatabaseConnection) -> Result<DateValue<String>, UpdateError>;
+}
 
-impl<C: ChartProperties> QueryBehaviour for QueryLastWithEstimationFallback<C> {
+pub struct QueryLastWithEstimationFallback<E, C>(PhantomData<(E, C)>)
+where
+    C: ChartProperties,
+    E: ValueEstimation;
+
+impl<E, C> QueryBehaviour for QueryLastWithEstimationFallback<E, C>
+where
+    C: ChartProperties,
+    E: ValueEstimation,
+{
     type Output = DateValue<String>;
 
     async fn query_data(
@@ -106,10 +118,86 @@ impl<C: ChartProperties> QueryBehaviour for QueryLastWithEstimationFallback<C> {
             C::missing_date_policy(),
         )
         .await?
-        .ok_or(UpdateError::Internal(format!(
-            "no data for counter '{}' was found",
-            C::name()
-        )))?;
+        .unwrap_or(E::estimate(cx.blockscout).await?);
         Ok(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use chrono::NaiveDate;
+    use entity::sea_orm_active_enums::ChartType;
+    use pretty_assertions::assert_eq;
+    use sea_orm::DatabaseConnection;
+
+    use super::*;
+
+    use crate::{
+        data_source::{types::BlockscoutMigrations, UpdateContext, UpdateParameters},
+        tests::init_db::init_db_all,
+        types::timespans::DateValue,
+        MissingDatePolicy, Named, UpdateError,
+    };
+
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn fallback_query_works() {
+        let _ = tracing_subscriber::fmt::try_init();
+        let (db, blockscout) = init_db_all("fallback_query_works").await;
+        let current_time = chrono::DateTime::from_str("2023-03-01T12:00:00Z").unwrap();
+
+        let parameters = UpdateParameters {
+            db: &db,
+            blockscout: &blockscout,
+            blockscout_applied_migrations: BlockscoutMigrations::latest(),
+            update_time_override: Some(current_time),
+            force_full: true,
+        };
+        let cx = UpdateContext::from_params_now_or_override(parameters.clone());
+
+        struct TestFallback;
+
+        fn expected_estimate() -> DateValue<String> {
+            DateValue {
+                timespan: chrono::NaiveDate::MAX,
+                value: "estimate".to_string(),
+            }
+        }
+
+        impl ValueEstimation for TestFallback {
+            async fn estimate(
+                _blockscout: &DatabaseConnection,
+            ) -> Result<DateValue<String>, UpdateError> {
+                Ok(expected_estimate())
+            }
+        }
+
+        pub struct InvalidProperties;
+        impl Named for InvalidProperties {
+            fn name() -> String {
+                "totalBlocks".into()
+            }
+        }
+        impl ChartProperties for InvalidProperties {
+            type Resolution = NaiveDate;
+
+            fn chart_type() -> ChartType {
+                ChartType::Counter
+            }
+            fn missing_date_policy() -> MissingDatePolicy {
+                MissingDatePolicy::FillPrevious
+            }
+        }
+
+        assert_eq!(
+            expected_estimate(),
+            QueryLastWithEstimationFallback::<TestFallback, InvalidProperties>::query_data(
+                &cx, None
+            )
+            .await
+            .unwrap()
+        );
     }
 }


### PR DESCRIPTION
It is a sequel to https://github.com/blockscout/blockscout-rs/pull/1120 and the third installment in the Migrate Backend Charts franchise.