### PR TITLE
fix(libs): change chain_id type in blockscout-chains response

### DIFF
--- a/libs/blockscout-chains/Cargo.toml
+++ b/libs/blockscout-chains/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-chains"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/libs/blockscout-chains/Cargo.toml
+++ b/libs/blockscout-chains/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-chains"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/libs/blockscout-chains/src/lib.rs
+++ b/libs/blockscout-chains/src/lib.rs
@@ -65,7 +65,7 @@ impl Default for BlockscoutChainsClientBuilder {
     }
 }
 
-pub type BlockscoutChains = HashMap<u64, BlockscoutChainData>;
+pub type BlockscoutChains = HashMap<String, BlockscoutChainData>;
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the package version of `blockscout-chains` to 0.1.1.
  
- **Changes**
	- Altered the key type in the `BlockscoutChains` structure from `u64` to `String`, impacting how data is indexed and retrieved from the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->