### PR TITLE
fix: decrease cache time for offchain

### DIFF
--- a/blockscout-ens/bens-logic/src/subgraph/offchain/resolve.rs
+++ b/blockscout-ens/bens-logic/src/subgraph/offchain/resolve.rs
@@ -54,7 +54,7 @@ pub async fn offchain_resolve(
     convert = r#"{
             format!("{}-{}",  from_user.deployed_protocol.protocol.info.slug, from_user.inner.id)
         }"#,
-    time = 14400, // 4 * 60 * 60 seconds = 4 hours
+    time = 900, // 15 * 60 seconds = 15 minutes
     size = 500,
     sync_writes = true,
     with_cached_flag = true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Reduced cache expiration time for offchain resolution results from 4 hours to 15 minutes, ensuring fresher data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->