### PR TITLE
chore: bump rust to 1.83

### DIFF
--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,4 +1,4 @@
-ARG CARGO_CHEF_VERSION=0.1.67-rust-1.79-buster
+ARG CARGO_CHEF_VERSION=0.1.68-rust-1.83-bullseye
 FROM lukemathwalker/cargo-chef:${CARGO_CHEF_VERSION}
 
 ARG PROTOC_VERSION=25.2


### PR DESCRIPTION
Bump rust in base image to 1.83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the base Docker image version for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->