### PR TITLE
typo-Update README.md

### DIFF
--- a/blockscout-ens/graph-node/README.md
+++ b/blockscout-ens/graph-node/README.md
@@ -104,7 +104,7 @@ just deploy-subgraph --prod <protocol_name>
 
 Developing subgraph for protocol based on space-id contracts requires providing additional information.
 
-SpaceID protocol has constant variable called `identifier` which unique describes protocol accross multiple chains.
+SpaceID protocol has constant variable called `identifier` which unique describes protocol across multiple chains.
 This values is used during calculation of [namehash](https://docs.ens.domains/resolution/names#algorithm), therefore subgraph should know this value.
 
 Actually blockscout-ens needs two values that can be calculated from `identifier`: `empty_label_hash` and `empty_label_hash`


### PR DESCRIPTION
# Fix: Corrected typo in README file

## Changes
1. **File**: `blockscout-ens/graph-node/README.md`
   - Fixed "accross" to "across" (Line 107).

## Purpose
- Improved documentation accuracy by fixing the typographical error.
- Enhanced the clarity and professionalism of the README file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README with detailed SQL queries for checking subgraph deployment status
	- Improved SpaceID integration documentation
	- Corrected spelling and clarified technical descriptions
	- Added examples for obtaining hash values for different network configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->