### PR TITLE
**Fix Typo in `README.md`**

### DIFF
--- a/blockscout-ens/graph-node/subgraph-writer/README.md
+++ b/blockscout-ens/graph-node/subgraph-writer/README.md
@@ -14,7 +14,7 @@ You can take a look at that subgraph and understand structure of our project mor
     just init
     ```
 
-1. Now you have to create file inside `protocols` directory decribing your procol. Use `example.protocol.yaml` as template.
+1. Now you have to create file inside `protocols` directory describing your procol. Use `example.protocol.yaml` as template.
 
     **[EXPEREMENTAL]** You can try to generate protocol desription file using `protocol-extractor`. This script will try to extract verified   contracts from etherscan and determine their affiliation with the protocol:
 


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `README.md`**

## Description  
This pull request fixes a typo in the `README.md` file, improving the accuracy and readability of the documentation.

### Changes Made:
- **File Modified:** `blockscout-ens/graph-node/subgraph-writer/README.md`
- **Summary of Changes:**
  - Corrected the typo "decribing" to "describing" in the instructions for creating a protocol file.

## Related Issues  
N/A

## Checklist  
- [x] Fixed the typo in the documentation.
- [x] Verified that the change does not affect the content structure or instructions.

## Testing  
N/A (Typo fix in documentation)

## Additional Notes  
This update ensures the documentation is clear and professional, which aids in user comprehension and usage of the repository.

---

**Allow edits by maintainers:** [x]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed typos in README.md for subgraph creation instructions
	- Corrected spelling of "describing" and "EXPERIMENTAL"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->