### PR TITLE
Fix Typo in `README.md`

### DIFF
--- a/stats/README.md
+++ b/stats/README.md
@@ -216,7 +216,7 @@ The service will periodically check the enabled start conditions and start updat
 just start-postgres
 ```
 
-+ Start blockscout instance with varialbe `DATABASE_URL=postgres://postgres:admin@host.docker.internal:5432/blockscout`
++ Start blockscout instance with variable `DATABASE_URL=postgres://postgres:admin@host.docker.internal:5432/blockscout`
 
 + Start stats server:
 


### PR DESCRIPTION
# Fix Typo in `README.md`

## Description
This pull request corrects a minor typo in the `README.md` documentation, ensuring better readability and accuracy.

**Before**:
- `varialbe`

**After**:
- `variable`

## References (if applicable)
- N/A

## Checklist
- [x] Typo corrected in `README.md`
- [ ] Documentation updated (if applicable)
