### PR TITLE
feat(api-client-framework)!: configuration and endpoint updates

### DIFF
--- a/libs/api-client-framework/Cargo.toml
+++ b/libs/api-client-framework/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 anyhow = { version = "1.0", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 reqwest-middleware = { version = "0.4", default-features = false }
-reqwest-retry = { version = "0.7", default-features = false }
 serde = { version = "1", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["std"] }
 serde_path_to_error = { version = "0.1.16", default-features = false }

--- a/libs/api-client-framework/src/endpoint.rs
+++ b/libs/api-client-framework/src/endpoint.rs
@@ -23,6 +23,14 @@ pub trait Endpoint {
         None
     }
 
+    /// The set of headers to be sent with request. Defaults to `None`.
+    ///
+    /// Implementors should inline this.
+    #[inline]
+    fn headers(&self) -> Option<reqwest::header::HeaderMap> {
+        None
+    }
+
     /// The HTTP body associated with this endpoint. If not implemented, defaults to `None`.
     ///
     /// Implementors should inline this.

--- a/libs/api-client-framework/src/lib.rs
+++ b/libs/api-client-framework/src/lib.rs
@@ -27,6 +27,8 @@ pub enum Error {
         status_code: reqwest::StatusCode,
         message: String,
     },
+    #[error("{0:#?}")]
+    CustomError(anyhow::Error),
 }
 
 impl From<reqwest_middleware::Error> for Error {

--- a/libs/api-client-framework/src/lib.rs
+++ b/libs/api-client-framework/src/lib.rs
@@ -6,6 +6,10 @@ mod endpoint;
 pub use async_client::{HttpApiClient, HttpApiClientConfig};
 pub use endpoint::{serialize_query, Endpoint};
 
+pub use reqwest;
+pub use reqwest_middleware;
+pub use url;
+
 /******************** Config definition ********************/
 
 #[derive(Debug, thiserror::Error)]
@@ -23,8 +27,6 @@ pub enum Error {
         status_code: reqwest::StatusCode,
         message: String,
     },
-    #[error("{0:#?}")]
-    CustomError(anyhow::Error),
 }
 
 impl From<reqwest_middleware::Error> for Error {


### PR DESCRIPTION
1. Remove `CustomError` from Error enum
2. Re-export reqwest related crates to be available to framework users
3. Update config to have middlewares being explicitly specified, instead of having just `max_retries` variable
4. Add method to setup headers to `Endpoint` trait

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional header configuration for API endpoints
	- Introduced middleware support for HTTP client configuration

- **Refactor**
	- Removed retry middleware from HTTP client
	- Simplified error handling in API client framework
	- Updated public exports for easier library usage

- **Chores**
	- Removed `reqwest-retry` dependency from project configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->