### PR TITLE
feat(bens): index reverse mapping changes from d3 connect protocol

### DIFF
--- a/blockscout-ens/bens-server/config/dev.json
+++ b/blockscout-ens/bens-server/config/dev.json
@@ -82,7 +82,7 @@
         "tld_list": ["shib"],
         "network_id": 109,
         "subgraph_name": "d3-connect-shib-subgraph",
-        "address_resolve_technique": "addr2name",
+        "address_resolve_technique": "reverse_registry",
         "specific": {
           "type": "d3_connect",
           "native_token_contract": "0xDe74799371Ceac11A0F52BA2694392A391D0dA18",
@@ -103,8 +103,8 @@
         "address_resolve_technique": "reverse_registry",
         "specific": {
           "type": "d3_connect",
-          "native_token_contract": "0x4F3775dfd49db0BBcd47eB6f45CEb6E6E9e15CD8",
-          "resolver_contract": "0x51B4894B45A764d2bF48aE5D7F9e70Ac70e28875"
+          "native_token_contract": "0x1443bC2bBAB07437BCF9C577b647523A736bB33E",
+          "resolver_contract": "0xae6Bdf6e9edA0bA60F97390e70a545e91B5E8bf2"
         },
         "meta": {
           "short_name": "D3 Connect",

--- a/blockscout-ens/bens-server/config/dev.json
+++ b/blockscout-ens/bens-server/config/dev.json
@@ -23,9 +23,18 @@
           "url": "https://shibariumscan.io"
         },
         "use_protocols": [
-          "d3_connect"
+          "d3_connect_shib"
         ],
         "rpc_url": "https://www.shibrpc.com"
+      },
+      "157": {
+        "blockscout": {
+          "url": "https://puppyscan.shib.io/"
+        },
+        "use_protocols": [
+          "d3_connect_shib_testnet"
+        ],
+        "rpc_url": "https://puppynet.shibrpc.com"
       }
     },
     "protocols": {
@@ -69,7 +78,7 @@
           "docs_url": "https://docs.ens.domains/"
         }
       },
-      "d3_connect": {
+      "d3_connect_shib": {
         "tld_list": ["shib"],
         "network_id": 109,
         "subgraph_name": "d3-connect-shib-subgraph",
@@ -78,6 +87,24 @@
           "type": "d3_connect",
           "native_token_contract": "0xDe74799371Ceac11A0F52BA2694392A391D0dA18",
           "resolver_contract": "0xD60D40674E678F0089736D6381071973a75B4B6f"
+        },
+        "meta": {
+          "short_name": "D3 Connect",
+          "title": "D3 Connect",
+          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "icon_url": "https://i.imgur.com/cD6VIXk.png",
+          "docs_url": "https://docs.d3.app/"
+        }
+      },
+      "d3_connect_shib_testnet": {
+        "tld_list": ["shib"],
+        "network_id": 157,
+        "subgraph_name": "d3-connect-shib-subgraph",
+        "address_resolve_technique": "reverse_registry",
+        "specific": {
+          "type": "d3_connect",
+          "native_token_contract": "0x4F3775dfd49db0BBcd47eB6f45CEb6E6E9e15CD8",
+          "resolver_contract": "0x51B4894B45A764d2bF48aE5D7F9e70Ac70e28875"
         },
         "meta": {
           "short_name": "D3 Connect",

--- a/blockscout-ens/graph-node/config.toml
+++ b/blockscout-ens/graph-node/config.toml
@@ -43,3 +43,9 @@ provider = [
     { label = "shibarium", url = "https://www.shibrpc.com", features = [] }
 ]
 shard = "primary"
+
+[chains.shibarium-testnet]
+provider = [
+    { label = "shibarium-testnet", url = "https://puppynet.shibrpc.com", features = [] }
+]
+shard = "primary"

--- a/blockscout-ens/graph-node/deployer/config.json
+++ b/blockscout-ens/graph-node/deployer/config.json
@@ -69,6 +69,11 @@
       "subgraph_path": "../subgraphs/d3-connect-subgraph",
       "subgraph_name": "d3-connect-ape-subgraph",
       "network": "ape-mainnet"
+    },
+    "d3-connect-shib-testnet": {
+        "subgraph_path": "../subgraphs/d3-connect-subgraph",
+        "subgraph_name": "d3-connect-shib-subgraph",
+        "network": "shibarium-testnet"
     }
   }
 }

--- a/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/abis/Resolver.json
+++ b/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/abis/Resolver.json
@@ -1,0 +1,648 @@
+[
+  {
+    "inputs": [],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "EmptySignersList",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidSigner",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "internalType": "string[]",
+        "name": "urls",
+        "type": "string[]"
+      },
+      {
+        "internalType": "bytes",
+        "name": "callData",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes4",
+        "name": "callbackFunction",
+        "type": "bytes4"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "OffchainLookup",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "ResponseExpired",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "previousAdmin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAdmin",
+        "type": "address"
+      }
+    ],
+    "name": "AdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "beacon",
+        "type": "address"
+      }
+    ],
+    "name": "BeaconUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "EIP712DomainChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint8",
+        "name": "version",
+        "type": "uint8"
+      }
+    ],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "previousAdminRole",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "newAdminRole",
+        "type": "bytes32"
+      }
+    ],
+    "name": "RoleAdminChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleGranted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "RoleRevoked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "wallet",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "symbol",
+        "type": "string"
+      }
+    ],
+    "name": "SetReverseMapping",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "Upgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "DEFAULT_ADMIN_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "OPERATOR_ROLE",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "eip712Domain",
+    "outputs": [
+      {
+        "internalType": "bytes1",
+        "name": "fields",
+        "type": "bytes1"
+      },
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "version",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "chainId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "verifyingContract",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "salt",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256[]",
+        "name": "extensions",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gatewayUrl",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      }
+    ],
+    "name": "getRoleAdmin",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "grantRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "hasRole",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "signers_",
+        "type": "address[]"
+      },
+      {
+        "internalType": "string",
+        "name": "gatewayUrl_",
+        "type": "string"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "proxiableUUID",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "renounceRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "network",
+        "type": "string"
+      }
+    ],
+    "name": "resolve",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "response",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "resolveWithProof",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "network",
+        "type": "string"
+      }
+    ],
+    "name": "reverseResolve",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "response",
+        "type": "bytes"
+      },
+      {
+        "internalType": "bytes",
+        "name": "extraData",
+        "type": "bytes"
+      }
+    ],
+    "name": "reverseResolveWithProof",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "role",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "revokeRole",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "gatewayUrl_",
+        "type": "string"
+      }
+    ],
+    "name": "setGatewayUrl",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "wallet",
+        "type": "address"
+      },
+      {
+        "internalType": "string[]",
+        "name": "name",
+        "type": "string[]"
+      },
+      {
+        "internalType": "string[]",
+        "name": "symbol",
+        "type": "string[]"
+      }
+    ],
+    "name": "setReverseMapping",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address[]",
+        "name": "signers_",
+        "type": "address[]"
+      }
+    ],
+    "name": "setSigners",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "signers",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes4",
+        "name": "interfaceId",
+        "type": "bytes4"
+      }
+    ],
+    "name": "supportsInterface",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeTo",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "upgradeToAndCall",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "pure",
+    "type": "function"
+  }
+]

--- a/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/networks.json
+++ b/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/networks.json
@@ -15,6 +15,10 @@
       "address": "0x0D435A6c16045Abeaf6A442Bf162fd52597B4Ed3",
       "startBlock": 36550
     },
+    "Resolver": {
+      "address": "0x3698485B8079FBDCc86Eb4f69Ebb9349DF1fc6f4",
+      "startBlock": 8241883
+    },
     "": ""
   },
   "shibarium-testnet": {

--- a/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/networks.json
+++ b/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/networks.json
@@ -3,18 +3,29 @@
     "Registry": {
       "address": "0xDe74799371Ceac11A0F52BA2694392A391D0dA18",
       "startBlock": 3473390
-    }
-  },
-  "shibarium-testnet": {
-    "Registry": {
-      "address": "0x91c2d22ca1028B2E55e3097096494Eb34b7fc81c",
-      "startBlock": 4555130
-    }
+    },
+    "Resolver": {
+      "address": "0x8b9d58e6915A71Dd782F5111c886377Df1d5cBe5",
+      "startBlock": 8954971
+    },
+    "": ""
   },
   "ape-mainnet": {
     "Registry": {
       "address": "0x0D435A6c16045Abeaf6A442Bf162fd52597B4Ed3",
       "startBlock": 36550
-    }
+    },
+    "": ""
+  },
+  "shibarium-testnet": {
+    "Registry": {
+      "address": "0x1443bC2bBAB07437BCF9C577b647523A736bB33E",
+      "startBlock": 1927346
+    },
+    "Resolver": {
+      "address": "0xae6Bdf6e9edA0bA60F97390e70a545e91B5E8bf2",
+      "startBlock": 6806860
+    },
+    "": ""
   }
 }

--- a/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/src/Resolver.ts
+++ b/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/src/Resolver.ts
@@ -1,0 +1,71 @@
+import { Address, ByteArray, ethereum, crypto, Bytes } from "@graphprotocol/graph-ts";
+
+import { SetReverseMapping } from '../generated/Resolver/Resolver';
+import { Domain, NameChanged } from '../generated/schema';
+import { hashByName } from "./utils";
+
+const ADDR_REVERSE_NODE = "0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2";
+
+export function handleSetReverseMapping(event: SetReverseMapping): void {
+  let name = `${event.params.wallet.toHexString().slice(2)}.addr.reverse`;
+  let subnode = hashByName(name);
+  let subnodeStr = subnode.toHexString();
+  let domain = Domain.load(subnodeStr);
+  let resolverId = createResolverID(subnode, event.address);
+
+  if (domain == null) {
+    domain = new Domain(subnodeStr);
+    domain.createdAt = event.block.timestamp;
+    domain.parent = ADDR_REVERSE_NODE;
+    domain.name = name;
+
+    domain.resolver = resolverId
+
+    domain.subdomainCount = 0;
+    domain.isMigrated = true;
+    domain.owner = event.transaction.from.toHexString();
+    domain.storedOffchain = false;
+    domain.resolvedWithWildcard = false;
+
+    domain.save();
+  }
+
+  let resolvedDomainNode = hashByName(event.params.name);
+  let resolvedDomain = Domain.load(resolvedDomainNode.toHexString());
+  if (resolvedDomain == null) {
+    resolvedDomain = new Domain(resolvedDomainNode.toHexString());
+    resolvedDomain.createdAt = event.block.timestamp;
+    resolvedDomain.name = event.params.name;
+
+    resolvedDomain.subdomainCount = 0;
+    resolvedDomain.isMigrated = true;
+    resolvedDomain.owner = event.params.wallet.toHexString();
+    resolvedDomain.storedOffchain = false;
+    resolvedDomain.resolvedWithWildcard = false;
+  }
+
+  resolvedDomain.resolver = resolverId;
+  resolvedDomain.resolvedAddress = event.params.wallet.toHexString();
+  resolvedDomain.save();
+
+  let resolverEvent = new NameChanged(createEventID(event));
+  resolverEvent.resolver = resolverId
+  resolverEvent.blockNumber = event.block.number.toI32();
+  resolverEvent.transactionID = event.transaction.hash;
+  resolverEvent.name = event.params.name;
+  resolverEvent.save();
+}
+
+function createEventID(event: ethereum.Event): string {
+    return event.block.number
+        .toString()
+        .concat("-")
+        .concat(event.logIndex.toString());
+}
+
+function createResolverID(node: ByteArray, resolver: Address): string {
+    return resolver
+      .toHexString()
+      .concat("-")
+      .concat(node.toHexString());
+  }

--- a/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/src/utils.ts
+++ b/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/src/utils.ts
@@ -120,17 +120,20 @@ export function hashByName(name: string): ByteArray {
       )
     )
   }
+}
+
+function splitStringOnce(input: string, separator: string): string[] {
+  const separatorIndex = input.indexOf(separator)
+
+  if (separatorIndex === -1) {
+    return [input, ''];
   }
 
-  function splitStringOnce(input: string, separator: string): string[] {
-    const splitArray = input.split(separator, 2);
-    
-    if (splitArray.length === 2) {
-      return [splitArray[0], splitArray[1]];
-    } else {
-      return [input, ''];
-    }
-  }
+  return [
+    input.slice(0, separatorIndex),
+    input.slice(separatorIndex + separator.length)
+  ]
+}
 
 function labelFromName(name: string): string {
   const labels = splitStringOnce(name, '.');

--- a/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/subgraph.yaml
+++ b/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/subgraph.yaml
@@ -32,3 +32,25 @@ dataSources:
           handler: handleSLDRenewed
         - event: Transfer(indexed address,indexed address,indexed uint256)
           handler: handleTransfer
+  - kind: ethereum/contract
+    name: Resolver
+    network: shibarium
+    source:
+      abi: Resolver
+      address: "0x8b9d58e6915A71Dd782F5111c886377Df1d5cBe5"
+      startBlock: 8954971
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      file: ./src/Resolver.ts
+      entities:
+        - Domain
+        - Account
+        - NameChanged
+      abis:
+        - name: Resolver
+          file: ./abis/Resolver.json
+      eventHandlers:
+        - event: SetReverseMapping(address,string,string)
+          handler: handleSetReverseMapping


### PR DESCRIPTION
This adds support for indexing the new `SetReverseMapping` event from the D3 Connect Resolver contract. With also a few things included:

- Update Registry contract address for testnet
- Fixed a bug on the function `splitStringOnce` (which only worked for names with at maximum two labels)
- Commit from other PR with support for configs for Shibarium testnet (#1187).

A few things are still unresolved:

- I've kept the mapping function as simple as possible, with only enough to make address lookups work.
- Making domain resolved address as the reverse mapping address breaks our protocol since we can't make sure this is the actual resolved address from DNS.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the Shibarium network and Shibarium testnet in configuration files.
	- Introduced a new Resolver contract with enhanced domain resolution capabilities.
	- Implemented reverse mapping functionality for domain names.

- **Configuration Updates**
	- Updated network and protocol configurations for Shibarium, including new protocols and chains.
	- Added new testnet chain configuration.

- **Technical Improvements**
	- Enhanced domain resolution and mapping processes.
	- Optimized utility functions for string processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->