### PR TITLE
fix(launcher): database macros with custom_prefix

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.16.1"
+version = "0.16.2"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/test_database.rs
+++ b/libs/blockscout-service-launcher/src/test_database.rs
@@ -217,9 +217,9 @@ macro_rules! database {
         .await
     }};
     ($migrator:ty, $custom_prefix:expr) => {{
-        $crate::test_database::TestDbGuard::new::<$migrator>($crate::test_database::database_name!(
-            $custom_prefix
-        ))
+        $crate::test_database::TestDbGuard::new::<$migrator>(
+            &$crate::test_database::database_name!($custom_prefix),
+        )
         .await
     }};
 }


### PR DESCRIPTION
`database!` macros with custom_prefix did not work for `test_database` because `TestDbGuard::new` expected a test name to be `&str` but the resultant macro passed it as a `String`. This PR fixes that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `blockscout-service-launcher` package version from 0.16.1 to 0.16.2
- **Refactor**
	- Modified test database macro to pass database name as a reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->