### PR TITLE
chore(auth): bump blockscout-auth deps

### DIFF
--- a/libs/blockscout-auth/Cargo.toml
+++ b/libs/blockscout-auth/Cargo.toml
@@ -6,15 +6,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cookie = {version = "0.17", features = ["percent-encode"]}
-reqwest = "0.11"
-serde = { version = "1.0", features = ["derive"] }
+cookie = { version = "0.18", features = [ "percent-encode" ] }
+reqwest = "0.12"
+serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1"
-thiserror = "1"
-tonic = "0.8"
+thiserror = "2"
+tonic = "0.12"
 tracing = "0.1"
 url = "2"
-wiremock = "0.5"
+wiremock = "0.6"
 
 [dev-dependencies]
 tokio = "1.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependencies to their latest versions:
		- `cookie` to 0.18
		- `reqwest` to 0.12
		- `thiserror` to 2.0
		- `tonic` to 0.12
		- `wiremock` to 0.6

<!-- end of auto-generated comment: release notes by coderabbit.ai -->