### PR TITLE
docs(da-indexer): intended links light node

### DIFF
--- a/da-indexer/README.md
+++ b/da-indexer/README.md
@@ -113,7 +113,7 @@ just run
 
 To fix this error, update the tonic dependency in [`blockscout-service-launcher/Cargo.toml`](../libs/blockscout-service-launcher/Cargo.toml#L31):
 
-```
+```toml
 [dependencies]
 tonic = "0.8"
 ```

--- a/da-indexer/README.md
+++ b/da-indexer/README.md
@@ -111,6 +111,11 @@ just run
 `Router` and `Router` have similar names, but are actually distinct types
 ```
 
-To fix this error you need to change tonic version of `tonic` in `blockscout-service-launcer` to `0.8`
+To fix this error, update the tonic dependency in [`blockscout-service-launcher/Cargo.toml`](../libs/blockscout-service-launcher/Cargo.toml#L31):
 
-For now you can only change in `Cargo.lock`
+```
+[dependencies]
+tonic = "0.8"
+```
+
+Then run `cargo update -p tonic` to update the lockfile.

--- a/da-indexer/README.md
+++ b/da-indexer/README.md
@@ -4,7 +4,7 @@ DA Indexer Service
 The DA Indexer service collects blobs from different DA solutions (currently only Celestia and EigenDA) and provides a convenient API for fetching blob data. In addition to indexing blobs, this service can be configured to fetch L2 batch metadata corresponding to a specific blob (currently only available for Celestia).
 
 ## Celestia
-The Celestia indexer runs on top of the [Celestia light node](https://docs.celestia.org/nodes/light-node). It is worth noting that the indexer collects only blobs and some block metadata, it does not collect full blocks, transactions, etc.
+The Celestia indexer runs on top of the [Celestia light node](https://docs.celestia.org/how-to-guides/light-node). It is worth noting that the indexer collects only blobs and some block metadata, it does not collect full blocks, transactions, etc.
 
 ## EigenDA
 The EigenDA indexer runs on top of the EigenDA disperser. It is worth mentioning that the disperser does not store blobs older than two weeks, so these blobs will be unavailable.

--- a/user-ops-indexer/README.md
+++ b/user-ops-indexer/README.md
@@ -31,7 +31,7 @@ instance ([configuration](https://github.com/blockscout/docs/blob/master/for-dev
 * `MICROSERVICE_ACCOUNT_ABSTRACTION_URL={service_url}`
 
 And the following ENVs on the Blockscout
-frontend ([configuration](https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#user-operations-feature-erc-4337)):
+frontend ([configuration](https://github.com/blockscout/frontend/blob/main/docs/ENVS.md#user-operations-erc-4337)):
 
 * `NEXT_PUBLIC_HAS_USER_OPS=true`
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated DA Indexer README with new Celestia light node documentation URL.
  - Added developer setup instructions for `just` CLI, PostgreSQL, and migrations.
  - Expanded troubleshooting section with specific error resolution steps.
  - Updated User Ops Indexer README with clarified Blockscout frontend configuration link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->