### PR TITLE
fix(verification-common): make CompilationArtifacts.sources to contain serde-json::Value

### DIFF
--- a/libs/verification-common/src/verifier_alliance/compilation_artifacts.rs
+++ b/libs/verification-common/src/verifier_alliance/compilation_artifacts.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::BTreeMap;
 
 pub trait ToCompilationArtifacts {
     fn abi(&self) -> Option<Value> {
@@ -45,7 +44,7 @@ pub struct CompilationArtifacts {
     pub devdoc: Option<Value>,
     pub userdoc: Option<Value>,
     pub storage_layout: Option<Value>,
-    pub sources: Option<BTreeMap<String, SourceId>>,
+    pub sources: Option<Value>,
 }
 
 impl<T: ToCompilationArtifacts> From<T> for CompilationArtifacts {


### PR DESCRIPTION
Make CompilationArtifacts.sources to contain opaque serde-json::Value instead of a map.

That is required because some of the data inside the test-verifier-alliance-database does not correspond to expected format, and service results in internal errors when trying to obtain that data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the `sources` field type in `CompilationArtifacts` to support more flexible JSON-compatible data structures
	- Generalized the `sources` field to improve serialization and data handling capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->