### PR TITLE
fix(eth-bytecode-db): bump verification-common to support non-map 'compilation_artifacts.sources' values

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -7689,7 +7689,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 [[package]]
 name = "verification-common"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=5481500#5481500910217806d23f420782a203b2debfa5be"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=8d9cf0e#8d9cf0e9533ceed7d99e86d7cf9ed5f77e523b4e"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",

--- a/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/Cargo.toml
@@ -75,4 +75,4 @@ tonic-build = { version = "0.8" }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3" }
 url = { version = "2" }
-verification-common = { git = "https://github.com/blockscout/blockscout-rs", rev = "5481500" }
+verification-common = { git = "https://github.com/blockscout/blockscout-rs", rev = "8d9cf0e" }

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
@@ -360,7 +360,10 @@ impl DatabaseService {
             contract_address.to_vec(),
         )
         .await
-        .map_err(|err| tonic::Status::internal(err.to_string()))?
+        .map_err(|err| {
+            tracing::error!("error while retrieving alliance sources: {err:#?}");
+            tonic::Status::internal(err.to_string())
+        })?
         .into_iter()
         .map(|source| SourceWrapper::from(source).into_inner())
         .collect();

--- a/eth-bytecode-db/verifier-alliance-database/tests/integration/internal_compiled_contracts.rs
+++ b/eth-bytecode-db/verifier-alliance-database/tests/integration/internal_compiled_contracts.rs
@@ -2,7 +2,7 @@ use crate::from_json;
 use blockscout_service_launcher::test_database::database;
 use std::collections::BTreeMap;
 use verification_common::verifier_alliance::{
-    CompilationArtifacts, CreationCodeArtifacts, RuntimeCodeArtifacts, SourceId,
+    CompilationArtifacts, CreationCodeArtifacts, RuntimeCodeArtifacts,
 };
 use verifier_alliance_database::{
     internal, CompiledContract, CompiledContractCompiler, CompiledContractLanguage,
@@ -30,7 +30,7 @@ async fn insert_compiled_contract_works() {
             devdoc: Some(from_json!({"devdoc": "value"})),
             userdoc: Some(from_json!({"userdoc": "value"})),
             storage_layout: Some(from_json!({"storage": "value"})),
-            sources: Some(BTreeMap::from([("src/Counter.sol".into(), SourceId {id: 0})])),
+            sources: Some(from_json!({"src/Counter.sol": { "id": 0 }})),
         },
         creation_code: vec![0x1, 0x2],
         creation_code_artifacts: CreationCodeArtifacts {

--- a/eth-bytecode-db/verifier-alliance-database/tests/integration/verified_contracts.rs
+++ b/eth-bytecode-db/verifier-alliance-database/tests/integration/verified_contracts.rs
@@ -5,7 +5,7 @@ use sea_orm::{prelude::Uuid, DatabaseConnection};
 use std::collections::BTreeMap;
 use verification_common::verifier_alliance::{
     CompilationArtifacts, CreationCodeArtifacts, Match, MatchTransformation, MatchValues,
-    RuntimeCodeArtifacts, SourceId,
+    RuntimeCodeArtifacts,
 };
 use verifier_alliance_database::{
     CompiledContract, CompiledContractCompiler, CompiledContractLanguage, InsertContractDeployment,
@@ -191,7 +191,7 @@ fn complete_compiled_contract() -> CompiledContract {
             devdoc: Some(from_json!({"devdoc": "value"})),
             userdoc: Some(from_json!({"userdoc": "value"})),
             storage_layout: Some(from_json!({"storage": "value"})),
-            sources: Some(BTreeMap::from([("src/Counter.sol".into(), SourceId {id: 0})]))
+            sources: Some(from_json!({"src/Counter.sol": { "id": 0 }})),
         },
         creation_code: vec![0x1, 0x2],
         creation_code_artifacts: CreationCodeArtifacts {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Updates**
	- Updated `verification-common` library to a new commit version

- **Bug Fixes**
	- Improved error logging in database service for alliance source retrieval

- **Refactor**
	- Modified source mapping representation in compilation artifacts
	- Simplified source ID handling in test configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->