### PR TITLE
STR-1000 indexer api changes

### DIFF
--- a/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
@@ -65,8 +65,8 @@ WITH accounts_cte AS (SELECT DISTINCT ON (sender) sender,
                                     ON blocks.hash = block_hash AND consensus
                       WHERE sender >= $2
                       AND ($1 IS NULL OR factory = $1)
-                      AND ($3 IS NULL OR creation_timestamp >= $3)
-                      AND ($4 IS NULL OR creation_timestamp <= $4)
+                      AND ($3 IS NULL OR creation_timestamp >= $3::timestamp)
+                      AND ($4 IS NULL OR creation_timestamp <= $4::timestamp)
                       ORDER BY sender, factory NULLS LAST
                       LIMIT $5),
      accounts_total_cte AS (SELECT accounts_cte.sender, count(*) as total_ops

--- a/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
@@ -65,8 +65,8 @@ WITH accounts_cte AS (SELECT DISTINCT ON (sender) sender,
                                     ON blocks.hash = block_hash AND consensus
                       WHERE sender >= $2
                       AND ($1 IS NULL OR factory = $1)
-                      AND ($3 IS NULL OR (factory IS NOT NULL AND creation_timestamp >= $3)
-                      AND ($4 IS NULL OR (factory IS NOT NULL AND creation_timestamp <= $4)
+                      AND ($3 IS NULL OR (factory IS NOT NULL AND creation_timestamp >= $3))
+                      AND ($4 IS NULL OR (factory IS NOT NULL AND creation_timestamp <= $4))
                       ORDER BY sender, factory NULLS LAST
                       LIMIT $5),
      accounts_total_cte AS (SELECT accounts_cte.sender, count(*) as total_ops

--- a/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
@@ -65,8 +65,8 @@ WITH accounts_cte AS (SELECT DISTINCT ON (sender) sender,
                                     ON blocks.hash = block_hash AND consensus
                       WHERE sender >= $2
                       AND ($1 IS NULL OR factory = $1)
-                      AND ($3 IS NULL OR creation_timestamp >= $3::timestamp)
-                      AND ($4 IS NULL OR creation_timestamp <= $4::timestamp)
+                      AND ($3 IS NULL OR (factory IS NOT NULL AND creation_timestamp >= $3)
+                      AND ($4 IS NULL OR (factory IS NOT NULL AND creation_timestamp <= $4)
                       ORDER BY sender, factory NULLS LAST
                       LIMIT $5),
      accounts_total_cte AS (SELECT accounts_cte.sender, count(*) as total_ops

--- a/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
@@ -59,7 +59,7 @@ WITH accounts_cte AS (SELECT DISTINCT ON (sender) sender,
                                                   factory,
                                                   CASE WHEN factory IS NOT NULL THEN user_operations.transaction_hash END as creation_transaction_hash,
                                                   CASE WHEN factory IS NOT NULL THEN user_operations.hash END             as creation_op_hash,
-                                                  CASE WHEN factory IS NOT NULL THEN blocks.timestamp END,                as creation_timestamp
+                                                  CASE WHEN factory IS NOT NULL THEN blocks.timestamp END                as creation_timestamp
                       FROM user_operations
                                JOIN blocks
                                     ON blocks.hash = block_hash AND consensus

--- a/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
@@ -85,8 +85,8 @@ FROM accounts_cte
         [
             factory_filter.map(|f| f.to_vec()).into(),
             page_token.unwrap_or(Address::ZERO).to_vec().into(),
-            start_time.into(),
-            end_time.into(),
+            //start_time.into(),
+            //end_time.into(),
             (limit + 1).into(),
         ],
     ))

--- a/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
@@ -59,7 +59,10 @@ WITH accounts_cte AS (SELECT DISTINCT ON (sender) sender,
                                                   factory,
                                                   CASE WHEN factory IS NOT NULL THEN user_operations.transaction_hash END as creation_transaction_hash,
                                                   CASE WHEN factory IS NOT NULL THEN user_operations.hash END             as creation_op_hash,
-                                                  CASE WHEN factory IS NOT NULL THEN blocks.timestamp END                 as creation_timestamp
+                                                  COALESCE(
+                                                        CASE WHEN factory IS NOT NULL THEN blocks.timestamp END,
+                                                        NULL
+                                                  ) AS creation_timestamp
                       FROM user_operations
                                JOIN blocks
                                     ON blocks.hash = block_hash AND consensus
@@ -85,8 +88,8 @@ FROM accounts_cte
         [
             factory_filter.map(|f| f.to_vec()).into(),
             page_token.unwrap_or(Address::ZERO).to_vec().into(),
-            //start_time.into(),
-            //end_time.into(),
+            start_time.into(),
+            end_time.into(),
             (limit + 1).into(),
         ],
     ))

--- a/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
+++ b/user-ops-indexer/user-ops-indexer-logic/src/repository/account.rs
@@ -85,8 +85,8 @@ FROM accounts_cte
         [
             factory_filter.map(|f| f.to_vec()).into(),
             page_token.unwrap_or(Address::ZERO).to_vec().into(),
-            start_time.map(|t| t.and_utc()).into(),
-            end_time.map(|t| t.and_utc()).into(),
+            start_time.into(),
+            end_time.into(),
             (limit + 1).into(),
         ],
     ))

--- a/user-ops-indexer/user-ops-indexer-proto/proto/user-ops-indexer.proto
+++ b/user-ops-indexer/user-ops-indexer-proto/proto/user-ops-indexer.proto
@@ -52,6 +52,8 @@ message ListAccountsRequest {
   optional string factory = 1;
   optional uint32 page_size = 2;
   optional string page_token = 3;
+  optional string start_time = 4;
+  optional string end_time = 5;
 }
 
 message ListAccountsResponse {
@@ -82,6 +84,8 @@ message ListUserOpsRequest {
   optional uint64 block_number = 8;
   optional uint32 page_size = 9;
   optional string page_token = 10;
+  optional string start_time = 11;
+  optional string end_time = 12;
 }
 
 message ListUserOpsResponse {

--- a/user-ops-indexer/user-ops-indexer-proto/swagger/user-ops-indexer.swagger.yaml
+++ b/user-ops-indexer/user-ops-indexer-proto/swagger/user-ops-indexer.swagger.yaml
@@ -36,6 +36,14 @@ paths:
           in: query
           required: false
           type: string
+        - name: start_time
+          in: query
+          required: false
+          type: string
+        - name: end_time
+          in: query
+          required: false
+          type: string
       tags:
         - UserOpsService
   /api/v1/accounts/{address}:
@@ -285,6 +293,14 @@ paths:
           type: integer
           format: int64
         - name: page_token
+          in: query
+          required: false
+          type: string
+        - name: start_time
+          in: query
+          required: false
+          type: string
+        - name: end_time
           in: query
           required: false
           type: string

--- a/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
+++ b/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
@@ -1,6 +1,6 @@
 use crate::{proto::user_ops_service_server::UserOpsService as UserOps, settings::ApiSettings};
-use sea_orm::DatabaseConnection;
-use std::{str::FromStr, sync::Arc};
+use sea_orm::{prelude::DateTime, DatabaseConnection};
+use std::{str::FromStr, sync::Arc, error::Error};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 use user_ops_indexer_logic::{
@@ -56,6 +56,16 @@ impl UserOpsService {
     fn normalize_page_size(&self, size: Option<u32>) -> u32 {
         size.unwrap_or(DEFAULT_PAGE_SIZE)
             .clamp(1, self.settings.max_page_size)
+    }
+
+    fn parse_iso8601(&self, timestamp: Option<&String>) -> Result<Option<DateTime>, Box<dyn Error>> {
+        match timestamp {
+            Some(ts) => {
+                let dt = ts.parse::<DateTime>()?;  // ✅ Now uses SeaORM's DateTime
+                Ok(Some(dt))
+            }
+            None => Ok(None), // ✅ Handle `None` gracefully
+        }
     }
 }
 
@@ -165,12 +175,16 @@ impl UserOps for UserOpsService {
         let factory_filter = inner.factory.parse_filter("factory")?;
         let page_token = inner.page_token.parse_page_token()?;
         let page_size = self.normalize_page_size(inner.page_size);
+        let start_time = self.parse_iso8601(inner.start_time.as_ref()).unwrap();
+        let end_time = self.parse_iso8601(inner.end_time.as_ref()).unwrap();
 
         let (accounts, next_page_token) = repository::account::list_accounts(
             &self.db,
             factory_filter,
             page_token,
             page_size as u64,
+            start_time,
+            end_time,
         )
         .await
         .map_err(|err| {
@@ -234,6 +248,8 @@ impl UserOps for UserOpsService {
         let block_number_filter = inner.block_number;
         let page_token = inner.page_token.parse_page_token()?;
         let page_size = self.normalize_page_size(inner.page_size);
+        let start_time = self.parse_iso8601(inner.start_time.as_ref()).unwrap();
+        let end_time = self.parse_iso8601(inner.end_time.as_ref()).unwrap();
 
         let (ops, next_page_token) = repository::user_op::list_user_ops(
             &self.db,
@@ -247,6 +263,8 @@ impl UserOps for UserOpsService {
             block_number_filter,
             page_token,
             page_size as u64,
+            start_time,
+            end_time,
         )
         .await
         .map_err(|err| {

--- a/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
+++ b/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
@@ -62,12 +62,6 @@ impl UserOpsService {
         match timestamp {
             Some(ts) => {
                 println!("Parsing timestamp: {:?}", ts); // ✅ Debug log
-    
-                // ✅ Try ISO 8601 (`2024-02-06T12:30:00Z`)
-                if let Ok(dt) = DateTime::parse_from_rfc3339(ts) {
-                    return Ok(Some(dt.naive_utc())); // ✅ Convert to `NaiveDateTime`
-                }
-    
                 // ✅ Try `YYYY-MM-DD HH:MM:SS`
                 if let Ok(dt) = DateTime::parse_from_str(ts, "%Y-%m-%d %H:%M:%S") {
                     return Ok(Some(dt));

--- a/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
+++ b/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
@@ -1,6 +1,6 @@
 use crate::{proto::user_ops_service_server::UserOpsService as UserOps, settings::ApiSettings};
 use sea_orm::{prelude::DateTime, DatabaseConnection};
-use std::{str::FromStr, sync::Arc, error::Error};
+use std::{str::FromStr, sync::Arc, string::ParseError};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 use user_ops_indexer_logic::{

--- a/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
+++ b/user-ops-indexer/user-ops-indexer-server/src/services/user_ops.rs
@@ -58,13 +58,28 @@ impl UserOpsService {
             .clamp(1, self.settings.max_page_size)
     }
 
-    fn parse_iso8601(&self, timestamp: Option<&String>) -> Result<Option<DateTime>, Box<dyn Error>> {
+    fn parse_iso8601(&self, timestamp: Option<&String>) -> Result<Option<DateTime>, ParseError> {
         match timestamp {
             Some(ts) => {
-                let dt = ts.parse::<DateTime>()?;  // ✅ Now uses SeaORM's DateTime
-                Ok(Some(dt))
+                println!("Parsing timestamp: {:?}", ts); // ✅ Debug log
+    
+                // ✅ Try ISO 8601 (`2024-02-06T12:30:00Z`)
+                if let Ok(dt) = DateTime::parse_from_rfc3339(ts) {
+                    return Ok(Some(dt.naive_utc())); // ✅ Convert to `NaiveDateTime`
+                }
+    
+                // ✅ Try `YYYY-MM-DD HH:MM:SS`
+                if let Ok(dt) = DateTime::parse_from_str(ts, "%Y-%m-%d %H:%M:%S") {
+                    return Ok(Some(dt));
+                }
+    
+                // ❌ If all fails, return None
+                Ok(None)
             }
-            None => Ok(None), // ✅ Handle `None` gracefully
+            None => {
+                println!("No timestamp provided");
+                Ok(None)
+            }
         }
     }
 }


### PR DESCRIPTION
Added `start_time` and `end_time` to `ListAccountsRequest` and `ListUserOpsRequest`. Implemented filtering using these timestamps in `list_accounts` and `list_user_ops`.

Tested manually by running blockscout services locally. When blockscout indexer is running, tested using
`http://localhost/api/v2/proxy/account-abstraction/accounts?start_time=2025-02-01%2000:00:00&end_time=2025-02-07%2000:00:00`
and
`http://localhost/api/v2/proxy/account-abstraction/operations?start_time=2025-02-01%2000:00:00&end_time=2025-02-07%2000:00:00`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features  
   - Added optional time range filters for account listings, allowing users to view accounts created within a specified period.  
   - Enabled time-based filtering for user operations, offering more precise control over data retrieval.  
   - Updated API endpoints to accept optional start and end time parameters, enhancing query flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->