### PR TITLE
config(bens): index address lookups for apechain testnet

### DIFF
--- a/blockscout-ens/bens-server/config/dev.json
+++ b/blockscout-ens/bens-server/config/dev.json
@@ -109,7 +109,7 @@
         "meta": {
           "short_name": "D3 Connect",
           "title": "D3 Connect",
-          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "description": "D3 Connect is official identity service for top web3 communities.",
           "icon_url": "https://i.imgur.com/cD6VIXk.png",
           "docs_url": "https://docs.d3.app/"
         }
@@ -127,7 +127,7 @@
         "meta": {
           "short_name": "D3 Connect",
           "title": "D3 Connect",
-          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "description": "D3 Connect is official identity service for top web3 communities.",
           "icon_url": "https://i.imgur.com/cD6VIXk.png",
           "docs_url": "https://docs.d3.app/"
         }
@@ -145,7 +145,7 @@
         "meta": {
           "short_name": "D3 Connect",
           "title": "D3 Connect",
-          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "description": "D3 Connect is official identity service for top web3 communities.",
           "icon_url": "https://i.imgur.com/cD6VIXk.png",
           "docs_url": "https://docs.d3.app/"
         }
@@ -163,7 +163,7 @@
         "meta": {
           "short_name": "D3 Connect",
           "title": "D3 Connect",
-          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "description": "D3 Connect is official identity service for top web3 communities.",
           "icon_url": "https://i.imgur.com/cD6VIXk.png",
           "docs_url": "https://docs.d3.app/"
         }

--- a/blockscout-ens/bens-server/config/dev.json
+++ b/blockscout-ens/bens-server/config/dev.json
@@ -35,6 +35,24 @@
           "d3-connect-shib-testnet"
         ],
         "rpc_url": "https://puppynet.shibrpc.com"
+      },
+      "33111": {
+        "blockscout": {
+          "url": "https://curtis.explorer.caldera.xyz/"
+        },
+        "use_protocols": [
+          "d3-connect-ape-testnet"
+        ],
+        "rpc_url": "https://curtis.rpc.caldera.xyz/http"
+      },
+      "33139": {
+        "blockscout": {
+          "url": "https://apescan.io/"
+        },
+        "use_protocols": [
+          "d3-connect-ape-mainnet"
+        ],
+        "rpc_url": "https://rpc.apechain.com/"
       }
     },
     "protocols": {
@@ -105,6 +123,42 @@
           "type": "d3_connect",
           "native_token_contract": "0x1443bC2bBAB07437BCF9C577b647523A736bB33E",
           "resolver_contract": "0xae6Bdf6e9edA0bA60F97390e70a545e91B5E8bf2"
+        },
+        "meta": {
+          "short_name": "D3 Connect",
+          "title": "D3 Connect",
+          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "icon_url": "https://i.imgur.com/cD6VIXk.png",
+          "docs_url": "https://docs.d3.app/"
+        }
+      },
+      "d3-connect-ape-testnet": {
+        "tld_list": ["ape"],
+        "network_id": 33111,
+        "subgraph_name": "d3-connect-ape-testnet-subgraph",
+        "address_resolve_technique": "reverse_registry",
+        "specific": {
+          "type": "d3_connect",
+          "native_token_contract": "0xA6A33ddE98BAb3ee5262e7e1a14ee5B1F06D0D40",
+          "resolver_contract": "0x2ad234136165B59f98cf03f696cB84eaf48E30cF"
+        },
+        "meta": {
+          "short_name": "D3 Connect",
+          "title": "D3 Connect",
+          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "icon_url": "https://i.imgur.com/cD6VIXk.png",
+          "docs_url": "https://docs.d3.app/"
+        }
+      },
+      "d3-connect-ape-mainnet": {
+        "tld_list": ["ape"],
+        "network_id": 33139,
+        "subgraph_name": "d3-connect-ape-mainnet-subgraph",
+        "address_resolve_technique": "reverse_registry",
+        "specific": {
+          "type": "d3_connect",
+          "native_token_contract": "0x0D435A6c16045Abeaf6A442Bf162fd52597B4Ed3",
+          "resolver_contract": "0x3698485B8079FBDCc86Eb4f69Ebb9349DF1fc6f4"
         },
         "meta": {
           "short_name": "D3 Connect",

--- a/blockscout-ens/bens-server/config/prod.json
+++ b/blockscout-ens/bens-server/config/prod.json
@@ -97,6 +97,15 @@
           "base-name-service", "ens"
         ]
       },
+      "33111": {
+        "blockscout": {
+          "url": "https://curtis.explorer.caldera.xyz/"
+        },
+        "use_protocols": [
+          "d3-connect-ape-testnet"
+        ],
+        "rpc_url": "https://curtis.rpc.caldera.xyz/http"
+      },
       "33139": {
         "blockscout": {
           "url": "https://apechain.calderaexplorer.xyz"
@@ -445,6 +454,24 @@
           "short_name": "D3",
           "title": "D3 Connect",
           "description": "D3 Connect is official identity service for top web3 communities.",
+          "icon_url": "https://i.imgur.com/cD6VIXk.png",
+          "docs_url": "https://docs.d3.app/"
+        }
+      },
+      "d3-connect-ape-testnet": {
+        "tld_list": ["ape"],
+        "network_id": 33111,
+        "subgraph_name": "d3-connect-ape-testnet-subgraph",
+        "address_resolve_technique": "reverse_registry",
+        "specific": {
+          "type": "d3_connect",
+          "native_token_contract": "0xA6A33ddE98BAb3ee5262e7e1a14ee5B1F06D0D40",
+          "resolver_contract": "0x2ad234136165B59f98cf03f696cB84eaf48E30cF"
+        },
+        "meta": {
+          "short_name": "D3 Connect",
+          "title": "D3 Connect",
+          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
           "icon_url": "https://i.imgur.com/cD6VIXk.png",
           "docs_url": "https://docs.d3.app/"
         }

--- a/blockscout-ens/bens-server/config/prod.json
+++ b/blockscout-ens/bens-server/config/prod.json
@@ -471,7 +471,7 @@
         "meta": {
           "short_name": "D3 Connect",
           "title": "D3 Connect",
-          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "description": "D3 Connect is official identity service for top web3 communities.",
           "icon_url": "https://i.imgur.com/cD6VIXk.png",
           "docs_url": "https://docs.d3.app/"
         }
@@ -489,7 +489,7 @@
         "meta": {
           "short_name": "D3 Connect",
           "title": "D3 Connect",
-          "description": "D3 Connect is a platform for connecting to the Shibarium network.",
+          "description": "D3 Connect is official identity service for top web3 communities.",
           "icon_url": "https://i.imgur.com/cD6VIXk.png",
           "docs_url": "https://docs.d3.app/"
         }

--- a/blockscout-ens/graph-node/config.toml
+++ b/blockscout-ens/graph-node/config.toml
@@ -49,3 +49,15 @@ provider = [
     { label = "shibarium-testnet", url = "https://puppynet.shibrpc.com", features = [] }
 ]
 shard = "primary"
+
+[chains.ape-mainnet]
+provider = [
+    { label = "ape-mainnet", url = "https://rpc.apechain.com", features = [] }
+]
+shard = "primary"
+
+[chains.ape-testnet]
+provider = [
+    { label = "ape-testnet", url = "https://curtis.rpc.caldera.xyz/http", features = [] }
+]
+shard = "primary"

--- a/blockscout-ens/graph-node/deployer/config.json
+++ b/blockscout-ens/graph-node/deployer/config.json
@@ -70,6 +70,11 @@
       "subgraph_name": "d3-connect-ape-subgraph",
       "network": "ape-mainnet"
     },
+    "d3-connect-ape-testnet": {
+      "subgraph_path": "../subgraphs/d3-connect-subgraph",
+      "subgraph_name": "d3-connect-ape-testnet-subgraph",
+      "network": "ape-testnet"
+    },
     "d3-connect-shib-testnet": {
         "subgraph_path": "../subgraphs/d3-connect-subgraph",
         "subgraph_name": "d3-connect-shib-testnet-subgraph",

--- a/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/networks.json
+++ b/blockscout-ens/graph-node/subgraphs/d3-connect-subgraph/networks.json
@@ -21,6 +21,17 @@
     },
     "": ""
   },
+  "ape-testnet": {
+    "Registry": {
+      "address": "0xA6A33ddE98BAb3ee5262e7e1a14ee5B1F06D0D40",
+      "startBlock": 1902834
+    },
+    "Resolver": {
+      "address": "0x2ad234136165B59f98cf03f696cB84eaf48E30cF",
+      "startBlock": 14614509
+    },
+    "": ""
+  },
   "shibarium-testnet": {
     "Registry": {
       "address": "0x1443bC2bBAB07437BCF9C577b647523A736bB33E",


### PR DESCRIPTION
Add configs for Apechain testnet so it can index address lookups for D3 and display them on the explorer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Expanded blockchain support now enables connectivity with both Ape Mainnet and Ape Testnet.
	- Added new network configurations for D3 Connect, enhancing access to additional protocols.
	- Improved integration details for the D3 Connect platform, including metadata for better user experience.
	- Introduced new protocol configurations for D3 Connect on Ape Testnet and Mainnet.
	- Added new network entries for "ape-testnet" with specific registry and resolver details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->