### PR TITLE
feat: add IPFS_PROFILE

### DIFF
--- a/blockscout-ens/graph-node/docker-compose.yml
+++ b/blockscout-ens/graph-node/docker-compose.yml
@@ -29,6 +29,8 @@ services:
     image: ipfs/kubo:v0.14.0
     ports:
       - '5001:5001'
+    environment:
+      - IPFS_PROFILE=server
     volumes:
       - ./data/ipfs:/data/ipfs
   postgres:


### PR DESCRIPTION
ref: https://github.com/ipfs/kubo/issues/8585#issuecomment-1485079021

Result:
(1) left:v0.14.0 right:v0.14.0+`IPFS_PROFILE=server`
It can be found from the log that after adding the environment variable, the scanning of the internal network was reduced.
![image](https://github.com/user-attachments/assets/b742c638-9915-45a5-9b80-02315fbff61a)

(2)v0.14.0+`IPFS_PROFILE=server` restart ipfs docker 
left: restart right: first time start
It can be found that after the restart, the internal network scanning situation is as expected.
![image](https://github.com/user-attachments/assets/00740799-70cc-4c7c-afdd-174c7f84ae1c)
