### PR TITLE
feat(launcher): add more test launch options

### DIFF
--- a/libs/blockscout-service-launcher/src/test_server.rs
+++ b/libs/blockscout-service-launcher/src/test_server.rs
@@ -106,10 +106,7 @@ where
 }
 
 /// Use [`TestServerSettings`] for more configurable interface
-pub async fn init_server<F, R, FCheck, RCheck>(
-    run: F,
-    base: &Url,
-) -> JoinHandle<Result<(), anyhow::Error>>
+pub async fn init_server<F, R>(run: F, base: &Url) -> JoinHandle<Result<(), anyhow::Error>>
 where
     F: FnOnce() -> R + Send + 'static,
     R: Future<Output = Result<(), anyhow::Error>> + Send,

--- a/libs/blockscout-service-launcher/src/test_server.rs
+++ b/libs/blockscout-service-launcher/src/test_server.rs
@@ -23,6 +23,15 @@ pub fn get_test_server_settings() -> (ServerSettings, Url) {
     (server, base)
 }
 
+/// Use [`TestServerSettings`] for more configurable interface
+pub async fn init_server<F, R>(run: F, base: &Url) -> JoinHandle<Result<(), anyhow::Error>>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Future<Output = Result<(), anyhow::Error>> + Send,
+{
+    TestServerSettings::new(base.clone()).init(run).await
+}
+
 pub fn health_always_valid(_: reqwest::Response) -> DefaultRCheck {
     Box::pin(async { true })
 }
@@ -104,16 +113,6 @@ where
         server_handle
     }
 }
-
-/// Use [`TestServerSettings`] for more configurable interface
-pub async fn init_server<F, R>(run: F, base: &Url) -> JoinHandle<Result<(), anyhow::Error>>
-where
-    F: FnOnce() -> R + Send + 'static,
-    R: Future<Output = Result<(), anyhow::Error>> + Send,
-{
-    TestServerSettings::new(base.clone()).init(run).await
-}
-
 async fn send_annotated_request<Response: for<'a> serde::Deserialize<'a>>(
     url: &Url,
     route: &str,

--- a/libs/blockscout-service-launcher/src/test_server.rs
+++ b/libs/blockscout-service-launcher/src/test_server.rs
@@ -45,7 +45,7 @@ where
         }
     };
     // Wait for the server to start
-    if (timeout(Duration::from_secs(10), wait_health_check).await).is_err() {
+    if (timeout(Duration::from_secs(30), wait_health_check).await).is_err() {
         match timeout(Duration::from_secs(1), server_handle).await {
             Ok(Ok(result)) => {
                 panic!("Server terminated with: {result:?}")
@@ -54,7 +54,7 @@ where
                 panic!("Server start terminated with exit error")
             }
             Err(_) => {
-                panic!("Server did not start in time, but did not terminate");
+                panic!("Server did not start in time, and did not terminate");
             }
         }
     }

--- a/libs/blockscout-service-launcher/src/test_server.rs
+++ b/libs/blockscout-service-launcher/src/test_server.rs
@@ -113,6 +113,7 @@ where
         server_handle
     }
 }
+
 async fn send_annotated_request<Response: for<'a> serde::Deserialize<'a>>(
     url: &Url,
     route: &str,


### PR DESCRIPTION
- configurable healthcheck timeout w/o breaking launch interface (I need that in `stats` integration tests)
- additional healthcheck condition `response.status() == reqwest::StatusCode::OK` for more correct behaviour