### PR TITLE
feat(blockscout-service-launcher): add base_path of api

### DIFF
--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { version = "0.12", features = ["json"], optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 serde_with = { version = "3", optional = true }
-tokio = { version = "1", optional = true }
+tokio = { version = "1.44", optional = true }
 tokio-util = { version = "0.7.13", features = ["rt"], optional = true }
 tonic = { version = "0.12", optional = true }
 tracing = { version = "0.1", optional = true }

--- a/libs/blockscout-service-launcher/Cargo.toml
+++ b/libs/blockscout-service-launcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blockscout-service-launcher"
-version = "0.18.0"
+version = "0.19.0"
 description = "Allows to launch blazingly fast blockscout rust services"
 license = "MIT"
 repository = "https://github.com/blockscout/blockscout-rs"

--- a/libs/blockscout-service-launcher/src/launcher/launch.rs
+++ b/libs/blockscout-service-launcher/src/launcher/launch.rs
@@ -137,6 +137,7 @@ where
     let json_cfg = actix_web::web::JsonConfig::default().limit(settings.max_body_size);
     let cors_settings = settings.cors.clone();
     let cors_enabled = cors_settings.enabled;
+    let base_path = settings.base_path.clone();
     let server = if let Some(metrics) = metrics {
         HttpServer::new(move || {
             let cors = cors_settings.clone().build();
@@ -145,7 +146,7 @@ where
                 .wrap(metrics.clone())
                 .wrap(Condition::new(cors_enabled, cors))
                 .app_data(json_cfg.clone())
-                .configure(configure_router(&http))
+                .configure(configure_router(&http, base_path.clone()))
         })
         .shutdown_timeout(SHUTDOWN_TIMEOUT_SEC)
         .bind(settings.addr)
@@ -158,7 +159,7 @@ where
                 .wrap(TracingLogger::<CompactRootSpanBuilder>::new())
                 .wrap(Condition::new(cors_enabled, cors))
                 .app_data(json_cfg.clone())
-                .configure(configure_router(&http))
+                .configure(configure_router(&http, base_path.clone()))
         })
         .shutdown_timeout(SHUTDOWN_TIMEOUT_SEC)
         .bind(settings.addr)

--- a/libs/blockscout-service-launcher/src/launcher/launch.rs
+++ b/libs/blockscout-service-launcher/src/launcher/launch.rs
@@ -146,7 +146,10 @@ where
                 .wrap(metrics.clone())
                 .wrap(Condition::new(cors_enabled, cors))
                 .app_data(json_cfg.clone())
-                .configure(configure_router(&http, base_path.clone()))
+                .configure(configure_router(
+                    &http,
+                    base_path.as_ref().map(|p| p.0.clone()),
+                ))
         })
         .shutdown_timeout(SHUTDOWN_TIMEOUT_SEC)
         .bind(settings.addr)
@@ -159,7 +162,10 @@ where
                 .wrap(TracingLogger::<CompactRootSpanBuilder>::new())
                 .wrap(Condition::new(cors_enabled, cors))
                 .app_data(json_cfg.clone())
-                .configure(configure_router(&http, base_path.clone()))
+                .configure(configure_router(
+                    &http,
+                    base_path.as_ref().map(|p| p.0.clone()),
+                ))
         })
         .shutdown_timeout(SHUTDOWN_TIMEOUT_SEC)
         .bind(settings.addr)

--- a/libs/blockscout-service-launcher/src/launcher/router.rs
+++ b/libs/blockscout-service-launcher/src/launcher/router.rs
@@ -12,6 +12,13 @@ impl<T: HttpRouter> HttpRouter for Option<T> {
 
 pub fn configure_router(
     router: &impl HttpRouter,
+    base_path: Option<String>,
 ) -> impl FnOnce(&mut actix_web::web::ServiceConfig) + '_ {
-    |service_config| router.register_routes(service_config)
+    |service_config| {
+        if let Some(base_path) = base_path {
+            service_config.service(actix_web::web::scope(&base_path).configure(|inner_config| router.register_routes(inner_config)));
+        } else {
+            router.register_routes(service_config);
+        }
+    }
 }

--- a/libs/blockscout-service-launcher/src/launcher/router.rs
+++ b/libs/blockscout-service-launcher/src/launcher/router.rs
@@ -16,7 +16,10 @@ pub fn configure_router(
 ) -> impl FnOnce(&mut actix_web::web::ServiceConfig) + '_ {
     |service_config| {
         if let Some(base_path) = base_path {
-            service_config.service(actix_web::web::scope(&base_path).configure(|inner_config| router.register_routes(inner_config)));
+            service_config.service(
+                actix_web::web::scope(&base_path)
+                    .configure(|inner_config| router.register_routes(inner_config)),
+            );
         } else {
             router.register_routes(service_config);
         }

--- a/libs/blockscout-service-launcher/src/launcher/settings.rs
+++ b/libs/blockscout-service-launcher/src/launcher/settings.rs
@@ -50,6 +50,7 @@ pub struct HttpServerSettings {
     pub addr: SocketAddr,
     pub max_body_size: usize,
     pub cors: CorsSettings,
+    pub base_path: Option<String>,
 }
 
 impl Default for HttpServerSettings {
@@ -59,6 +60,7 @@ impl Default for HttpServerSettings {
             addr: SocketAddr::from_str("0.0.0.0:8050").unwrap(),
             max_body_size: 2 * 1024 * 1024, // 2 Mb - default Actix value
             cors: Default::default(),
+            base_path: None,
         }
     }
 }

--- a/libs/blockscout-service-launcher/src/launcher/settings.rs
+++ b/libs/blockscout-service-launcher/src/launcher/settings.rs
@@ -50,7 +50,7 @@ pub struct HttpServerSettings {
     pub addr: SocketAddr,
     pub max_body_size: usize,
     pub cors: CorsSettings,
-    pub base_path: Option<String>,
+    pub base_path: Option<BasePath>,
 }
 
 impl Default for HttpServerSettings {
@@ -116,6 +116,30 @@ impl CorsSettings {
             }
         };
         cors
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "String")]
+pub struct BasePath(pub String);
+
+impl TryFrom<String> for BasePath {
+    type Error = String;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if !value.starts_with("/") {
+            return Err(format!(
+                "Invalid base path '{}': must start with '/'",
+                value
+            ));
+        };
+        if value.ends_with("/") {
+            return Err(format!(
+                "Invalid base path '{}': must not end with '/'",
+                value
+            ));
+        };
+        Ok(Self(value))
     }
 }
 

--- a/libs/blockscout-service-launcher/src/launcher/settings.rs
+++ b/libs/blockscout-service-launcher/src/launcher/settings.rs
@@ -121,7 +121,7 @@ impl CorsSettings {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(try_from = "String")]
-pub struct BasePath(pub String);
+pub struct BasePath(String);
 
 impl TryFrom<String> for BasePath {
     type Error = String;
@@ -140,6 +140,12 @@ impl TryFrom<String> for BasePath {
             ));
         };
         Ok(Self(value))
+    }
+}
+
+impl From<BasePath> for String {
+    fn from(value: BasePath) -> Self {
+        value.0
     }
 }
 

--- a/libs/reqwest-rate-limiter/src/lib.rs
+++ b/libs/reqwest-rate-limiter/src/lib.rs
@@ -10,7 +10,7 @@ pub type DefaultRateLimiterMiddleware<
 impl DefaultRateLimiterMiddleware {
     /// Default rate limiter splits the given period evenly between quotas
     /// and allows only 1 request per the cell.
-    const BURST_SIZE: NonZeroU32 = unsafe { NonZeroU32::new_unchecked(1) };
+    const BURST_SIZE: NonZeroU32 = NonZeroU32::new(1).unwrap();
 
     pub fn per_second(max_burst: NonZeroU32) -> Self {
         let quota = governor::Quota::per_second(max_burst).allow_burst(Self::BURST_SIZE);


### PR DESCRIPTION
add `base_path: Option<String>` to settings that allows paths to start with custom string like `/api/v1/charts` -> `/stats-service/api/1/charts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an optional configuration for routing customization that allows users to define a custom path prefix. This enhancement improves the flexibility of HTTP endpoint exposure and enriches server logging, offering a more tailored service experience.

- **Chores**
  - Upgraded the package version to 0.19.0 and updated the `tokio` dependency, resulting in improved performance and overall stability of the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->