### PR TITLE
fix(types): Incorrect paths to main and types files in package.json for TypeScript definitions

### DIFF
--- a/service-template/types/package.json
+++ b/service-template/types/package.json
@@ -6,7 +6,7 @@
   "types": "./dist/{{project-name}}-proto/proto/v1/{{project-name}}.d.ts",
   "scripts": {
     "build": "npm run compile:proto && npm run compile:ts",
-    "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=snakeToCamel=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../{{project-name}}-proto/proto/v1/{{project-name}}.proto",
+    "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=snakeToCamel=false --ts_proto_opt=exportCommonSymbols=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../{{project-name}}-proto/proto/v1/{{project-name}}.proto",
     "compile:ts": "tsc --declaration ./dist/{{project-name}}-proto/proto/v1/{{project-name}}.ts"
   },
   "repository": {

--- a/service-template/types/package.json
+++ b/service-template/types/package.json
@@ -2,8 +2,8 @@
   "name": "@blockscout/{{project-name}}-types",
   "version": "0.0.1",
   "description": "TypeScript definitions for {{project-name-title}} microservice",
-  "main": "./dist/{{project-name}}-proto/proto/{{project-name}}.js",
-  "types": "./dist/{{project-name}}-proto/proto/{{project-name}}.d.ts",
+  "main": "./dist/{{project-name}}-proto/proto/v1/{{project-name}}.js",
+  "types": "./dist/{{project-name}}-proto/proto/v1/{{project-name}}.d.ts",
   "scripts": {
     "build": "npm run compile:proto && npm run compile:ts",
     "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=snakeToCamel=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../{{project-name}}-proto/proto/v1/{{project-name}}.proto",

--- a/tac-operation-lifecycle/types/.gitignore
+++ b/tac-operation-lifecycle/types/.gitignore
@@ -1,1 +1,4 @@
 /dist
+/node_modules
+index.d.ts
+index.js

--- a/tac-operation-lifecycle/types/index.ts
+++ b/tac-operation-lifecycle/types/index.ts
@@ -1,0 +1,2 @@
+export * from './dist/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle';
+export * from './dist/tac-operation-lifecycle-proto/proto/v1/statistic';

--- a/tac-operation-lifecycle/types/package.json
+++ b/tac-operation-lifecycle/types/package.json
@@ -2,8 +2,8 @@
   "name": "@blockscout/tac-operation-lifecycle-types",
   "version": "0.0.1",
   "description": "TypeScript definitions for TAC Operation Lifecycle microservice",
-  "main": "./dist/tac-operation-lifecycle-proto/proto/tac-operation-lifecycle.js",
-  "types": "./dist/tac-operation-lifecycle-proto/proto/tac-operation-lifecycle.d.ts",
+  "main": "./dist/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.js",
+  "types": "./dist/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.d.ts",
   "scripts": {
     "build": "npm run compile:proto && npm run compile:ts",
     "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=snakeToCamel=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto",

--- a/tac-operation-lifecycle/types/package.json
+++ b/tac-operation-lifecycle/types/package.json
@@ -2,12 +2,12 @@
   "name": "@blockscout/tac-operation-lifecycle-types",
   "version": "0.0.1",
   "description": "TypeScript definitions for TAC Operation Lifecycle microservice",
-  "main": "./dist/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.js",
-  "types": "./dist/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.d.ts",
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "scripts": {
     "build": "npm run compile:proto && npm run compile:ts",
-    "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=snakeToCamel=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto",
-    "compile:ts": "tsc --declaration ./dist/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.ts"
+    "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=exportCommonSymbols=false --ts_proto_opt=snakeToCamel=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto ../tac-operation-lifecycle-proto/proto/v1/statistic.proto",
+    "compile:ts": "tsc --declaration ./index.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix the paths to the main and types files in the package.json of the type definitions packages.