### PR TITLE
fix(tac): endpoints refactoring

### DIFF
--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
@@ -71,12 +71,12 @@ message OperationRelatedTransaction {
 
 message OperationStage {
   enum StageType {
-    CollectedInTAC = 0;
-    IncludedInTACConsensus = 1;
-    ExecutedInTAC = 2;
-    CollectedInTON = 3;
-    IncludedInTONConsensus = 4;
-    ExecutedInTON = 5;
+    COLLECTED_IN_TAC = 0;
+    INCLUDED_IN_TAC_CONSENSUS = 1;
+    EXECUTED_IN_TAC = 2;
+    COLLECTED_IN_TON = 3;
+    INCLUDED_IN_TON_CONSENSUS = 4;
+    EXECUTED_IN_TON = 5;
   }
   StageType type = 1;
   bool is_exist = 2;

--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
@@ -40,21 +40,21 @@ enum OperationType {
 }
 
 message OperationsResponse {
-  repeated OperationBriefDetails operations = 1;
+  repeated OperationBriefDetails items = 1;
   optional Pagination next_page_params = 2;
 }
 
 message OperationBriefDetails {
   string operation_id = 1;
   OperationType type = 2;
-  optional uint64 timestamp = 3;
+  string timestamp = 3;
   optional string sender = 4;
 }
 
 message OperationDetails {
   string operation_id = 1;
   OperationType type = 2;
-  optional uint64 timestamp = 3;
+  string timestamp = 3;
   optional string sender = 4;
   repeated OperationStage status_history = 5;
 }
@@ -81,7 +81,7 @@ message OperationStage {
   StageType type = 1;
   bool is_exist = 2;
   optional bool is_success = 3;
-  optional uint64 timestamp = 4;
+  optional string timestamp = 4;
   repeated OperationRelatedTransaction transactions = 5;
   optional string note = 6;
 }

--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
@@ -158,13 +158,13 @@ definitions:
   OperationStageStageType:
     type: string
     enum:
-      - CollectedInTAC
-      - IncludedInTACConsensus
-      - ExecutedInTAC
-      - CollectedInTON
-      - IncludedInTONConsensus
-      - ExecutedInTON
-    default: CollectedInTAC
+      - COLLECTED_IN_TAC
+      - INCLUDED_IN_TAC_CONSENSUS
+      - EXECUTED_IN_TAC
+      - COLLECTED_IN_TON
+      - INCLUDED_IN_TON_CONSENSUS
+      - EXECUTED_IN_TON
+    default: COLLECTED_IN_TAC
   protobufAny:
     type: object
     properties:

--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
@@ -257,7 +257,6 @@ definitions:
         $ref: '#/definitions/v1OperationType'
       timestamp:
         type: string
-        format: uint64
       sender:
         type: string
   v1OperationDetails:
@@ -269,7 +268,6 @@ definitions:
         $ref: '#/definitions/v1OperationType'
       timestamp:
         type: string
-        format: uint64
       sender:
         type: string
       status_history:
@@ -295,7 +293,6 @@ definitions:
         type: boolean
       timestamp:
         type: string
-        format: uint64
       transactions:
         type: array
         items:
@@ -341,7 +338,7 @@ definitions:
   v1OperationsResponse:
     type: object
     properties:
-      operations:
+      items:
         type: array
         items:
           type: object

--- a/tac-operation-lifecycle/tac-operation-lifecycle-server/src/services/operations.rs
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-server/src/services/operations.rs
@@ -148,5 +148,6 @@ impl TacService for OperationsService {
 }
 
 fn db_datetime_to_string(ts: NaiveDateTime) -> String {
-    ts.and_utc().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+    ts.and_utc()
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }

--- a/tac-operation-lifecycle/tac-operation-lifecycle-server/src/services/operations.rs
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-server/src/services/operations.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::NaiveDateTime;
 use tac_operation_lifecycle_entity::{operation, operation_stage, transaction};
 use tac_operation_lifecycle_logic::{
     client::models::profiling::OperationType,
@@ -41,7 +42,7 @@ impl OperationsService {
                 Ok(tonic::Response::new(OperationDetails {
                     operation_id: op.id,
                     r#type: op_type.to_id(),
-                    timestamp: Some(op.timestamp.and_utc().timestamp() as u64),
+                    timestamp: db_datetime_to_string(op.timestamp),
                     sender: None,
                     status_history: stages
                         .iter()
@@ -49,7 +50,7 @@ impl OperationsService {
                             r#type: s.stage_type_id as i32 - 1,
                             is_exist: true,
                             is_success: Some(s.success),
-                            timestamp: Some(s.timestamp.and_utc().timestamp() as u64),
+                            timestamp: Some(db_datetime_to_string(s.timestamp)),
                             transactions: txs
                                 .iter()
                                 .map(|tx| {
@@ -98,7 +99,7 @@ impl TacService for OperationsService {
                     .map(|op| op.timestamp.and_utc().timestamp() as u64);
 
                 Ok(tonic::Response::new(OperationsResponse {
-                    operations: operations
+                    items: operations
                         .into_iter()
                         .map(|op| {
                             let op_type = match op.op_type {
@@ -108,7 +109,7 @@ impl TacService for OperationsService {
                             OperationBriefDetails {
                                 operation_id: op.id,
                                 r#type: op_type.to_id(),
-                                timestamp: Some(op.timestamp.and_utc().timestamp() as u64),
+                                timestamp: db_datetime_to_string(op.timestamp),
                                 sender: None,
                             }
                         })
@@ -144,4 +145,8 @@ impl TacService for OperationsService {
 
         OperationsService::create_full_operation_response(db_resp)
     }
+}
+
+fn db_datetime_to_string(ts: NaiveDateTime) -> String {
+    ts.and_utc().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }


### PR DESCRIPTION
### The following changes were introduced by this PR
- Renaming (operations -> items) in /api/v1/tac/operations
- casting timestamps to RFC-3339 format
- fix `StageType` element names (UPPER_SNAKE_CASE) in `proto` and `swaggerfile`