### PR TITLE
chore(tac): Tune endpoints

### DIFF
--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
@@ -18,14 +18,13 @@ message Pagination {
 }
 
 message GetOperationsRequest {
-  optional uint64 page_token = 1;
-  optional uint64 page_items = 2;
+  optional string q = 1;  // multi-search by operation_id, tx_hash and sender
+  optional uint64 page_token = 2;
+  optional uint64 page_items = 3;
 }
 
 message SearchOperationRequest {
-  string q = 1;
-  optional uint64 page_token = 2;
-  optional uint64 page_items = 3;
+  string q = 1; // search by operation_id only
 }
 
 message GetOperationDetailsRequest {

--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto
@@ -7,7 +7,6 @@ option go_package = "github.com/blockscout/blockscout-rs/tac-operation-lifecycle
 
 service TacService {
   rpc GetOperations(GetOperationsRequest) returns (OperationsResponse) {}
-  rpc SearchOperations(SearchOperationRequest) returns (OperationsResponse) {}
   rpc GetOperationDetails(GetOperationDetailsRequest) returns (OperationDetails) {}
   rpc GetOperationsByTransaction(GetOperationByTxHashRequest) returns (OperationsFullResponse) {}
 }
@@ -21,10 +20,6 @@ message GetOperationsRequest {
   optional string q = 1;  // multi-search by operation_id, tx_hash and sender
   optional uint64 page_token = 2;
   optional uint64 page_items = 3;
-}
-
-message SearchOperationRequest {
-  string q = 1; // search by operation_id only
 }
 
 message GetOperationDetailsRequest {

--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
@@ -66,6 +66,11 @@ paths:
           schema:
             $ref: '#/definitions/rpcStatus'
       parameters:
+        - name: q
+          description: multi-search by operation_id, tx_hash and sender
+          in: query
+          required: false
+          type: string
         - name: page_token
           in: query
           required: false
@@ -92,19 +97,10 @@ paths:
             $ref: '#/definitions/rpcStatus'
       parameters:
         - name: q
+          description: search by operation_id only
           in: query
           required: false
           type: string
-        - name: page_token
-          in: query
-          required: false
-          type: string
-          format: uint64
-        - name: page_items
-          in: query
-          required: false
-          type: string
-          format: uint64
       tags:
         - TacService
   /api/v1/tac/operations/{operation_id}:

--- a/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-proto/swagger/v1/tac-operation-lifecycle.swagger.yaml
@@ -83,26 +83,6 @@ paths:
           format: uint64
       tags:
         - TacService
-  /api/v1/tac/operations/search/quick:
-    get:
-      operationId: TacService_SearchOperations
-      responses:
-        "200":
-          description: A successful response.
-          schema:
-            $ref: '#/definitions/v1OperationsResponse'
-        default:
-          description: An unexpected error response.
-          schema:
-            $ref: '#/definitions/rpcStatus'
-      parameters:
-        - name: q
-          description: search by operation_id only
-          in: query
-          required: false
-          type: string
-      tags:
-        - TacService
   /api/v1/tac/operations/{operation_id}:
     get:
       operationId: TacService_GetOperationDetails

--- a/tac-operation-lifecycle/tac-operation-lifecycle-server/src/services/operations.rs
+++ b/tac-operation-lifecycle/tac-operation-lifecycle-server/src/services/operations.rs
@@ -10,7 +10,7 @@ use tac_operation_lifecycle_logic::{
 use tac_operation_lifecycle_proto::blockscout::tac_operation_lifecycle::v1::{
     GetOperationByTxHashRequest, GetOperationDetailsRequest, GetOperationsRequest,
     OperationBriefDetails, OperationDetails, OperationRelatedTransaction, OperationStage,
-    OperationsFullResponse, OperationsResponse, Pagination, SearchOperationRequest,
+    OperationsFullResponse, OperationsResponse, Pagination,
 };
 
 pub struct OperationsService {
@@ -168,38 +168,6 @@ impl TacService for OperationsService {
                     Err(e) => Err(tonic::Status::internal(e.to_string())),
                 }
             }
-        }
-    }
-
-    async fn search_operations(
-        &self,
-        request: tonic::Request<SearchOperationRequest>,
-    ) -> Result<tonic::Response<OperationsResponse>, tonic::Status> {
-        let q = request.into_inner().q;
-        if is_generic_hash(&q) {
-            // operation_id
-            let map_internal = |e: anyhow::Error| tonic::Status::internal(e.to_string());
-
-            let operations = match self
-                .db
-                .get_brief_operation_by_id(&q)
-                .await
-                .map_err(map_internal)?
-            {
-                Some(op) => vec![op],
-                None => vec![],
-            };
-
-            Ok(tonic::Response::new(OperationsResponse {
-                items: OperationsService::convert_short_db_operation_into_response(operations),
-                next_page_params: None,
-            }))
-        } else {
-            // unknown query string -> return void array without DB interacting
-            Ok(tonic::Response::new(OperationsResponse {
-                items: vec![],
-                next_page_params: None,
-            }))
         }
     }
 


### PR DESCRIPTION
To comply with other APIs, the `/api/v1/tac/operations/search/quick?q=string` endpoint was moved to `/api/v1/tac/operations?q=string`. An additional `q` parameter was added to the regular operations list endpoint to support inline filtering by `operation_id`, `tx_hash`, and `sender_address`.

**NOTE1:** _Filtering by sender will be implemented in a neighboring PR, as this field does not exist in the current version of the database._

**NOTE2:** _It's assumed that the global frontend search engine will be use this method as well_