### PR TITLE
feat(eth-bytecode-db): add option to use read replica for verifier alliance database

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -1150,9 +1150,9 @@ dependencies = [
 
 [[package]]
 name = "blockscout-service-launcher"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5318f8f4e6262dbd3fa564866941421adae8df44e756bc343ce6262c52d0dc73"
+checksum = "7bf074a9cd2f5abd65b033437fba2505321bfc11921ee02d50f544f5a0f63eb3"
 dependencies = [
  "actix-cors",
  "actix-web",

--- a/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/Cargo.toml
@@ -33,7 +33,7 @@ anyhow = { version = "1" }
 async-std = { version = "^1" }
 async-trait = { version = "0.1" }
 blockscout-display-bytes = { version = "1.1.0" }
-blockscout-service-launcher = { version = "0.19.0", default-features = false, features = ["database-1"] }
+blockscout-service-launcher = { version = "0.20.0", default-features = false, features = ["database-1"] }
 bytes = { version = "1.2" }
 ethabi = { version = "18.0" }
 ethers = { version = "2.0.0" }

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
@@ -11,13 +11,13 @@ use crate::{
 use amplify::Wrapper;
 use async_trait::async_trait;
 use blockscout_display_bytes::Bytes as DisplayBytes;
+use blockscout_service_launcher::database::ReadWriteRepo;
 use eth_bytecode_db::{
     search::{self},
     verification,
     verification::sourcify_from_etherscan,
 };
 use ethers::types::H256;
-use sea_orm::DatabaseConnection;
 use std::{str::FromStr, sync::Arc};
 use tracing::instrument;
 
@@ -342,7 +342,7 @@ impl DatabaseService {
 
     async fn search_alliance_sources_internal(
         &self,
-        alliance_db_client: Arc<DatabaseConnection>,
+        alliance_db_client: Arc<ReadWriteRepo>,
         chain_id: &str,
         contract_address: &str,
     ) -> Result<Vec<Source>, tonic::Status> {
@@ -355,7 +355,7 @@ impl DatabaseService {
             .0;
 
         let sources = search::alliance_db_find_contract(
-            alliance_db_client.as_ref(),
+            alliance_db_client.read_db(),
             chain_id,
             contract_address.to_vec(),
         )

--- a/eth-bytecode-db/eth-bytecode-db-server/src/settings.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/settings.rs
@@ -1,4 +1,5 @@
 use blockscout_service_launcher::{
+    database::ReplicaDatabaseSettings,
     launcher::{ConfigSettings, MetricsSettings, ServerSettings},
     tracing::{JaegerSettings, TracingSettings},
 };
@@ -24,6 +25,10 @@ pub struct Settings {
     pub sourcify: SourcifySettings,
     #[serde(default)]
     pub verifier_alliance_database: VerifierAllianceDatabaseSettings,
+    // Optional verifier alliance database read-only replica.
+    // If provided, all search queries will be redirected to this database.
+    #[serde(default)]
+    pub verifier_alliance_replica_database: Option<ReplicaDatabaseSettings>,
 
     #[serde(default)]
     pub authorized_keys: HashMap<String, ApiKey>,
@@ -108,6 +113,7 @@ impl Settings {
             },
             sourcify: Default::default(),
             verifier_alliance_database: Default::default(),
+            verifier_alliance_replica_database: Default::default(),
             authorized_keys: Default::default(),
         }
     }

--- a/eth-bytecode-db/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/eth-bytecode-db/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 alloy-json-abi = { workspace = true, features = ["serde_json"] }
 anyhow = { workspace = true }
 blockscout-display-bytes = { workspace = true }
+blockscout-service-launcher = { workspace = true }
 bytes = { workspace = true }
 entity = { workspace = true }
 eth-bytecode-db-proto = { workspace = true }

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/client.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/client.rs
@@ -1,10 +1,11 @@
+use blockscout_service_launcher::database::ReadWriteRepo;
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Client {
     pub db_client: Arc<DatabaseConnection>,
-    pub alliance_db_client: Option<Arc<DatabaseConnection>>,
+    pub alliance_db_client: Option<Arc<ReadWriteRepo>>,
     pub verifier_http_client: smart_contract_verifier_proto::http_client::Client,
 }
 
@@ -46,11 +47,11 @@ impl Client {
         })
     }
 
-    pub fn with_alliance_db(self, alliance_db_client: DatabaseConnection) -> Self {
+    pub fn with_alliance_db(self, alliance_db_client: ReadWriteRepo) -> Self {
         self.with_alliance_db_arc(Arc::new(alliance_db_client))
     }
 
-    pub fn with_alliance_db_arc(mut self, alliance_db_client: Arc<DatabaseConnection>) -> Self {
+    pub fn with_alliance_db_arc(mut self, alliance_db_client: Arc<ReadWriteRepo>) -> Self {
         self.alliance_db_client = Some(alliance_db_client);
         self
     }

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/alliance_stats.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/alliance_stats.rs
@@ -23,7 +23,7 @@ pub async fn stats(client: Client) -> Result<Option<Stats>, Error> {
             .column_as(verified_contracts::Column::Id.count(), "count")
             .group_by(verified_contracts::Column::CreatedBy)
             .into_model::<ProviderContractsCount>()
-            .all(alliance_db_client.as_ref())
+            .all(alliance_db_client.read_db())
             .await?
             .into_iter()
             .map(|value| (value.created_by, value.count as u64))

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_multi_part.rs
@@ -56,7 +56,10 @@ pub async fn verify(
     );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
-        client.alliance_db_client.as_deref(),
+        client
+            .alliance_db_client
+            .as_ref()
+            .map(|client| client.main_db()),
         verification_metadata.clone(),
         is_authorized,
     );

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/solidity_standard_json.rs
@@ -52,7 +52,10 @@ pub async fn verify(
     );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
-        client.alliance_db_client.as_deref(),
+        client
+            .alliance_db_client
+            .as_ref()
+            .map(|client| client.main_db()),
         verification_metadata.clone(),
         is_authorized,
     );

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/verifier_alliance.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/verifier_alliance.rs
@@ -79,7 +79,7 @@ pub async fn import_solidity_standard_json(
 
     let result = super::process_batch_import_response(
         client.db_client.as_ref(),
-        client.alliance_db_client.as_ref().unwrap(),
+        client.alliance_db_client.unwrap().main_db(),
         verifier_response,
         deployment_data,
     )
@@ -150,7 +150,7 @@ pub async fn import_solidity_multi_part(
 
     let result = super::process_batch_import_response(
         client.db_client.as_ref(),
-        client.alliance_db_client.as_ref().unwrap(),
+        client.alliance_db_client.unwrap().main_db(),
         verifier_response,
         deployment_data,
     )

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_multi_part.rs
@@ -54,7 +54,10 @@ pub async fn verify(
     );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
-        client.alliance_db_client.as_deref(),
+        client
+            .alliance_db_client
+            .as_ref()
+            .map(|client| client.main_db()),
         verification_metadata.clone(),
         is_authorized,
     );

--- a/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
+++ b/eth-bytecode-db/eth-bytecode-db/src/verification/handlers/vyper_standard_json.rs
@@ -48,7 +48,10 @@ pub async fn verify(
     );
 
     let verifier_alliance_db_action = VerifierAllianceDbAction::from_db_client_and_metadata(
-        client.alliance_db_client.as_deref(),
+        client
+            .alliance_db_client
+            .as_ref()
+            .map(|client| client.main_db()),
         verification_metadata.clone(),
         is_authorized,
     );


### PR DESCRIPTION
Allows to specify read replica to use for contracts lookup inside verifier-alliance database. Currently we are heavily using the database to search for the contract sources which results in the database instance utilizing 100% of cpu. Making use of read replica should allow those lookup requests not to interfere with writing in the database.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for an optional read-only replica database for the verifier alliance, allowing all search queries to be redirected if configured.

- **Refactor**
  - Updated internal database abstractions for alliance-related operations to improve maintainability and future extensibility.
  - Adjusted method and struct signatures to use new database client types for alliance database interactions.

- **Chores**
  - Updated dependencies to incorporate the latest version of the service launcher library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->