### PR TITLE
fix(eth-bytecode-db): invalid chain_id type when retrieving alliance database

### DIFF
--- a/eth-bytecode-db/eth-bytecode-db-server/tests/integration/types/verifier_alliance.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/integration/types/verifier_alliance.rs
@@ -254,7 +254,7 @@ impl VerifierAllianceDatabaseChecker for TestCase {
         db: &DatabaseConnection,
     ) -> Option<contract_deployments::Model> {
         contract_deployments::Entity::find()
-            .filter(contract_deployments::Column::ChainId.eq(Decimal::from(self.chain_id)))
+            .filter(contract_deployments::Column::ChainId.eq(self.chain_id))
             .filter(contract_deployments::Column::Address.eq(self.address.to_vec()))
             .filter(
                 contract_deployments::Column::TransactionHash.eq(self.transaction_hash.to_vec()),

--- a/eth-bytecode-db/eth-bytecode-db-server/tests/verifier_alliance.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/tests/verifier_alliance.rs
@@ -329,7 +329,7 @@
 //     let mut query = contract_deployments::Entity::find();
 //     if let Some(test_case) = test_case {
 //         query = query
-//             .filter(contract_deployments::Column::ChainId.eq(Decimal::from(test_case.chain_id)))
+//             .filter(contract_deployments::Column::ChainId.eq(test_case.chain_id))
 //             .filter(contract_deployments::Column::Address.eq(test_case.address.to_vec()))
 //             .filter(
 //                 contract_deployments::Column::TransactionHash

--- a/eth-bytecode-db/verifier-alliance-database/src/internal.rs
+++ b/eth-bytecode-db/verifier-alliance-database/src/internal.rs
@@ -276,9 +276,7 @@ pub async fn retrieve_contract_deployment<C: ConnectionTrait>(
     });
 
     contract_deployments::Entity::find()
-        .filter(
-            contract_deployments::Column::ChainId.eq(Decimal::from(contract_deployment.chain_id)),
-        )
+        .filter(contract_deployments::Column::ChainId.eq(contract_deployment.chain_id))
         .filter(contract_deployments::Column::Address.eq(contract_deployment.address))
         .filter(contract_deployments::Column::TransactionHash.eq(transaction_hash))
         .one(database_connection)
@@ -292,7 +290,7 @@ pub async fn retrieve_contract_deployments_by_chain_id_and_address<C: Connection
     contract_address: Vec<u8>,
 ) -> Result<Vec<contract_deployments::Model>, Error> {
     contract_deployments::Entity::find()
-        .filter(contract_deployments::Column::ChainId.eq(Decimal::from(chain_id)))
+        .filter(contract_deployments::Column::ChainId.eq(chain_id))
         .filter(contract_deployments::Column::Address.eq(contract_address))
         .all(database_connection)
         .await


### PR DESCRIPTION
Verifier alliance database has `contract_deployments.chain_id` type to be `bigint`. But in our code we cast chain_id to decimal before providing into the sea_orm::filter. As a result the query with decimal chain_id is sent, and results in postgres using sequence scan instead of the index when looking for the contract deployment. The query execution time increases sharply and database performance downgrade