### PR TITLE
feat(multi): extend interop api with transfers

### DIFF
--- a/multichain-aggregator/multichain-aggregator-logic/src/services/import.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/services/import.rs
@@ -30,7 +30,7 @@ pub async fn batch_import(
         .inspect_err(|e| {
             tracing::error!(error = ?e, "failed to upsert hashes");
         })?;
-    let messages =
+    let messages_with_transfers =
         repository::interop_messages::upsert_many_with_transfers(&tx, request.interop_messages)
             .await
             .inspect_err(|e| {
@@ -38,13 +38,14 @@ pub async fn batch_import(
             })?;
     tx.commit().await?;
 
-    let messages = messages
+    let interop_messages = messages_with_transfers
         .into_iter()
+        .filter(|(m, _)| m.init_transaction_hash.is_some())
         .filter_map(|m| InteropMessage::try_from(m).ok())
         .map(proto::InteropMessage::from)
         .collect::<Vec<_>>();
-    if !messages.is_empty() {
-        channel.broadcast((NEW_INTEROP_MESSAGES_TOPIC, "new_messages", messages));
+    if !interop_messages.is_empty() {
+        channel.broadcast((NEW_INTEROP_MESSAGES_TOPIC, "new_messages", interop_messages));
     }
 
     let block_ranges = block_ranges

--- a/multichain-aggregator/multichain-aggregator-logic/src/types/interop_message_transfers.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/interop_message_transfers.rs
@@ -1,3 +1,4 @@
+use crate::{error::ParseError, proto, types::proto_address_hash_from_alloy};
 use alloy_primitives::Address;
 use sea_orm::{prelude::BigDecimal, ActiveValue::Set};
 
@@ -9,6 +10,22 @@ pub struct InteropMessageTransfer {
     pub amount: BigDecimal,
 }
 
+impl TryFrom<entity::interop_messages_transfers::Model> for InteropMessageTransfer {
+    type Error = ParseError;
+
+    fn try_from(v: entity::interop_messages_transfers::Model) -> Result<Self, Self::Error> {
+        Ok(Self {
+            token_address_hash: v
+                .token_address_hash
+                .map(|a| Address::try_from(a.as_slice()))
+                .transpose()?,
+            from_address_hash: Address::try_from(v.from_address_hash.as_slice())?,
+            to_address_hash: Address::try_from(v.to_address_hash.as_slice())?,
+            amount: v.amount,
+        })
+    }
+}
+
 impl From<InteropMessageTransfer> for entity::interop_messages_transfers::ActiveModel {
     fn from(v: InteropMessageTransfer) -> Self {
         Self {
@@ -17,6 +34,19 @@ impl From<InteropMessageTransfer> for entity::interop_messages_transfers::Active
             to_address_hash: Set(v.to_address_hash.to_vec()),
             amount: Set(v.amount),
             ..Default::default()
+        }
+    }
+}
+
+impl From<InteropMessageTransfer> for proto::InteropMessageTransfer {
+    fn from(v: InteropMessageTransfer) -> Self {
+        Self {
+            token: v
+                .token_address_hash
+                .map(|a| proto_address_hash_from_alloy(&a)),
+            from: Some(proto_address_hash_from_alloy(&v.from_address_hash)),
+            to: Some(proto_address_hash_from_alloy(&v.to_address_hash)),
+            amount: v.amount.to_string(),
         }
     }
 }

--- a/multichain-aggregator/multichain-aggregator-logic/src/types/interop_message_transfers.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/interop_message_transfers.rs
@@ -38,15 +38,19 @@ impl From<InteropMessageTransfer> for entity::interop_messages_transfers::Active
     }
 }
 
-impl From<InteropMessageTransfer> for proto::InteropMessageTransfer {
+impl From<InteropMessageTransfer> for proto::interop_message::InteropMessageTransfer {
     fn from(v: InteropMessageTransfer) -> Self {
         Self {
             token: v
                 .token_address_hash
-                .map(|a| proto_address_hash_from_alloy(&a)),
+                .map(|a| proto::interop_message::TokenDetails {
+                    address_hash: a.to_checksum(None),
+                }),
             from: Some(proto_address_hash_from_alloy(&v.from_address_hash)),
             to: Some(proto_address_hash_from_alloy(&v.to_address_hash)),
-            amount: v.amount.to_string(),
+            total: Some(proto::interop_message::TransferTotal {
+                value: v.amount.to_string(),
+            }),
         }
     }
 }

--- a/multichain-aggregator/multichain-aggregator-logic/src/types/mod.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/mod.rs
@@ -12,3 +12,11 @@ pub mod search_results;
 pub mod token_info;
 
 pub type ChainId = i64;
+
+pub fn proto_address_hash_from_alloy(
+    address: &alloy_primitives::Address,
+) -> crate::proto::AddressHash {
+    crate::proto::AddressHash {
+        hash: address.to_checksum(None),
+    }
+}

--- a/multichain-aggregator/multichain-aggregator-proto/proto/v1/multichain-aggregator.proto
+++ b/multichain-aggregator/multichain-aggregator-proto/proto/v1/multichain-aggregator.proto
@@ -103,18 +103,26 @@ message AddressHash {
   string hash = 1;
 }
 
-message InteropMessageTransfer {
-  optional AddressHash token = 1;
-  AddressHash from = 2;
-  AddressHash to = 3;
-  string amount = 4;
-}
-
 message InteropMessage {
   enum Status {
     PENDING = 0;
     FAILED = 1;
     SUCCESS = 2;
+  }
+
+  message TokenDetails {
+    string address_hash = 1;
+  }
+
+  message TransferTotal {
+    string value = 1;
+  }
+
+  message InteropMessageTransfer {
+    optional TokenDetails token = 1;
+    AddressHash from = 2;
+    AddressHash to = 3;
+    TransferTotal total = 4;
   }
 
   optional AddressHash sender = 1;
@@ -129,6 +137,7 @@ message InteropMessage {
   Status status = 10;
   optional InteropMessageTransfer transfer = 11;
   string message_type = 12;
+  string method = 13;
 }
 
 message BatchImportRequest {

--- a/multichain-aggregator/multichain-aggregator-proto/proto/v1/multichain-aggregator.proto
+++ b/multichain-aggregator/multichain-aggregator-proto/proto/v1/multichain-aggregator.proto
@@ -99,15 +99,26 @@ message Domain {
   google.protobuf.Struct protocol = 4;
 }
 
+message AddressHash {
+  string hash = 1;
+}
+
+message InteropMessageTransfer {
+  optional AddressHash token = 1;
+  AddressHash from = 2;
+  AddressHash to = 3;
+  string amount = 4;
+}
+
 message InteropMessage {
   enum Status {
-    STATUS_PENDING = 0;
-    STATUS_FAILED = 1;
-    STATUS_SUCCESS = 2;
+    PENDING = 0;
+    FAILED = 1;
+    SUCCESS = 2;
   }
 
-  optional string sender_address_hash = 1;
-  optional string target_address_hash = 2;
+  optional AddressHash sender = 1;
+  optional AddressHash target = 2;
   int64 nonce = 3;
   string init_chain_id = 4;
   optional string init_transaction_hash = 5;
@@ -115,8 +126,9 @@ message InteropMessage {
   string relay_chain_id = 7;
   optional string relay_transaction_hash = 8;
   optional string payload = 9;
-  optional bool failed = 10;
-  Status status = 11;
+  Status status = 10;
+  optional InteropMessageTransfer transfer = 11;
+  string message_type = 12;
 }
 
 message BatchImportRequest {

--- a/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
+++ b/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
@@ -529,6 +529,11 @@ definitions:
         type: boolean
       chain_id:
         type: string
+  v1AddressHash:
+    type: object
+    properties:
+      hash:
+        type: string
   v1BatchImportRequest:
     type: object
     properties:
@@ -624,10 +629,10 @@ definitions:
   v1InteropMessage:
     type: object
     properties:
-      sender_address_hash:
-        type: string
-      target_address_hash:
-        type: string
+      sender:
+        $ref: '#/definitions/v1AddressHash'
+      target:
+        $ref: '#/definitions/v1AddressHash'
       nonce:
         type: string
         format: int64
@@ -643,17 +648,30 @@ definitions:
         type: string
       payload:
         type: string
-      failed:
-        type: boolean
       status:
         $ref: '#/definitions/v1InteropMessageStatus'
+      transfer:
+        $ref: '#/definitions/v1InteropMessageTransfer'
+      message_type:
+        type: string
   v1InteropMessageStatus:
     type: string
     enum:
-      - STATUS_PENDING
-      - STATUS_FAILED
-      - STATUS_SUCCESS
-    default: STATUS_PENDING
+      - PENDING
+      - FAILED
+      - SUCCESS
+    default: PENDING
+  v1InteropMessageTransfer:
+    type: object
+    properties:
+      token:
+        $ref: '#/definitions/v1AddressHash'
+      from:
+        $ref: '#/definitions/v1AddressHash'
+      to:
+        $ref: '#/definitions/v1AddressHash'
+      amount:
+        type: string
   v1ListAddressesResponse:
     type: object
     properties:

--- a/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
+++ b/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
@@ -468,6 +468,27 @@ definitions:
         type: string
       failed:
         type: boolean
+  InteropMessageInteropMessageTransfer:
+    type: object
+    properties:
+      token:
+        $ref: '#/definitions/InteropMessageTokenDetails'
+      from:
+        $ref: '#/definitions/v1AddressHash'
+      to:
+        $ref: '#/definitions/v1AddressHash'
+      total:
+        $ref: '#/definitions/InteropMessageTransferTotal'
+  InteropMessageTokenDetails:
+    type: object
+    properties:
+      address_hash:
+        type: string
+  InteropMessageTransferTotal:
+    type: object
+    properties:
+      value:
+        type: string
   QuickSearchResponseChainBlockNumber:
     type: object
     properties:
@@ -651,8 +672,10 @@ definitions:
       status:
         $ref: '#/definitions/v1InteropMessageStatus'
       transfer:
-        $ref: '#/definitions/v1InteropMessageTransfer'
+        $ref: '#/definitions/InteropMessageInteropMessageTransfer'
       message_type:
+        type: string
+      method:
         type: string
   v1InteropMessageStatus:
     type: string
@@ -661,17 +684,6 @@ definitions:
       - FAILED
       - SUCCESS
     default: PENDING
-  v1InteropMessageTransfer:
-    type: object
-    properties:
-      token:
-        $ref: '#/definitions/v1AddressHash'
-      from:
-        $ref: '#/definitions/v1AddressHash'
-      to:
-        $ref: '#/definitions/v1AddressHash'
-      amount:
-        type: string
   v1ListAddressesResponse:
     type: object
     properties:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for transfer details within interop messages, including sender, target, and token address information.
  - Introduced new message method and type classifications for interop messages (SendMessage, SendERC20, SendETH; CoinTransfer, TokenTransfer, ContractCall).
  - Enabled combined retrieval and insertion of interop messages with their associated transfers.

- **API Changes**
  - Interop messages now include structured address fields and an optional transfer payload in both API and protobuf responses.
  - Updated status enum values for interop messages to be more concise.
  - Removed the deprecated `failed` field from interop messages.

- **Documentation**
  - Updated API schema and documentation to reflect new address and transfer structures, new message type fields, and revised enum values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->