### PR TITLE
feat(da-indexer): add s3 storage support

### DIFF
--- a/.github/workflows/da-indexer.yml
+++ b/.github/workflows/da-indexer.yml
@@ -39,6 +39,23 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
+
+      minio:
+        # Official minio build requires the following command to be started
+        # `minio server /data --address=0.0.0.0:9000`
+        # Github actions do not support any custom command arguments, so the official image cannot be used.
+        # `lazybit/minio` bypasses that restriction by including
+        # `CMD ["server" "/data" "--address=0.0.0.0:9000"]` into the dockerfile.
+        #
+        # This solution was taken from https://stackoverflow.com/a/71855338.
+        #
+        # TODO: we probably would like to remove an non-official third-party image
+        #       which is not regularly updated and replace it by our own image.
+        image: lazybit/minio:latest
+        ports:
+          - 9000:9000
+        options: --name=minio --health-cmd "curl http://localhost:9000/minio/health/live"
+
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -57,6 +74,9 @@ jobs:
         if: steps.build.outcome == 'success'
         env:
           DATABASE_URL: postgres://postgres:admin@localhost:5432/
+          S3_ENDPOINT: http://localhost:9000
+          S3_ACCESS_KEY_ID: minioadmin
+          S3_SECRET_ACCESS_KEY: minioadmin
 
       - name: Doc tests
         run: RUST_BACKTRACE=1 RUST_LOG=info cargo test --locked --workspace --all-features --doc

--- a/da-indexer/Cargo.lock
+++ b/da-indexer/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "smallvec",
  "tokio",
@@ -319,7 +319,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
 ]
@@ -331,7 +331,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -564,7 +564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -574,7 +574,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -730,17 +730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +839,328 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f6c68419d8ba16d9a7463671593c54f81ba58cab466e9b759418da606dcc2e2"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid 1.10.0",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.94.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc24d9d761bd464534d9e477a9f724c118ca2557a95444097cf6ce71f3229a72"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.10.8",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfb9021f581b71870a17eac25b52335b82211cdc092e02b6876b2bcefa61666"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.3.1",
+ "p256",
+ "percent-encoding",
+ "ring 0.17.8",
+ "sha2 0.10.8",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e190749ea56f8c42bf15dd76c65e14f8f765233e6df9b0506d9d934ebef867c"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.63.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "244f00666380d35c1c76b90f7b88a11935d11b84076ac22a4c014ea0939627af"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.8",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338a3642c399c0a5d157648426110e199ca7fd1c689cc395676b81aa563700c4"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f108f1ca850f3feef3009bdcc977be201bca9a91058864d9de0684e64514bee0"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.26",
+ "h2 0.4.5",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "hyper 0.14.30",
+ "hyper 1.6.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.23",
+ "rustls-native-certs 0.8.1",
+ "rustls-pki-types",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a16e040799d29c17412943bdbf488fd75db04112d0c0d4b9290bacf5ae0014b9"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand 2.3.0",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8531b6d8882fd8f48f82a9754e682e29dd44cff27154af51fa3eb730f59efb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.3.1",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d498595448e43de7f4296b7b7a18a8a02c61ec9349128c80a368f7c3b4ab11a8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.3.1",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db87b96cb1b16c024980f133968d52882ca0daaee3a086c6decc500f6c99728"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version 0.4.0",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1230,12 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
@@ -940,6 +1257,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -977,6 +1304,29 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.104",
+ "which",
 ]
 
 [[package]]
@@ -1240,6 +1590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "bytestring"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,7 +1723,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha2 0.10.8",
- "signature",
+ "signature 2.2.0",
  "subtle",
  "subtle-encoding",
  "time",
@@ -1425,6 +1785,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1843,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1894,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "coins-bip32"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1540,7 +1929,7 @@ dependencies = [
  "hmac",
  "once_cell",
  "pbkdf2 0.12.2",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror 1.0.63",
 ]
@@ -1731,6 +2120,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc-fast"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf62af4cc77d8fe1c22dde4e721d87f2f54056139d8c412e1366b740305f56f"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "libc",
+ "rand 0.9.1",
+ "regex",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,12 +2192,24 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1827,7 +2241,7 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle-ng",
  "zeroize",
 ]
@@ -1845,6 +2259,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "aws-credential-types",
+ "aws-sdk-s3",
  "base64 0.22.1",
  "blockscout-display-bytes",
  "blockscout-service-launcher",
@@ -1860,8 +2276,7 @@ dependencies = [
  "http 1.3.1",
  "jsonrpsee",
  "lazy_static",
- "md5 0.8.0",
- "minio",
+ "md5",
  "prost 0.13.5",
  "reqwest 0.12.20",
  "reqwest-middleware",
@@ -2033,6 +2448,16 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
@@ -2161,6 +2586,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2186,16 +2622,28 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.9",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2204,8 +2652,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -2216,7 +2664,7 @@ checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -2232,19 +2680,39 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.0",
  "generic-array",
- "group",
- "pkcs8",
- "rand_core",
- "sec1",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2278,7 +2746,7 @@ dependencies = [
  "hex",
  "k256",
  "log",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "sha3",
@@ -2295,29 +2763,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
 ]
 
 [[package]]
@@ -2359,7 +2804,7 @@ dependencies = [
  "hex",
  "hmac",
  "pbkdf2 0.11.0",
- "rand",
+ "rand 0.8.5",
  "scrypt",
  "serde",
  "serde_json",
@@ -2515,14 +2960,14 @@ dependencies = [
  "cargo_metadata",
  "chrono",
  "const-hex",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "ethabi",
  "generic-array",
  "k256",
  "num_enum",
  "once_cell",
  "open-fastrlp",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "serde",
  "serde_json",
@@ -2625,10 +3070,10 @@ dependencies = [
  "coins-bip32",
  "coins-bip39",
  "const-hex",
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
  "eth-keystore",
  "ethers-core",
- "rand",
+ "rand 0.8.5",
  "sha2 0.10.8",
  "thiserror 1.0.63",
  "tracing",
@@ -2731,11 +3176,21 @@ dependencies = [
 
 [[package]]
 name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2746,7 +3201,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand",
+ "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
 ]
@@ -2833,6 +3288,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -3017,8 +3478,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3047,12 +3520,23 @@ dependencies = [
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
- "rand_core",
+ "ff 0.13.0",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -3323,7 +3807,9 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.30",
+ "log",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -3340,6 +3826,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.23.23",
+ "rustls-native-certs 0.7.3",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3425,6 +3912,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,12 +4005,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -3611,30 +4195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3736,7 +4296,7 @@ dependencies = [
  "http-body-util",
  "jsonrpsee-types",
  "pin-project",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "serde_json",
  "thiserror 1.0.63",
@@ -3829,11 +4389,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
  "sha2 0.10.8",
- "signature",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -3910,6 +4470,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leopard-codec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,6 +4491,16 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "libloading"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "libm"
@@ -3984,6 +4560,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "local-channel"
@@ -4055,6 +4637,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.4",
+]
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4078,12 +4669,6 @@ dependencies = [
  "cfg-if",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "md5"
@@ -4143,46 +4728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minio"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3824101357fa899d01c729e4a245776e20a03f2f6645979e86b9d3d5d9c42741"
-dependencies = [
- "async-recursion",
- "async-trait",
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "chrono",
- "crc",
- "dashmap 6.1.0",
- "derivative",
- "env_logger",
- "futures",
- "futures-util",
- "hex",
- "hmac",
- "http 1.3.1",
- "hyper 1.6.0",
- "lazy_static",
- "log",
- "md5 0.7.0",
- "multimap",
- "percent-encoding",
- "rand",
- "regex",
- "reqwest 0.12.20",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "urlencoding",
- "xmltree",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4199,7 +4744,7 @@ checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -4211,7 +4756,7 @@ checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -4260,9 +4805,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "mutually_exclusive_features"
@@ -4347,7 +4889,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -4588,7 +5130,7 @@ dependencies = [
  "once_cell",
  "opentelemetry_api",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror 1.0.63",
  "tokio",
  "tokio-stream",
@@ -4653,10 +5195,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.8",
+]
 
 [[package]]
 name = "parity-scale-codec"
@@ -4745,7 +5304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -4904,7 +5463,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.2",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -4987,9 +5546,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.9",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -4998,8 +5567,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -5040,18 +5609,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "portable-atomic"
-version = "1.11.1"
+name = "potential_utf"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
 dependencies = [
- "portable-atomic",
+ "zerovec",
 ]
 
 [[package]]
@@ -5188,8 +5751,8 @@ dependencies = [
  "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "unarray",
@@ -5396,6 +5959,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5408,8 +5977,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5419,7 +5998,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5428,7 +6017,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -5437,7 +6035,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5493,7 +6091,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror 1.0.63",
 ]
@@ -5628,7 +6226,6 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2 0.4.5",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -5650,14 +6247,12 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
 ]
 
@@ -5685,7 +6280,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "getrandom",
+ "getrandom 0.2.15",
  "http 1.3.1",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
@@ -5703,7 +6298,18 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
 dependencies = [
- "rand",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -5739,7 +6345,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5829,10 +6435,10 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -5853,7 +6459,7 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "rlp",
  "ruint-macro",
  "serde",
@@ -5887,7 +6493,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -5898,6 +6504,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -5974,6 +6586,7 @@ version = "0.23.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47796c98c480fce5406ef69d1c76378375492c3b0a0de587be0c1d9feb12f395"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.8",
@@ -5981,6 +6594,18 @@ dependencies = [
  "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
@@ -6079,6 +6704,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -6357,14 +6983,28 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.9",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -6617,6 +7257,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6627,12 +7273,22 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -6708,7 +7364,7 @@ dependencies = [
  "futures",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
 ]
 
@@ -6743,12 +7399,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.9",
 ]
 
 [[package]]
@@ -6874,7 +7540,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "rust_decimal",
  "serde",
@@ -6918,7 +7584,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "rust_decimal",
  "serde",
  "serde_json",
@@ -6959,6 +7625,12 @@ dependencies = [
  "url",
  "uuid 1.10.0",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -7106,6 +7778,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 dependencies = [
  "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7289,6 +7972,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -7520,7 +8213,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -7702,7 +8395,7 @@ dependencies = [
  "http 0.2.12",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "rustls 0.21.12",
  "sha1",
  "thiserror 1.0.63",
@@ -7829,9 +8522,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -7851,6 +8544,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7862,7 +8561,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -7872,7 +8571,7 @@ version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -7907,6 +8606,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7936,6 +8641,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasite"
@@ -8015,19 +8729,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasm-timer"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8065,6 +8766,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -8344,6 +9057,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
 name = "ws_stream_wasm"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8372,19 +9100,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.26"
+name = "xmlparser"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
-
-[[package]]
-name = "xmltree"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b619f8c85654798007fb10afa5125590b43b088c225a25fc2fec100a9fad0fc6"
-dependencies = [
- "xml-rs",
-]
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yaml-rust"
@@ -8406,6 +9125,30 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -8449,6 +9192,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8462,6 +9226,39 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/da-indexer/Cargo.lock
+++ b/da-indexer/Cargo.lock
@@ -284,7 +284,7 @@ dependencies = [
  "actix-web",
  "futures-core",
  "pin-project-lite",
- "prometheus",
+ "prometheus 0.13.4",
 ]
 
 [[package]]
@@ -1443,7 +1443,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-jaeger",
- "prometheus",
+ "prometheus 0.13.4",
  "reqwest 0.12.20",
  "sea-orm",
  "sea-orm-migration",
@@ -2277,6 +2277,7 @@ dependencies = [
  "jsonrpsee",
  "lazy_static",
  "md5",
+ "prometheus 0.14.0",
  "prost 0.13.5",
  "reqwest 0.12.20",
  "reqwest-middleware",
@@ -5738,8 +5739,23 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot 0.12.3",
- "protobuf",
+ "protobuf 2.28.0",
  "thiserror 1.0.63",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.3",
+ "protobuf 3.7.2",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5892,6 +5908,26 @@ name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.63",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.63",
+]
 
 [[package]]
 name = "protox"

--- a/da-indexer/Cargo.lock
+++ b/da-indexer/Cargo.lock
@@ -649,7 +649,7 @@ checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.1.0",
+ "fastrand 2.3.0",
  "futures-lite 2.3.0",
  "slab",
 ]
@@ -822,6 +822,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "attohttpc"
+version = "0.28.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
+dependencies = [
+ "http 1.3.1",
+ "log",
+ "native-tls",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +851,32 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
+name = "aws-creds"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
+dependencies = [
+ "attohttpc",
+ "home",
+ "log",
+ "quick-xml",
+ "rust-ini 0.21.1",
+ "serde",
+ "thiserror 1.0.63",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
+dependencies = [
+ "thiserror 1.0.63",
+]
 
 [[package]]
 name = "axum"
@@ -1591,7 +1631,7 @@ dependencies = [
  "nom",
  "pathdiff",
  "ron",
- "rust-ini",
+ "rust-ini 0.18.0",
  "serde",
  "serde_json",
  "toml 0.5.11",
@@ -1616,6 +1656,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_format"
@@ -1852,6 +1912,7 @@ dependencies = [
  "reqwest 0.12.5",
  "reqwest-middleware",
  "reqwest-retry",
+ "rust-s3",
  "sea-orm",
  "serde",
  "serde_json",
@@ -2151,6 +2212,15 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "dotenvy"
@@ -2677,9 +2747,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fastrlp"
@@ -2830,9 +2900,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -2883,7 +2953,7 @@ version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52527eb5074e35e9339c6b4e8d12600c7128b68fb25dcb9fa9dec18f7c25f3a5"
 dependencies = [
- "fastrand 2.1.0",
+ "fastrand 2.3.0",
  "futures-core",
  "futures-io",
  "parking",
@@ -3249,7 +3319,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3320,6 +3390,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.30",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -3800,7 +3883,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3814,7 +3897,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
 dependencies = [
- "regex-automata 0.4.7",
+ "regex-automata 0.4.9",
 ]
 
 [[package]]
@@ -3964,7 +4047,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "syn 2.0.87",
 ]
 
@@ -3993,6 +4076,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4001,6 +4095,12 @@ dependencies = [
  "cfg-if",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -4045,6 +4145,15 @@ checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime",
  "unicase",
+]
+
+[[package]]
+name = "minidom"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f45614075738ce1b77a1768912a60c0227525971b03e09122a05b8a34a2a6278"
+dependencies = [
+ "rxml",
 ]
 
 [[package]]
@@ -4492,8 +4601,18 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
- "dlv-list",
+ "dlv-list 0.3.0",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
+dependencies = [
+ "dlv-list 0.5.2",
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4845,7 +4964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1d5c74c9876f070d3e8fd503d748c7d974c3e48da8f41350fa5222ef9b4391"
 dependencies = [
  "atomic-waker",
- "fastrand 2.1.0",
+ "fastrand 2.3.0",
  "futures-io",
 ]
 
@@ -5044,7 +5163,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "unarray",
 ]
 
@@ -5240,6 +5359,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5373,14 +5502,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.5"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5394,13 +5523,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -5417,9 +5546,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rend"
@@ -5488,7 +5617,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.2",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5727,7 +5856,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
  "cfg-if",
- "ordered-multimap",
+ "ordered-multimap 0.4.3",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap 0.7.3",
+ "trim-in-place",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.35.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "futures",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "hyper 0.14.30",
+ "hyper-tls 0.5.0",
+ "log",
+ "maybe-async",
+ "md5",
+ "minidom",
+ "native-tls",
+ "percent-encoding",
+ "quick-xml",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha2 0.10.8",
+ "thiserror 1.0.63",
+ "time",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-stream",
+ "url",
 ]
 
 [[package]]
@@ -5882,9 +6059,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-platform-verifier"
@@ -5939,6 +6119,23 @@ name = "rustversion"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
+name = "rxml"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a98f186c7a2f3abbffb802984b7f1dfd65dac8be1aafdaabbca4137f53f0dff7"
+dependencies = [
+ "bytes",
+ "rxml_validation",
+ "smartstring",
+]
+
+[[package]]
+name = "rxml_validation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22a197350ece202f19a166d1ad6d9d6de145e1d2a8ef47db299abe164dbd7530"
 
 [[package]]
 name = "ryu"
@@ -6297,9 +6494,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -6315,9 +6512,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6525,6 +6722,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "smartstring"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
+dependencies = [
+ "autocfg",
+ "static_assertions",
+ "version_check",
 ]
 
 [[package]]
@@ -6989,7 +7197,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.1.0",
+ "fastrand 2.3.0",
  "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
@@ -7490,6 +7698,12 @@ dependencies = [
  "tracing-log 0.2.0",
  "tracing-serde",
 ]
+
+[[package]]
+name = "trim-in-place"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"

--- a/da-indexer/Cargo.lock
+++ b/da-indexer/Cargo.lock
@@ -113,7 +113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_yaml",
- "syn 2.0.87",
+ "syn 2.0.104",
  "thiserror 2.0.12",
 ]
 
@@ -272,7 +272,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -730,6 +730,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "async-std"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -775,7 +786,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -786,13 +797,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -822,20 +833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "attohttpc"
-version = "0.28.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
-dependencies = [
- "http 1.3.1",
- "log",
- "native-tls",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,7 +840,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -851,32 +848,6 @@ name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
-
-[[package]]
-name = "aws-creds"
-version = "0.37.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f84143206b9c72b3c5cb65415de60c7539c79cd1559290fddec657939131be0"
-dependencies = [
- "attohttpc",
- "home",
- "log",
- "quick-xml",
- "rust-ini 0.21.1",
- "serde",
- "thiserror 1.0.63",
- "time",
- "url",
-]
-
-[[package]]
-name = "aws-region"
-version = "0.25.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
-dependencies = [
- "thiserror 1.0.63",
-]
 
 [[package]]
 name = "axum"
@@ -1123,7 +1094,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "prometheus",
- "reqwest 0.12.5",
+ "reqwest 0.12.20",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -1184,7 +1155,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
  "syn_derive",
 ]
 
@@ -1467,9 +1438,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1477,7 +1448,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1533,7 +1504,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1631,7 +1602,7 @@ dependencies = [
  "nom",
  "pathdiff",
  "ron",
- "rust-ini 0.18.0",
+ "rust-ini",
  "serde",
  "serde_json",
  "toml 0.5.11",
@@ -1656,26 +1627,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-random"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
-dependencies = [
- "const-random-macro",
-]
-
-[[package]]
-name = "const-random-macro"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
-dependencies = [
- "getrandom",
- "once_cell",
- "tiny-keccak",
-]
 
 [[package]]
 name = "const_format"
@@ -1766,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -1894,6 +1845,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "blockscout-display-bytes",
  "blockscout-service-launcher",
  "celestia-rpc",
@@ -1908,11 +1860,12 @@ dependencies = [
  "http 1.3.1",
  "jsonrpsee",
  "lazy_static",
+ "md5 0.8.0",
+ "minio",
  "prost 0.13.5",
- "reqwest 0.12.5",
+ "reqwest 0.12.20",
  "reqwest-middleware",
  "reqwest-retry",
- "rust-s3",
  "sea-orm",
  "serde",
  "serde_json",
@@ -1993,7 +1946,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2004,7 +1957,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2120,7 +2073,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2140,7 +2093,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -2212,15 +2165,6 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
-name = "dlv-list"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
-dependencies = [
- "const-random",
-]
 
 [[package]]
 name = "dotenvy"
@@ -2350,7 +2294,30 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -2516,7 +2483,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "syn 2.0.87",
+ "syn 2.0.104",
  "toml 0.8.19",
  "walkdir",
 ]
@@ -2534,7 +2501,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2560,7 +2527,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.87",
+ "syn 2.0.104",
  "tempfile",
  "thiserror 1.0.63",
  "tiny-keccak",
@@ -2875,9 +2842,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2890,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2906,9 +2873,9 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2928,9 +2895,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -2972,26 +2939,26 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-timer"
@@ -3005,9 +2972,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -3394,19 +3361,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.30",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -3427,6 +3381,7 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -3434,12 +3389,16 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.5.10",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3555,7 +3514,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3603,6 +3562,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3642,6 +3611,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jiff"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "jni"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3672,10 +3665,11 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
@@ -3786,7 +3780,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4020,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "value-bag",
 ]
@@ -4048,7 +4042,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.5",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4076,17 +4070,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
-name = "maybe-async"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf92c10c7e361d6b99666ec1c6f9805b0bea2c3bd8c78dc6fe98ac5bd78db11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4101,6 +4084,12 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -4128,7 +4117,7 @@ checksum = "23c9b935fbe1d6cbd1dac857b54a688145e2d93f48db36010514d0f612d0ad67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4148,19 +4137,50 @@ dependencies = [
 ]
 
 [[package]]
-name = "minidom"
-version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45614075738ce1b77a1768912a60c0227525971b03e09122a05b8a34a2a6278"
-dependencies = [
- "rxml",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "minio"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3824101357fa899d01c729e4a245776e20a03f2f6645979e86b9d3d5d9c42741"
+dependencies = [
+ "async-recursion",
+ "async-trait",
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "dashmap 6.1.0",
+ "derivative",
+ "env_logger",
+ "futures",
+ "futures-util",
+ "hex",
+ "hmac",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "lazy_static",
+ "log",
+ "md5 0.7.0",
+ "multimap",
+ "percent-encoding",
+ "rand",
+ "regex",
+ "reqwest 0.12.20",
+ "serde",
+ "serde_json",
+ "sha2 0.10.8",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "urlencoding",
+ "xmltree",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -4237,9 +4257,12 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "mutually_exclusive_features"
@@ -4404,7 +4427,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4476,7 +4499,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4601,18 +4624,8 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
 dependencies = [
- "dlv-list 0.3.0",
+ "dlv-list",
  "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "ordered-multimap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
-dependencies = [
- "dlv-list 0.5.2",
- "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -4636,7 +4649,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4831,7 +4844,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4904,7 +4917,7 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4942,7 +4955,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5027,6 +5040,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5054,7 +5082,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5116,9 +5144,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -5131,7 +5159,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -5204,7 +5232,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -5224,7 +5252,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.87",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -5238,7 +5266,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5251,7 +5279,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5359,20 +5387,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -5497,7 +5515,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5588,7 +5606,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
  "tower-service",
@@ -5597,14 +5615,14 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 0.25.4",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.5"
+version = "0.12.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
+checksum = "eabf4c97d9130e2bf606614eb937e86edac8292eaa6f422f995d7e8de1eb1813"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5617,30 +5635,30 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.2",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.1",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
+ "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
- "winreg 0.52.0",
 ]
 
 [[package]]
@@ -5652,7 +5670,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.3.1",
- "reqwest 0.12.5",
+ "reqwest 0.12.20",
  "serde",
  "thiserror 1.0.63",
  "tower-service",
@@ -5671,7 +5689,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "parking_lot 0.11.2",
- "reqwest 0.12.5",
+ "reqwest 0.12.20",
  "reqwest-middleware",
  "retry-policies",
  "tokio",
@@ -5856,55 +5874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
  "cfg-if",
- "ordered-multimap 0.4.3",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
-dependencies = [
- "cfg-if",
- "ordered-multimap 0.7.3",
- "trim-in-place",
-]
-
-[[package]]
-name = "rust-s3"
-version = "0.35.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3df3f353b1f4209dcf437d777cda90279c397ab15a0cd6fd06bd32c88591533"
-dependencies = [
- "async-trait",
- "aws-creds",
- "aws-region",
- "base64 0.22.1",
- "bytes",
- "cfg-if",
- "futures",
- "hex",
- "hmac",
- "http 0.2.12",
- "hyper 0.14.30",
- "hyper-tls 0.5.0",
- "log",
- "maybe-async",
- "md5",
- "minidom",
- "native-tls",
- "percent-encoding",
- "quick-xml",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.10.8",
- "thiserror 1.0.63",
- "time",
- "tokio",
- "tokio-native-tls",
- "tokio-stream",
- "url",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -6121,23 +6091,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
-name = "rxml"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98f186c7a2f3abbffb802984b7f1dfd65dac8be1aafdaabbca4137f53f0dff7"
-dependencies = [
- "bytes",
- "rxml_validation",
- "smartstring",
-]
-
-[[package]]
-name = "rxml_validation"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a197350ece202f19a166d1ad6d9d6de145e1d2a8ef47db299abe164dbd7530"
-
-[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6244,7 +6197,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6304,7 +6257,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.87",
+ "syn 2.0.104",
  "unicode-ident",
 ]
 
@@ -6367,7 +6320,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
  "thiserror 2.0.12",
 ]
 
@@ -6393,7 +6346,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6518,7 +6471,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6541,7 +6494,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6593,7 +6546,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6722,17 +6675,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
 ]
 
 [[package]]
@@ -6873,7 +6815,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6896,7 +6838,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.87",
+ "syn 2.0.104",
  "tokio",
  "url",
 ]
@@ -7073,7 +7015,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7130,9 +7072,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7148,7 +7090,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7162,6 +7104,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "system-configuration"
@@ -7171,7 +7116,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -7179,6 +7135,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -7239,7 +7205,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7250,7 +7216,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7366,7 +7332,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7540,7 +7506,7 @@ dependencies = [
  "prost-build 0.13.5",
  "prost-types 0.13.5",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7573,6 +7539,25 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 1.0.1",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
  "tower-layer",
  "tower-service",
 ]
@@ -7609,7 +7594,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7698,12 +7683,6 @@ dependencies = [
  "tracing-log 0.2.0",
  "tracing-serde",
 ]
-
-[[package]]
-name = "trim-in-place"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
 
 [[package]]
 name = "try-lock"
@@ -7966,46 +7945,48 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8013,22 +7994,38 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wasm-timer"
@@ -8047,9 +8044,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8118,6 +8115,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -8288,16 +8320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wiremock"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8350,6 +8372,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+
+[[package]]
+name = "xmltree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b619f8c85654798007fb10afa5125590b43b088c225a25fc2fec100a9fad0fc6"
+dependencies = [
+ "xml-rs",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8397,7 +8434,7 @@ checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8408,7 +8445,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8428,7 +8465,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.87",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/da-indexer/Cargo.toml
+++ b/da-indexer/Cargo.toml
@@ -35,12 +35,13 @@ hex = { version = "0.4.3" }
 http = { version = "1.1.0" }
 jsonrpsee = { version = "0.24.7", features = ["client-core", "macros"] }
 lazy_static = { version = "1.4.0" }
+md5 = { version = "0.8.0" }
+minio = { version = "0.3.0" }
 prost = { version = "0.13" }
 prost-build = "0.13"
 reqwest = { version = "0.12.5", features = ["json"] }
 reqwest-middleware = { version = "0.3.3" }
 reqwest-retry = { version = "0.6.1" }
-rust-s3 = { version = "0.35.1"}
 sea-orm = { version = "1.1", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros", "postgres-array"] }
 sea-orm-migration = { version = "1.1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 serde = { version = "1.0" }

--- a/da-indexer/Cargo.toml
+++ b/da-indexer/Cargo.toml
@@ -36,8 +36,9 @@ futures = { version = "0.3" }
 hex = { version = "0.4.3" }
 http = { version = "1.1.0" }
 jsonrpsee = { version = "0.24.7", features = ["client-core", "macros"] }
-lazy_static = { version = "1.4.0" }
+lazy_static = { version = "1.5.0" }
 md5 = { version = "0.8.0" }
+prometheus = { version = "0.14.0" }
 prost = { version = "0.13" }
 prost-build = "0.13"
 reqwest = { version = "0.12.5", features = ["json"] }

--- a/da-indexer/Cargo.toml
+++ b/da-indexer/Cargo.toml
@@ -21,6 +21,8 @@ actix-web = "4"
 anyhow = { version = "1.0" }
 async-std = { version = "1" }
 async-trait = { version = "0.1" }
+aws-credential-types = { version = "1.2.3", features = ["hardcoded-credentials"] }
+aws-sdk-s3 = { version = "1.94.0", features = ["behavior-version-latest"] }
 base64 = { version = "0.22.0" }
 blockscout-display-bytes = { version = "1.0" }
 blockscout-endpoint-swagger = { git = "https://github.com/blockscout/blockscout-rs", rev = "4a755c5" }
@@ -36,7 +38,6 @@ http = { version = "1.1.0" }
 jsonrpsee = { version = "0.24.7", features = ["client-core", "macros"] }
 lazy_static = { version = "1.4.0" }
 md5 = { version = "0.8.0" }
-minio = { version = "0.3.0" }
 prost = { version = "0.13" }
 prost-build = "0.13"
 reqwest = { version = "0.12.5", features = ["json"] }

--- a/da-indexer/Cargo.toml
+++ b/da-indexer/Cargo.toml
@@ -40,6 +40,7 @@ prost-build = "0.13"
 reqwest = { version = "0.12.5", features = ["json"] }
 reqwest-middleware = { version = "0.3.3" }
 reqwest-retry = { version = "0.6.1" }
+rust-s3 = { version = "0.35.1"}
 sea-orm = { version = "1.1", features = ["sqlx-postgres", "runtime-tokio-rustls", "macros", "postgres-array"] }
 sea-orm-migration = { version = "1.1", features = ["runtime-tokio-rustls", "sqlx-postgres"] }
 serde = { version = "1.0" }

--- a/da-indexer/README.md
+++ b/da-indexer/README.md
@@ -174,6 +174,14 @@ Response:
 }
 ```
 
+## Tests
+In order to run tests you have to connect to s3 storage. We suggest to run [minio](https://github.com/minio/minio).
+The easiest option is to use a docker image:
+```commandline
+docker run -p 9000:9000 quay.io/minio/minio server /data
+```
+You can specify connection settings via `S3_ENDPOINT`, `S3_ACCESS_KEY_ID`, and `S3_SECRET_ACCESS_KEY` envs.
+
 ## Dev
 
 + Install [just](https://github.com/casey/just) cli. Just is like make but better.

--- a/da-indexer/da-indexer-entity/src/celestia_blobs.rs
+++ b/da-indexer/da-indexer-entity/src/celestia_blobs.rs
@@ -16,8 +16,9 @@ pub struct Model {
     pub namespace: Vec<u8>,
     #[sea_orm(column_type = "VarBinary(StringLen::None)")]
     pub commitment: Vec<u8>,
-    #[sea_orm(column_type = "VarBinary(StringLen::None)")]
-    pub data: Vec<u8>,
+    #[sea_orm(column_type = "VarBinary(StringLen::None)", nullable)]
+    pub data: Option<Vec<u8>>,
+    pub data_s3_object_key: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/da-indexer/da-indexer-entity/src/eigenda_blobs.rs
+++ b/da-indexer/da-indexer-entity/src/eigenda_blobs.rs
@@ -14,8 +14,9 @@ pub struct Model {
     #[sea_orm(column_type = "VarBinary(StringLen::None)")]
     pub batch_header_hash: Vec<u8>,
     pub blob_index: i32,
-    #[sea_orm(column_type = "VarBinary(StringLen::None)")]
-    pub data: Vec<u8>,
+    #[sea_orm(column_type = "VarBinary(StringLen::None)", nullable)]
+    pub data: Option<Vec<u8>>,
+    pub data_s3_object_key: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/da-indexer/da-indexer-logic/Cargo.toml
+++ b/da-indexer/da-indexer-logic/Cargo.toml
@@ -23,6 +23,7 @@ prost = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
+rust-s3 = { workspace = true }
 sea-orm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/da-indexer/da-indexer-logic/Cargo.toml
+++ b/da-indexer/da-indexer-logic/Cargo.toml
@@ -23,6 +23,7 @@ http = { workspace = true }
 jsonrpsee = { workspace = true }
 lazy_static = { workspace = true }
 md5 = { workspace = true }
+prometheus = { workspace = true }
 prost = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/da-indexer/da-indexer-logic/Cargo.toml
+++ b/da-indexer/da-indexer-logic/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+base64 = { workspace = true }
 blockscout-display-bytes = { workspace = true }
 celestia-rpc = { workspace = true }
 celestia-types = { workspace = true }
@@ -19,11 +20,12 @@ hex = { workspace = true }
 http = { workspace = true }
 jsonrpsee = { workspace = true }
 lazy_static = { workspace = true }
+md5 = { workspace = true }
+minio = { workspace = true }
 prost = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }
 reqwest-retry = { workspace = true }
-rust-s3 = { workspace = true }
 sea-orm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/da-indexer/da-indexer-logic/Cargo.toml
+++ b/da-indexer/da-indexer-logic/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+aws-credential-types = { workspace = true }
+aws-sdk-s3 = { workspace = true }
 base64 = { workspace = true }
 blockscout-display-bytes = { workspace = true }
 celestia-rpc = { workspace = true }
@@ -21,7 +23,6 @@ http = { workspace = true }
 jsonrpsee = { workspace = true }
 lazy_static = { workspace = true }
 md5 = { workspace = true }
-minio = { workspace = true }
 prost = { workspace = true }
 reqwest = { workspace = true }
 reqwest-middleware = { workspace = true }

--- a/da-indexer/da-indexer-logic/src/celestia/da.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/da.rs
@@ -1,6 +1,11 @@
+use super::{
+    client::share::ShareClient, job::CelestiaJob, parser, repository::blocks,
+    settings::IndexerSettings,
+};
 use crate::{
     celestia::{client, repository::blobs},
     indexer::{Job, DA},
+    s3_storage::S3Storage,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -12,23 +17,23 @@ use std::sync::{
     Arc,
 };
 
-use super::{
-    client::share::ShareClient, job::CelestiaJob, parser, repository::blocks,
-    settings::IndexerSettings,
-};
-
 pub struct CelestiaDA {
     settings: IndexerSettings,
 
     client: Client,
     db: Arc<DatabaseConnection>,
+    s3_storage: Option<S3Storage>,
 
     last_known_height: AtomicU64,
     catch_up_completed: AtomicBool,
 }
 
 impl CelestiaDA {
-    pub async fn new(db: Arc<DatabaseConnection>, settings: IndexerSettings) -> Result<Self> {
+    pub async fn new(
+        db: Arc<DatabaseConnection>,
+        s3_storage: Option<S3Storage>,
+        settings: IndexerSettings,
+    ) -> Result<Self> {
         let client = client::new_celestia_client(
             &settings.rpc.url,
             settings.rpc.auth_token.as_deref(),
@@ -52,6 +57,7 @@ impl CelestiaDA {
             settings,
             client,
             db,
+            s3_storage,
             last_known_height: AtomicU64::new(start_from.saturating_sub(1)),
             catch_up_completed: AtomicBool::new(false),
         })
@@ -96,7 +102,8 @@ impl DA for CelestiaDA {
             // blobs might be quite big, so we save them periodically
             // to save ram and to avoid huge db insertions
             for chunk in blobs.chunks(self.settings.save_batch_size as usize) {
-                blobs::upsert_many(&txn, job.height, chunk.to_vec()).await?;
+                blobs::upsert_many(&txn, self.s3_storage.as_ref(), job.height, chunk.to_vec())
+                    .await?;
             }
             tracing::debug!(height = job.height, blobs_count, "saved blobs to db");
         }

--- a/da-indexer/da-indexer-logic/src/celestia/repository/blobs.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/repository/blobs.rs
@@ -54,7 +54,8 @@ pub async fn upsert_many<C: ConnectionTrait>(
             height: height as i64,
             namespace: blob.namespace.as_bytes().to_vec(),
             commitment: blob.commitment.0.to_vec(),
-            data: blob.data,
+            data: Some(blob.data),
+            data_s3_object_key: None,
         };
         let active: ActiveModel = model.into();
         active

--- a/da-indexer/da-indexer-logic/src/celestia/repository/blobs.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/repository/blobs.rs
@@ -1,7 +1,4 @@
-use crate::{
-    common,
-    s3_storage::{S3Object, S3Storage},
-};
+use crate::{common, s3_storage::S3Storage};
 use celestia_types::Blob as CelestiaBlob;
 use da_indexer_entity::{
     celestia_blobs::{ActiveModel, Column, Entity, Model},
@@ -70,17 +67,11 @@ pub async fn upsert_many<C: ConnectionTrait>(
     let blobs = blobs.into_iter().map(|blob| {
         let id = compute_id(height, &blob.commitment.0);
 
-        let mut data = None;
-        let mut data_s3_object_key = None;
-        if s3_storage.is_none() {
-            data = Some(blob.data);
-        } else {
-            let object_key = hex::encode(&id);
-            data_s3_object_key = Some(object_key.clone());
-            data_s3_objects.push(S3Object {
-                key: object_key,
-                content: blob.data,
-            });
+        let (db_data, s3_object) = common::repository::convert_blob_data_to_db_data_and_s3_object(
+            s3_storage, "celestia", &id, blob.data,
+        );
+        if let Some(s3_object) = s3_object {
+            data_s3_objects.push(s3_object);
         }
 
         let model = Model {
@@ -88,8 +79,8 @@ pub async fn upsert_many<C: ConnectionTrait>(
             height: height as i64,
             namespace: blob.namespace.as_bytes().to_vec(),
             commitment: blob.commitment.0.to_vec(),
-            data,
-            data_s3_object_key,
+            data: db_data.data,
+            data_s3_object_key: db_data.data_s3_object_key,
         };
         let active: ActiveModel = model.into();
         active

--- a/da-indexer/da-indexer-logic/src/celestia/tests/blobs.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/tests/blobs.rs
@@ -18,7 +18,7 @@ async fn celestia_blobs_smoke_test_without_s3_storage() {
     smoke_test(db, None).await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn smoke_test_with_s3_storage() {
     let test_name = "celestia_blobs_smoke_test_with_s3_storage";
     let db = init_db(test_name).await;

--- a/da-indexer/da-indexer-logic/src/celestia/tests/blobs.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/tests/blobs.rs
@@ -1,17 +1,34 @@
+use blockscout_service_launcher::test_database::TestDbGuard;
 use celestia_types::{
     consts::appconsts::subtree_root_threshold, nmt::Namespace, AppVersion, Blob as CelestiaBlob,
     Commitment,
 };
 
-use crate::celestia::{
-    repository::{blobs, blocks},
-    tests::init_db,
+use crate::{
+    celestia::repository::{blobs, blocks},
+    common::tests::{init_db, initialize_s3_storage, is_s3_storage_empty},
+    s3_storage::S3Storage,
 };
 use sha3::{Digest, Sha3_256};
 
 #[tokio::test]
-async fn smoke_test() {
-    let db = init_db("celestia_blobs_smoke_test").await;
+async fn celestia_blobs_smoke_test_without_s3_storage() {
+    let test_name = "celestia_blobs_smoke_test_without_s3_storage";
+    let db = init_db(test_name).await;
+    smoke_test(db, None).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn smoke_test_with_s3_storage() {
+    let test_name = "celestia_blobs_smoke_test_with_s3_storage";
+    let db = init_db(test_name).await;
+    let s3_storage = initialize_s3_storage(test_name).await;
+
+    smoke_test(db, Some(s3_storage)).await;
+    assert!(!is_s3_storage_empty(test_name).await);
+}
+
+async fn smoke_test(db: TestDbGuard, s3_storage: Option<S3Storage>) {
     let height_range = 1..=5;
     let blobs_range = 1..=5;
 
@@ -20,7 +37,7 @@ async fn smoke_test() {
         blocks::upsert(db.client().as_ref(), height, &[], 5, 0)
             .await
             .unwrap();
-        blobs::upsert_many(db.client().as_ref(), height, blobs)
+        blobs::upsert_many(db.client().as_ref(), s3_storage.as_ref(), height, blobs)
             .await
             .unwrap();
     }
@@ -28,23 +45,30 @@ async fn smoke_test() {
     for height in height_range {
         let blobs = blobs_range.clone().map(celestia_blob).collect::<Vec<_>>();
         for blob in blobs {
-            let blob_db =
-                blobs::find_by_height_and_commitment(&db.client(), height, &blob.commitment.0)
-                    .await
-                    .unwrap()
-                    .unwrap();
+            let blob_db = blobs::find_by_height_and_commitment(
+                &db.client(),
+                s3_storage.as_ref(),
+                height,
+                &blob.commitment.0,
+            )
+            .await
+            .unwrap()
+            .unwrap();
             assert_eq!(blob.namespace.as_bytes(), blob_db.namespace);
             assert_eq!(blob.data, blob_db.data);
             assert_eq!(&blob.commitment.0[..], blob_db.commitment);
         }
     }
 
-    assert!(
-        blobs::find_by_height_and_commitment(&db.client(), 0, &[0_u8; 32])
-            .await
-            .unwrap()
-            .is_none()
-    );
+    assert!(blobs::find_by_height_and_commitment(
+        &db.client(),
+        s3_storage.as_ref(),
+        0,
+        &[0_u8; 32]
+    )
+    .await
+    .unwrap()
+    .is_none());
 }
 
 fn celestia_blob(seed: u32) -> CelestiaBlob {

--- a/da-indexer/da-indexer-logic/src/celestia/tests/blocks.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/tests/blocks.rs
@@ -1,6 +1,6 @@
 use sea_orm::DatabaseConnection;
 
-use crate::celestia::{repository::blocks, tests::init_db};
+use crate::{celestia::repository::blocks, common::tests::init_db};
 
 #[tokio::test]
 async fn upsert_test() {

--- a/da-indexer/da-indexer-logic/src/celestia/tests/mod.rs
+++ b/da-indexer/da-indexer-logic/src/celestia/tests/mod.rs
@@ -1,9 +1,3 @@
 pub mod blobs;
 pub mod blocks;
 pub mod l2_router;
-
-use blockscout_service_launcher::test_database::TestDbGuard;
-
-pub async fn init_db(test_name: &str) -> TestDbGuard {
-    TestDbGuard::new::<migration::Migrator>(test_name).await
-}

--- a/da-indexer/da-indexer-logic/src/common/mod.rs
+++ b/da-indexer/da-indexer-logic/src/common/mod.rs
@@ -1,3 +1,7 @@
 mod common_transport;
 pub mod eth_provider;
+pub mod repository;
 pub mod types;
+
+#[cfg(test)]
+pub mod tests;

--- a/da-indexer/da-indexer-logic/src/common/repository.rs
+++ b/da-indexer/da-indexer-logic/src/common/repository.rs
@@ -1,10 +1,40 @@
-use crate::s3_storage::S3Storage;
+use crate::s3_storage::{S3Object, S3Storage};
 use sea_orm::FromQueryResult;
 
 #[derive(FromQueryResult, Default, Debug)]
 pub struct DbData {
     pub data: Option<Vec<u8>>,
     pub data_s3_object_key: Option<String>,
+}
+
+pub fn convert_blob_data_to_db_data_and_s3_object(
+    maybe_s3_storage: Option<&S3Storage>,
+    da_prefix: &str,
+    blob_id: &[u8],
+    data: Vec<u8>,
+) -> (DbData, Option<S3Object>) {
+    if maybe_s3_storage.is_none() {
+        (
+            DbData {
+                data: Some(data),
+                data_s3_object_key: None,
+            },
+            None,
+        )
+    } else {
+        let object_key = format!("{da_prefix}_{}", hex::encode(blob_id));
+        let s3_object = S3Object {
+            key: object_key.clone(),
+            content: data,
+        };
+        (
+            DbData {
+                data: None,
+                data_s3_object_key: Some(object_key),
+            },
+            Some(s3_object),
+        )
+    }
 }
 
 pub async fn extract_blob_data(

--- a/da-indexer/da-indexer-logic/src/common/repository.rs
+++ b/da-indexer/da-indexer-logic/src/common/repository.rs
@@ -1,0 +1,48 @@
+use crate::s3_storage::S3Storage;
+use sea_orm::FromQueryResult;
+
+#[derive(FromQueryResult, Default, Debug)]
+pub struct DbData {
+    pub data: Option<Vec<u8>>,
+    pub data_s3_object_key: Option<String>,
+}
+
+pub async fn extract_blob_data(
+    s3_storage: Option<&S3Storage>,
+    blob_id: &[u8],
+    db_data: DbData,
+) -> Result<Vec<u8>, anyhow::Error> {
+    if let Some(data) = db_data.data {
+        return Ok(data);
+    }
+
+    let data_s3_object_key = db_data.data_s3_object_key.ok_or_else(|| {
+        // Must never be the case as we added a constraint on the postgres table
+        // ensuring exactly one of `data` or `data_s3_object_key` fields is not null.
+        tracing::error!(
+            blob_id = hex::encode(blob_id),
+            "both blob data and object key are missing from the database. \
+            The database is corrupted!"
+        );
+        anyhow::anyhow!("both blob data and object key are missing from the database")
+    })?;
+
+    let s3_storage = s3_storage.ok_or_else(|| {
+        tracing::error!(
+            blob_id = hex::encode(blob_id),
+            "blob data is located in s3 storage, but the storage is not available. \
+                Please check your configuration."
+        );
+        anyhow::anyhow!("blob data was stored in s3 storage but the storage is not available")
+    })?;
+
+    let object = s3_storage.find_object_by_key(&data_s3_object_key).await?;
+    object.map(|object| object.content).ok_or_else(|| {
+        tracing::error!(
+            blob_id = hex::encode(blob_id),
+            data_s3_object_key = data_s3_object_key,
+            "blob data is missing from s3 storage"
+        );
+        anyhow::anyhow!("blob data is missing from s3 storage")
+    })
+}

--- a/da-indexer/da-indexer-logic/src/common/repository.rs
+++ b/da-indexer/da-indexer-logic/src/common/repository.rs
@@ -13,28 +13,25 @@ pub fn convert_blob_data_to_db_data_and_s3_object(
     blob_id: &[u8],
     data: Vec<u8>,
 ) -> (DbData, Option<S3Object>) {
-    if maybe_s3_storage.is_none() {
-        (
-            DbData {
-                data: Some(data),
-                data_s3_object_key: None,
-            },
-            None,
-        )
-    } else {
-        let object_key = format!("{da_prefix}_{}", hex::encode(blob_id));
-        let s3_object = S3Object {
-            key: object_key.clone(),
-            content: data,
-        };
-        (
-            DbData {
-                data: None,
-                data_s3_object_key: Some(object_key),
-            },
-            Some(s3_object),
-        )
-    }
+    let (data, data_s3_object_key, s3_object) = match maybe_s3_storage {
+        None => (Some(data), None, None),
+        Some(_) => {
+            let object_key = format!("{da_prefix}_{}", hex::encode(blob_id));
+            let s3_object = S3Object {
+                key: object_key.clone(),
+                content: data,
+            };
+            (None, Some(object_key), Some(s3_object))
+        }
+    };
+
+    (
+        DbData {
+            data,
+            data_s3_object_key,
+        },
+        s3_object,
+    )
 }
 
 pub async fn extract_blob_data(

--- a/da-indexer/da-indexer-logic/src/common/tests.rs
+++ b/da-indexer/da-indexer-logic/src/common/tests.rs
@@ -38,6 +38,7 @@ mod s3_storage {
             access_key_id: client_with_details.access_key_id,
             secret_access_key: client_with_details.secret_access_key,
             save_concurrency_limit: None,
+            create_bucket: false,
             validate_on_initialization: true,
         })
         .await

--- a/da-indexer/da-indexer-logic/src/common/tests.rs
+++ b/da-indexer/da-indexer-logic/src/common/tests.rs
@@ -93,7 +93,7 @@ mod s3_storage {
         if !does_bucket_exist(client, bucket_name).await {
             return;
         }
-        clear_bucket(client, bucket_name).await;
+        empty_bucket(client, bucket_name).await;
         client
             .delete_bucket()
             .bucket(bucket_name)
@@ -102,7 +102,7 @@ mod s3_storage {
             .expect("failed to delete existing bucket");
     }
 
-    async fn clear_bucket(client: &s3::Client, bucket_name: &str) {
+    async fn empty_bucket(client: &s3::Client, bucket_name: &str) {
         let mut objects = client
             .list_objects_v2()
             .bucket(bucket_name)

--- a/da-indexer/da-indexer-logic/src/common/tests.rs
+++ b/da-indexer/da-indexer-logic/src/common/tests.rs
@@ -1,0 +1,140 @@
+use blockscout_service_launcher::test_database::TestDbGuard;
+
+pub async fn init_db(test_name: &str) -> TestDbGuard {
+    TestDbGuard::new::<migration::Migrator>(test_name).await
+}
+
+pub use s3_storage::{initialize_s3_storage, is_s3_storage_empty};
+mod s3_storage {
+    use crate::s3_storage::{S3Storage, S3StorageSettings};
+    use futures::StreamExt;
+    use minio::s3::{
+        self,
+        builders::ObjectToDelete,
+        creds::StaticProvider,
+        response::ListObjectsResponse,
+        types::{S3Api, ToStream},
+    };
+
+    struct ClientWithDetails {
+        endpoint: String,
+        access_key_id: String,
+        secret_access_key: String,
+        bucket_name: String,
+        client: s3::Client,
+    }
+
+    pub async fn initialize_s3_storage(test_name: &str) -> S3Storage {
+        let client_with_details = initialize_client(test_name).await;
+        initialize_bucket(
+            &client_with_details.client,
+            &client_with_details.bucket_name,
+        )
+        .await;
+
+        S3Storage::new(S3StorageSettings {
+            endpoint: client_with_details.endpoint,
+            bucket: client_with_details.bucket_name,
+            access_key_id: client_with_details.access_key_id,
+            secret_access_key: client_with_details.secret_access_key,
+            save_concurrency_limit: None,
+            validate_on_initialization: true,
+        })
+        .await
+        .expect("cannot initialize s3 storage")
+    }
+
+    pub async fn is_s3_storage_empty(test_name: &str) -> bool {
+        let client_with_details = initialize_client(test_name).await;
+        is_bucket_empty(
+            &client_with_details.client,
+            &client_with_details.bucket_name,
+        )
+        .await
+    }
+
+    async fn initialize_client(test_name: &str) -> ClientWithDetails {
+        let endpoint =
+            std::env::var("S3_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:9000".to_string());
+        let access_key_id =
+            std::env::var("S3_ACCESS_KEY_ID").unwrap_or_else(|_| "minioadmin".to_string());
+        let secret_access_key =
+            std::env::var("S3_SECRET_ACCESS_KEY").unwrap_or_else(|_| "minioadmin".to_string());
+
+        // Bucket names can consist only of lowercase letters, numbers, periods (.), and hyphens (-)
+        let bucket_name = test_name.replace("_", "-");
+
+        let credentials = StaticProvider::new(&access_key_id, &secret_access_key, None);
+        let client = s3::Client::new(
+            endpoint.parse().expect("cannot parse endpoint as url"),
+            Some(Box::new(credentials)),
+            None,
+            None,
+        )
+        .expect("cannot initialize s3 client");
+
+        ClientWithDetails {
+            endpoint,
+            access_key_id,
+            secret_access_key,
+            bucket_name,
+            client,
+        }
+    }
+
+    async fn initialize_bucket(client: &s3::Client, bucket_name: &str) {
+        delete_bucket_if_exists(client, bucket_name).await;
+        client
+            .create_bucket(bucket_name)
+            .send()
+            .await
+            .expect("failed to create bucket");
+    }
+
+    async fn delete_bucket_if_exists(client: &s3::Client, bucket_name: &str) {
+        let bucket_exists = client
+            .bucket_exists(bucket_name)
+            .send()
+            .await
+            .expect("failed to check if bucket exists");
+        if !bucket_exists.exists {
+            return;
+        }
+
+        delete_bucket_objects(client, bucket_name).await;
+        client
+            .delete_bucket(bucket_name)
+            .send()
+            .await
+            .expect("failed to delete existing bucket");
+    }
+
+    async fn delete_bucket_objects(client: &s3::Client, bucket_name: &str) {
+        let mut list_objects_stream = client
+            .list_objects(bucket_name)
+            .recursive(true)
+            .to_stream()
+            .await
+            .map(|object| object);
+
+        while let Some(result) = list_objects_stream.next().await {
+            let list_objects: ListObjectsResponse =
+                result.expect("failed to obtain next object to delete");
+            let objects_to_delete: Vec<ObjectToDelete> =
+                list_objects.contents.into_iter().map(Into::into).collect();
+            if !objects_to_delete.is_empty() {
+                client
+                    .delete_objects::<_, ObjectToDelete>(bucket_name, objects_to_delete)
+                    .send()
+                    .await
+                    .expect("failed to delete objects");
+            }
+        }
+    }
+
+    async fn is_bucket_empty(client: &s3::Client, bucket_name: &str) -> bool {
+        let objects = client.list_objects(bucket_name).to_stream().await;
+        let bucket_size = objects.count().await;
+        bucket_size == 0
+    }
+}

--- a/da-indexer/da-indexer-logic/src/eigenda/da.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/da.rs
@@ -8,18 +8,19 @@ use tokio::sync::Mutex;
 
 use sea_orm::DatabaseConnection;
 
+use super::{client::Client, job::EigenDAJob, settings::IndexerSettings};
 use crate::{
     common::{eth_provider::EthProvider, types::gap::Gap},
     eigenda::repository::{batches, blobs},
     indexer::{Job, DA},
+    s3_storage::S3Storage,
 };
-
-use super::{client::Client, job::EigenDAJob, settings::IndexerSettings};
 
 pub struct EigenDA {
     settings: IndexerSettings,
 
     db: Arc<DatabaseConnection>,
+    s3_storage: Option<S3Storage>,
     client: Client,
     provider: EthProvider,
 
@@ -28,7 +29,11 @@ pub struct EigenDA {
 }
 
 impl EigenDA {
-    pub async fn new(db: Arc<DatabaseConnection>, settings: IndexerSettings) -> Result<Self> {
+    pub async fn new(
+        db: Arc<DatabaseConnection>,
+        s3_storage: Option<S3Storage>,
+        settings: IndexerSettings,
+    ) -> Result<Self> {
         let provider = EthProvider::new(&settings.rpc.url).await?;
         let client = Client::new(&settings.disperser_url, vec![5, 15, 30]).await?;
         let start_from = settings
@@ -39,6 +44,7 @@ impl EigenDA {
         Ok(Self {
             settings,
             db,
+            s3_storage,
             client,
             provider,
             last_known_block: AtomicU64::new(start_from.saturating_sub(1)),
@@ -92,6 +98,7 @@ impl DA for EigenDA {
             if blobs.len() == self.settings.save_batch_size as usize {
                 blobs::upsert_many(
                     self.db.as_ref(),
+                    self.s3_storage.as_ref(),
                     blob_index as i32 - blobs.len() as i32,
                     &job.batch_header_hash,
                     blobs,
@@ -104,6 +111,7 @@ impl DA for EigenDA {
         if !blobs.is_empty() {
             blobs::upsert_many(
                 self.db.as_ref(),
+                self.s3_storage.as_ref(),
                 blob_index as i32 - blobs.len() as i32,
                 &job.batch_header_hash,
                 blobs,

--- a/da-indexer/da-indexer-logic/src/eigenda/repository/blobs.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/repository/blobs.rs
@@ -59,7 +59,8 @@ pub async fn upsert_many<C: ConnectionTrait>(
             id: compute_id(batch_header_hash, blob_index),
             batch_header_hash: batch_header_hash.to_vec(),
             blob_index,
-            data,
+            data: Some(data),
+            data_s3_object_key: None,
         };
         let active: ActiveModel = model.into();
         active

--- a/da-indexer/da-indexer-logic/src/eigenda/repository/blobs.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/repository/blobs.rs
@@ -1,4 +1,5 @@
 use crate::{common, s3_storage::S3Storage};
+use anyhow::Context;
 use da_indexer_entity::{
     eigenda_batches,
     eigenda_blobs::{ActiveModel, Column, Entity, Model},
@@ -69,38 +70,52 @@ pub async fn upsert_many<C: ConnectionTrait>(
     blobs: Vec<Vec<u8>>,
 ) -> Result<(), anyhow::Error> {
     let mut data_s3_objects = vec![];
-    let blobs = blobs.into_iter().enumerate().map(|(i, blob_data)| {
-        let blob_index = start_index + i as i32;
+    let blobs: Vec<_> = blobs
+        .into_iter()
+        .enumerate()
+        .map(|(i, blob_data)| {
+            let blob_index = start_index + i as i32;
 
-        let id = compute_id(batch_header_hash, blob_index);
+            let id = compute_id(batch_header_hash, blob_index);
 
-        let (db_data, s3_object) = common::repository::convert_blob_data_to_db_data_and_s3_object(
-            s3_storage, "eigenda", &id, blob_data,
-        );
-        if let Some(s3_object) = s3_object {
-            data_s3_objects.push(s3_object);
+            let (db_data, s3_object) =
+                common::repository::convert_blob_data_to_db_data_and_s3_object(
+                    s3_storage, "eigenda", &id, blob_data,
+                );
+            if let Some(s3_object) = s3_object {
+                data_s3_objects.push(s3_object);
+            }
+
+            let model = Model {
+                id: compute_id(batch_header_hash, blob_index),
+                batch_header_hash: batch_header_hash.to_vec(),
+                blob_index,
+                data: db_data.data,
+                data_s3_object_key: db_data.data_s3_object_key,
+            };
+            let active: ActiveModel = model.into();
+            active
+        })
+        .collect();
+
+    let database_insert_future = async move {
+        Entity::insert_many(blobs)
+            .on_conflict(OnConflict::column(Column::Id).do_nothing().to_owned())
+            .on_empty_do_nothing()
+            .exec(db)
+            .await
+            .context("database insertion")
+    };
+    let s3_storage_insert_future = async move {
+        match s3_storage {
+            None => Ok(()),
+            Some(s3_storage) => s3_storage
+                .insert_many(data_s3_objects)
+                .await
+                .context("s3 storage insertion"),
         }
-
-        let model = Model {
-            id: compute_id(batch_header_hash, blob_index),
-            batch_header_hash: batch_header_hash.to_vec(),
-            blob_index,
-            data: db_data.data,
-            data_s3_object_key: db_data.data_s3_object_key,
-        };
-        let active: ActiveModel = model.into();
-        active
-    });
-
-    Entity::insert_many(blobs)
-        .on_conflict(OnConflict::column(Column::Id).do_nothing().to_owned())
-        .on_empty_do_nothing()
-        .exec(db)
-        .await?;
-
-    if let Some(s3_storage) = s3_storage {
-        s3_storage.insert_many(data_s3_objects).await?;
-    }
+    };
+    futures::future::try_join(database_insert_future, s3_storage_insert_future).await?;
 
     Ok(())
 }

--- a/da-indexer/da-indexer-logic/src/eigenda/tests/batches.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/tests/batches.rs
@@ -1,6 +1,6 @@
 use sea_orm::DatabaseConnection;
 
-use crate::eigenda::{repository::batches, tests::init_db};
+use crate::{common::tests::init_db, eigenda::repository::batches};
 
 #[tokio::test]
 async fn find_gaps() {

--- a/da-indexer/da-indexer-logic/src/eigenda/tests/blobs.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/tests/blobs.rs
@@ -12,7 +12,7 @@ async fn eigenda_blobs_smoke_test_without_s3_storage() {
     smoke_test(db, None).await;
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn eigenda_blobs_smoke_test_with_s3_storage() {
     let test_name = "eigenda_blobs_smoke_test_with_s3_storage";
     let db = init_db(test_name).await;

--- a/da-indexer/da-indexer-logic/src/eigenda/tests/mod.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/tests/mod.rs
@@ -1,8 +1,2 @@
 pub mod batches;
 pub mod blobs;
-
-use blockscout_service_launcher::test_database::TestDbGuard;
-
-pub async fn init_db(test_name: &str) -> TestDbGuard {
-    TestDbGuard::new::<migration::Migrator>(test_name).await
-}

--- a/da-indexer/da-indexer-logic/src/indexer.rs
+++ b/da-indexer/da-indexer-logic/src/indexer.rs
@@ -81,11 +81,11 @@ impl Indexer {
         while let Err(err) = &self.da.process_job(job.clone()).await {
             match backoff.next() {
                 Some(delay) => {
-                    tracing::warn!(error = ?err, job = ?job, ?delay, "failed to process job, retrying");
+                    tracing::warn!(error = %err, job = ?job, ?delay, "failed to process job, retrying");
                     sleep(delay).await;
                 }
                 None => {
-                    tracing::error!(error = ?err, job = ?job, "failed to process job, skipping for now, will retry later");
+                    tracing::error!(error = %err, job = ?job, "failed to process job, skipping for now, will retry later");
                     self.failed_jobs.lock().await.insert(job.clone());
                     break;
                 }
@@ -101,7 +101,7 @@ impl Indexer {
         .filter_map(|fut| async {
             fut.await
                 .map_err(
-                    |err: Error| tracing::error!(error = ?err, "failed to retrieve unprocessed jobs"),
+                    |err: Error| tracing::error!(error = %err, "failed to retrieve unprocessed jobs"),
                 )
                 .ok()
         })
@@ -117,7 +117,7 @@ impl Indexer {
         })
         .filter_map(|fut| async {
             fut.await
-                .map_err(|err: Error| tracing::error!(error = ?err, "failed to poll for new jobs"))
+                .map_err(|err: Error| tracing::error!(error = %err, "failed to poll for new jobs"))
                 .ok()
         })
         .flat_map(stream::iter)
@@ -135,7 +135,7 @@ impl Indexer {
         })
         .filter_map(|fut| async {
             fut.await
-                .map_err(|err: Error| tracing::error!(error = ?err, "failed to retry failed jobs"))
+                .map_err(|err: Error| tracing::error!(error = %err, "failed to retry failed jobs"))
                 .ok()
         })
         .flat_map(stream::iter)

--- a/da-indexer/da-indexer-logic/src/indexer.rs
+++ b/da-indexer/da-indexer-logic/src/indexer.rs
@@ -12,6 +12,7 @@ use tracing::instrument;
 
 use crate::{
     celestia, eigenda,
+    s3_storage::S3Storage,
     settings::{DASettings, IndexerSettings},
 };
 
@@ -36,7 +37,11 @@ pub struct Indexer {
 }
 
 impl Indexer {
-    pub async fn new(db: Arc<DatabaseConnection>, settings: IndexerSettings) -> Result<Self> {
+    pub async fn new(
+        db: Arc<DatabaseConnection>,
+        _s3_storage: Option<S3Storage>,
+        settings: IndexerSettings,
+    ) -> Result<Self> {
         let da: Box<dyn DA + Send + Sync> = match settings.da.clone() {
             DASettings::Celestia(settings) => {
                 Box::new(celestia::da::CelestiaDA::new(db.clone(), settings).await?)

--- a/da-indexer/da-indexer-logic/src/indexer.rs
+++ b/da-indexer/da-indexer-logic/src/indexer.rs
@@ -39,15 +39,15 @@ pub struct Indexer {
 impl Indexer {
     pub async fn new(
         db: Arc<DatabaseConnection>,
-        _s3_storage: Option<S3Storage>,
+        s3_storage: Option<S3Storage>,
         settings: IndexerSettings,
     ) -> Result<Self> {
         let da: Box<dyn DA + Send + Sync> = match settings.da.clone() {
-            DASettings::Celestia(settings) => {
-                Box::new(celestia::da::CelestiaDA::new(db.clone(), settings).await?)
-            }
+            DASettings::Celestia(settings) => Box::new(
+                celestia::da::CelestiaDA::new(db.clone(), s3_storage.clone(), settings).await?,
+            ),
             DASettings::EigenDA(settings) => {
-                Box::new(eigenda::da::EigenDA::new(db.clone(), settings).await?)
+                Box::new(eigenda::da::EigenDA::new(db.clone(), s3_storage.clone(), settings).await?)
             }
         };
         Ok(Self {

--- a/da-indexer/da-indexer-logic/src/lib.rs
+++ b/da-indexer/da-indexer-logic/src/lib.rs
@@ -5,4 +5,5 @@ pub mod celestia;
 pub mod common;
 pub mod eigenda;
 pub mod indexer;
+pub mod s3_storage;
 pub mod settings;

--- a/da-indexer/da-indexer-logic/src/lib.rs
+++ b/da-indexer/da-indexer-logic/src/lib.rs
@@ -5,5 +5,6 @@ pub mod celestia;
 pub mod common;
 pub mod eigenda;
 pub mod indexer;
+mod metrics;
 pub mod s3_storage;
 pub mod settings;

--- a/da-indexer/da-indexer-logic/src/metrics.rs
+++ b/da-indexer/da-indexer-logic/src/metrics.rs
@@ -1,0 +1,20 @@
+use lazy_static::lazy_static;
+use prometheus::{register_histogram, register_int_counter, Histogram, IntCounter};
+
+lazy_static! {
+    pub static ref S3_BULK_UPLOAD_TOTAL: IntCounter = register_int_counter!(
+        "da_indexer_s3_bulk_upload_total",
+        "total number of attempts to upload bulk of files into s3 storage",
+    )
+    .unwrap();
+    pub static ref S3_BULK_UPLOAD_SUCCESSES: IntCounter = register_int_counter!(
+        "da_indexer_s3_bulk_upload_successes",
+        "number of successful attempts to upload bulk of file into s3 storage",
+    )
+    .unwrap();
+    pub static ref S3_BULK_UPLOAD_TIME: Histogram = register_histogram!(
+        "da_indexer_s3_bulk_upload_time_seconds",
+        "bulk upload time into s3 storage in seconds",
+    )
+    .unwrap();
+}

--- a/da-indexer/da-indexer-logic/src/s3_storage.rs
+++ b/da-indexer/da-indexer-logic/src/s3_storage.rs
@@ -1,6 +1,14 @@
 use anyhow::Context;
+use base64::{prelude::BASE64_STANDARD, Engine};
+use futures::{stream::TryStreamExt, StreamExt};
+use minio::{
+    s3,
+    s3::{
+        multimap::{Multimap, MultimapExt},
+        types::S3Api,
+    },
+};
 use serde::Deserialize;
-use std::sync::Arc;
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
@@ -9,6 +17,7 @@ pub struct S3StorageSettings {
     pub bucket: String,
     pub access_key_id: String,
     pub secret_access_key: String,
+    pub save_concurrency_limit: Option<usize>,
     #[serde(default)]
     pub validate_on_initialization: bool,
 }
@@ -16,37 +25,109 @@ pub struct S3StorageSettings {
 #[derive(Clone, Debug)]
 pub struct S3Storage {
     // Use one bucket instance for all users
-    _bucket: Arc<s3::Bucket>,
+    client: s3::Client,
+    bucket: String,
+    save_concurrency_limit: Option<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct S3Object {
+    pub key: String,
+    pub content: Vec<u8>,
 }
 
 impl S3Storage {
     pub async fn new(settings: S3StorageSettings) -> anyhow::Result<Self> {
-        let region = s3::Region::Custom {
-            region: "custom".to_string(),
-            endpoint: settings.endpoint,
-        };
-        let bucket = s3::Bucket::new(
-            &settings.bucket,
-            region,
-            s3::creds::Credentials::new(
-                Some(&settings.access_key_id),
-                Some(&settings.secret_access_key),
-                None,
-                None,
-                None,
-            )
-            .context("credentials initialization failed")?,
+        let credentials = s3::creds::StaticProvider::new(
+            &settings.access_key_id,
+            &settings.secret_access_key,
+            None,
+        );
+        let client = s3::Client::new(
+            settings
+                .endpoint
+                .parse()
+                .context("parsing endpoint into url failed")?,
+            Some(Box::new(credentials)),
+            None,
+            None,
         )
-        .context("bucket initialization failed")?;
+        .context("s3 client initialization failed")?;
 
-        if settings.validate_on_initialization
-            && !bucket.exists().await.context("bucket validation failed")?
-        {
-            anyhow::bail!("bucket ({}) is not available", settings.bucket);
+        if settings.validate_on_initialization {
+            let bucket_exists_response = client
+                .bucket_exists(&settings.bucket)
+                .send()
+                .await
+                .context("bucket validation failed")?;
+            if !bucket_exists_response.exists {
+                anyhow::bail!("bucket ({}) is not available", settings.bucket);
+            }
         }
 
         Ok(S3Storage {
-            _bucket: bucket.into(),
+            client,
+            bucket: settings.bucket,
+            save_concurrency_limit: settings.save_concurrency_limit,
         })
+    }
+
+    pub async fn find_object_by_key(&self, key: &str) -> Result<Option<S3Object>, anyhow::Error> {
+        let result = self.client.get_object(&self.bucket, key).send().await;
+        match result {
+            Ok(object_response) => {
+                let content = object_response
+                    .content
+                    .to_segmented_bytes()
+                    .await
+                    .context("download object content")?;
+
+                Ok(Some(S3Object {
+                    key: key.to_string(),
+                    content: content.to_bytes().to_vec(),
+                }))
+            }
+            Err(s3::error::Error::S3Error(error))
+                if error.code == s3::error::ErrorCode::NoSuchKey =>
+            {
+                Ok(None)
+            }
+            Err(error) => Err(error).context("get object by key"),
+        }
+    }
+
+    pub async fn insert_many(&self, objects: Vec<S3Object>) -> Result<(), anyhow::Error> {
+        futures::stream::iter(objects)
+            .map(Ok)
+            .try_for_each_concurrent(self.save_concurrency_limit, |object| async move {
+                let content_md5 = md5::compute(&object.content);
+
+                let mut content = s3::segmented_bytes::SegmentedBytes::new();
+                content.append(object.content.into());
+
+                let mut extra_headers = Multimap::new();
+                extra_headers.add("Content-MD5", BASE64_STANDARD.encode(content_md5.0));
+
+                let response = self
+                    .client
+                    .put_object(&self.bucket, &object.key, content)
+                    .extra_headers(Some(extra_headers))
+                    .send()
+                    .await
+                    .context(format!("put object {} into s3 storage failed", object.key))?;
+
+                // Have to always be false, as the integrity should already be validated
+                // by S3 storage as we provided 'Content-MD5' header. But added additional
+                // check here just in case the header is not supported by the given storage.
+                if response.etag != hex::encode(content_md5.0) {
+                    anyhow::bail!(
+                        "({}) object MD5 checksum does not match returned ETag value",
+                        object.key
+                    )
+                }
+
+                Ok(())
+            })
+            .await
     }
 }

--- a/da-indexer/da-indexer-logic/src/s3_storage.rs
+++ b/da-indexer/da-indexer-logic/src/s3_storage.rs
@@ -1,0 +1,52 @@
+use anyhow::Context;
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct S3StorageSettings {
+    pub endpoint: String,
+    pub bucket: String,
+    pub access_key_id: String,
+    pub secret_access_key: String,
+    #[serde(default)]
+    pub validate_on_initialization: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct S3Storage {
+    // Use one bucket instance for all users
+    _bucket: Arc<s3::Bucket>,
+}
+
+impl S3Storage {
+    pub async fn new(settings: S3StorageSettings) -> anyhow::Result<Self> {
+        let region = s3::Region::Custom {
+            region: "custom".to_string(),
+            endpoint: settings.endpoint,
+        };
+        let bucket = s3::Bucket::new(
+            &settings.bucket,
+            region,
+            s3::creds::Credentials::new(
+                Some(&settings.access_key_id),
+                Some(&settings.secret_access_key),
+                None,
+                None,
+                None,
+            )
+            .context("credentials initialization failed")?,
+        )
+        .context("bucket initialization failed")?;
+
+        if settings.validate_on_initialization
+            && !bucket.exists().await.context("bucket validation failed")?
+        {
+            anyhow::bail!("bucket ({}) is not available", settings.bucket);
+        }
+
+        Ok(S3Storage {
+            _bucket: bucket.into(),
+        })
+    }
+}

--- a/da-indexer/da-indexer-logic/src/s3_storage.rs
+++ b/da-indexer/da-indexer-logic/src/s3_storage.rs
@@ -123,7 +123,7 @@ impl S3Storage {
                         .await
                         .context(format!("put object {} into s3 storage failed", object.key))?;
 
-                    // Have to always be false, as the integrity should already be validated
+                    // Have to always be valid, as the integrity should already be validated
                     // by S3 storage as we provided 'Content-MD5' header. But added additional
                     // check here just in case the header is not supported by the given storage.
                     Self::validate_object_e_tag(&object.key, response.e_tag(), content_md5)?;

--- a/da-indexer/da-indexer-migration/src/lib.rs
+++ b/da-indexer/da-indexer-migration/src/lib.rs
@@ -3,6 +3,7 @@ use sea_orm_migration::sea_orm::{Statement, TransactionTrait};
 
 mod m20220101_000001_create_table;
 mod m20240523_095338_eigenda_tables;
+mod m20250623_122642_alter_blob_tables_add_data_s3_object_key_column;
 
 pub struct Migrator;
 
@@ -12,6 +13,7 @@ impl MigratorTrait for Migrator {
         vec![
             Box::new(m20220101_000001_create_table::Migration),
             Box::new(m20240523_095338_eigenda_tables::Migration),
+            Box::new(m20250623_122642_alter_blob_tables_add_data_s3_object_key_column::Migration),
         ]
     }
 }

--- a/da-indexer/da-indexer-migration/src/m20250623_122642_alter_blob_tables_add_data_s3_object_key_column.rs
+++ b/da-indexer/da-indexer-migration/src/m20250623_122642_alter_blob_tables_add_data_s3_object_key_column.rs
@@ -1,0 +1,34 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            ALTER TABLE "celestia_blobs"
+                ALTER COLUMN "data" DROP NOT NULL,
+                ADD COLUMN "data_s3_object_key" varchar;
+
+            ALTER TABLE "eigenda_blobs"
+                ALTER COLUMN "data" DROP NOT NULL,
+                ADD COLUMN "data_s3_object_key" varchar;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            ALTER TABLE "celestia_blobs"
+                DROP COLUMN "data_s3_object_key",
+                ALTER COLUMN "data" SET NOT NULL;
+
+            ALTER TABLE "eigenda_blobs"
+                DROP COLUMN "data_s3_object_key",
+                ALTER COLUMN "data" SET NOT NULL;
+        "#;
+
+        crate::from_sql(manager, sql).await
+    }
+}

--- a/da-indexer/da-indexer-migration/src/m20250623_122642_alter_blob_tables_add_data_s3_object_key_column.rs
+++ b/da-indexer/da-indexer-migration/src/m20250623_122642_alter_blob_tables_add_data_s3_object_key_column.rs
@@ -9,11 +9,17 @@ impl MigrationTrait for Migration {
         let sql = r#"
             ALTER TABLE "celestia_blobs"
                 ALTER COLUMN "data" DROP NOT NULL,
-                ADD COLUMN "data_s3_object_key" varchar;
+                ADD COLUMN "data_s3_object_key" varchar,
+                ADD CONSTRAINT "data_integrity"
+                    CHECK ("data" IS NOT NULL AND "data_s3_object_key" IS NULL 
+                        OR "data" IS NULL AND "data_s3_object_key" IS NOT NULL);
 
             ALTER TABLE "eigenda_blobs"
                 ALTER COLUMN "data" DROP NOT NULL,
-                ADD COLUMN "data_s3_object_key" varchar;
+                ADD COLUMN "data_s3_object_key" varchar,
+                ADD CONSTRAINT "data_integrity"
+                    CHECK ("data" IS NOT NULL AND "data_s3_object_key" IS NULL 
+                        OR "data" IS NULL AND "data_s3_object_key" IS NOT NULL);
         "#;
         crate::from_sql(manager, sql).await
     }

--- a/da-indexer/da-indexer-server/src/indexer.rs
+++ b/da-indexer/da-indexer-server/src/indexer.rs
@@ -1,4 +1,4 @@
-use da_indexer_logic::{indexer::Indexer, settings::IndexerSettings};
+use da_indexer_logic::{indexer::Indexer, s3_storage::S3Storage, settings::IndexerSettings};
 use sea_orm::DatabaseConnection;
 use std::sync::Arc;
 use tokio::time::sleep;
@@ -6,12 +6,14 @@ use tokio::time::sleep;
 pub async fn run(
     settings: IndexerSettings,
     db_connection: DatabaseConnection,
+    s3_storage: Option<S3Storage>,
 ) -> Result<(), anyhow::Error> {
     let db_connection = Arc::new(db_connection);
 
     // If the first connect fails, the function will return an error immediately.
     // All subsequent reconnects are done inside tokio task and will not propagate to above.
-    let mut indexer = Indexer::new(db_connection.clone(), settings.clone()).await?;
+    let mut indexer =
+        Indexer::new(db_connection.clone(), s3_storage.clone(), settings.clone()).await?;
     let delay = settings.restart_delay;
 
     tokio::spawn(async move {
@@ -30,7 +32,9 @@ pub async fn run(
 
                 tracing::info!("re-connecting to rpc");
 
-                match Indexer::new(db_connection.clone(), settings.clone()).await {
+                match Indexer::new(db_connection.clone(), s3_storage.clone(), settings.clone())
+                    .await
+                {
                     Ok(new_indexer) => {
                         indexer = new_indexer;
                         break;

--- a/da-indexer/da-indexer-server/src/lib.rs
+++ b/da-indexer/da-indexer-server/src/lib.rs
@@ -7,3 +7,57 @@ mod settings;
 pub use indexer::run as run_indexer;
 pub use server::run as run_server;
 pub use settings::Settings;
+
+/********** run application **********/
+
+use anyhow::Context;
+use blockscout_service_launcher::database;
+use da_indexer_logic::{celestia::l2_router::L2Router, s3_storage::S3Storage};
+use migration::Migrator;
+
+const SERVICE_NAME: &str = "da_indexer";
+
+pub async fn run(settings: Settings) -> Result<(), anyhow::Error> {
+    blockscout_service_launcher::tracing::init_logs(
+        SERVICE_NAME,
+        &settings.tracing,
+        &settings.jaeger,
+    )?;
+
+    let db_connection = match settings.database.clone() {
+        Some(database_settings) => {
+            Some(database::initialize_postgres::<Migrator>(&database_settings).await?)
+        }
+        None => None,
+    };
+
+    let s3_storage = match settings.s3_storage.clone() {
+        Some(s3_storage_settings) => Some(
+            S3Storage::new(s3_storage_settings)
+                .await
+                .context("s3 storage initialization failed")?,
+        ),
+        None => None,
+    };
+
+    let mut l2_router = None;
+    if let Some(settings) = settings.l2_router.clone() {
+        l2_router = Some(L2Router::from_settings(settings)?);
+    }
+
+    if let Some(indexer_settings) = settings.indexer.clone() {
+        let db_connection = db_connection.expect("database is required for the indexer");
+        run_indexer(indexer_settings, db_connection, s3_storage.clone()).await?;
+    }
+
+    let db_connection = match settings.database.clone() {
+        Some(mut database_settings) => {
+            database_settings.create_database = false;
+            database_settings.run_migrations = false;
+            Some(database::initialize_postgres::<Migrator>(&database_settings).await?)
+        }
+        None => None,
+    };
+
+    run_server(settings, db_connection, s3_storage, l2_router).await
+}

--- a/da-indexer/da-indexer-server/src/main.rs
+++ b/da-indexer/da-indexer-server/src/main.rs
@@ -1,55 +1,8 @@
-use anyhow::Context;
-use blockscout_service_launcher::{database, launcher::ConfigSettings};
-use da_indexer_logic::{celestia::l2_router::L2Router, s3_storage::S3Storage};
-use da_indexer_server::{run_indexer, run_server, Settings};
-use migration::Migrator;
-
-const SERVICE_NAME: &str = "da_indexer";
+use blockscout_service_launcher::launcher::ConfigSettings;
+use da_indexer_server::Settings;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
     let settings = Settings::build().expect("failed to read config");
-
-    blockscout_service_launcher::tracing::init_logs(
-        SERVICE_NAME,
-        &settings.tracing,
-        &settings.jaeger,
-    )?;
-
-    let db_connection = match settings.database.clone() {
-        Some(database_settings) => {
-            Some(database::initialize_postgres::<Migrator>(&database_settings).await?)
-        }
-        None => None,
-    };
-
-    let s3_storage = match settings.s3_storage.clone() {
-        Some(s3_storage_settings) => Some(
-            S3Storage::new(s3_storage_settings)
-                .await
-                .context("s3 storage initialization failed")?,
-        ),
-        None => None,
-    };
-
-    let mut l2_router = None;
-    if let Some(settings) = settings.l2_router.clone() {
-        l2_router = Some(L2Router::from_settings(settings)?);
-    }
-
-    if let Some(indexer_settings) = settings.indexer.clone() {
-        let db_connection = db_connection.expect("database is required for the indexer");
-        run_indexer(indexer_settings, db_connection, s3_storage.clone()).await?;
-    }
-
-    let db_connection = match settings.database.clone() {
-        Some(mut database_settings) => {
-            database_settings.create_database = false;
-            database_settings.run_migrations = false;
-            Some(database::initialize_postgres::<Migrator>(&database_settings).await?)
-        }
-        None => None,
-    };
-
-    run_server(settings, db_connection, s3_storage, l2_router).await
+    da_indexer_server::run(settings).await
 }

--- a/da-indexer/da-indexer-server/src/server.rs
+++ b/da-indexer/da-indexer-server/src/server.rs
@@ -13,6 +13,7 @@ use da_indexer_proto::blockscout::da_indexer::v1::{
 };
 use sea_orm::DatabaseConnection;
 
+use da_indexer_logic::s3_storage::S3Storage;
 use std::{path::PathBuf, sync::Arc};
 
 const SERVICE_NAME: &str = "da_indexer";
@@ -52,11 +53,16 @@ impl launcher::HttpRouter for Router {
 pub async fn run(
     settings: Settings,
     database_connection: Option<DatabaseConnection>,
+    s3_storage: Option<S3Storage>,
     l2_router: Option<L2Router>,
 ) -> Result<(), anyhow::Error> {
     let health = Arc::new(HealthService::default());
-    let celestia = Arc::new(CelestiaService::new(database_connection.clone(), l2_router));
-    let eigenda = Arc::new(EigenDaService::new(database_connection.clone()));
+    let celestia = Arc::new(CelestiaService::new(
+        database_connection.clone(),
+        s3_storage.clone(),
+        l2_router,
+    ));
+    let eigenda = Arc::new(EigenDaService::new(database_connection.clone(), s3_storage));
 
     let router = Router {
         health,

--- a/da-indexer/da-indexer-server/src/services/celestia.rs
+++ b/da-indexer/da-indexer-server/src/services/celestia.rs
@@ -1,23 +1,34 @@
+use super::bytes_from_hex_or_base64;
 use crate::proto::celestia_service_server::CelestiaService as Celestia;
 use base64::prelude::*;
-use da_indexer_logic::celestia::{l2_router::L2Router, repository::blobs};
+use da_indexer_logic::{
+    celestia::{l2_router::L2Router, repository::blobs},
+    s3_storage::S3Storage,
+};
 use da_indexer_proto::blockscout::da_indexer::v1::{
     CelestiaBlob, CelestiaBlobId, CelestiaL2BatchMetadata, GetCelestiaBlobRequest,
 };
 use sea_orm::DatabaseConnection;
 use tonic::{Request, Response, Status};
 
-use super::bytes_from_hex_or_base64;
-
 #[derive(Default)]
 pub struct CelestiaService {
     db: Option<DatabaseConnection>,
+    _s3_storage: Option<S3Storage>,
     l2_router: Option<L2Router>,
 }
 
 impl CelestiaService {
-    pub fn new(db: Option<DatabaseConnection>, l2_router: Option<L2Router>) -> Self {
-        Self { db, l2_router }
+    pub fn new(
+        db: Option<DatabaseConnection>,
+        s3_storage: Option<S3Storage>,
+        l2_router: Option<L2Router>,
+    ) -> Self {
+        Self {
+            db,
+            _s3_storage: s3_storage,
+            l2_router,
+        }
     }
 }
 

--- a/da-indexer/da-indexer-server/src/services/eigenda.rs
+++ b/da-indexer/da-indexer-server/src/services/eigenda.rs
@@ -1,20 +1,23 @@
+use super::bytes_from_hex_or_base64;
 use crate::proto::eigen_da_service_server::EigenDaService as EigenDa;
 use base64::prelude::*;
-use da_indexer_logic::eigenda::repository::blobs;
+use da_indexer_logic::{eigenda::repository::blobs, s3_storage::S3Storage};
 use da_indexer_proto::blockscout::da_indexer::v1::{EigenDaBlob, GetEigenDaBlobRequest};
 use sea_orm::DatabaseConnection;
 use tonic::{Request, Response, Status};
 
-use super::bytes_from_hex_or_base64;
-
 #[derive(Default)]
 pub struct EigenDaService {
     db: Option<DatabaseConnection>,
+    _s3_storage: Option<S3Storage>,
 }
 
 impl EigenDaService {
-    pub fn new(db: Option<DatabaseConnection>) -> Self {
-        Self { db }
+    pub fn new(db: Option<DatabaseConnection>, s3_storage: Option<S3Storage>) -> Self {
+        Self {
+            db,
+            _s3_storage: s3_storage,
+        }
     }
 }
 

--- a/da-indexer/da-indexer-server/src/services/mod.rs
+++ b/da-indexer/da-indexer-server/src/services/mod.rs
@@ -18,7 +18,7 @@ pub fn bytes_from_hex_or_base64(s: &str, name: &str) -> Result<Vec<u8>, Status> 
         .map(|b| b.to_vec())
         .or_else(|_| BASE64_STANDARD.decode(s))
         .map_err(|err| {
-            tracing::error!(error = ?err, "failed to decode {}", name);
-            Status::invalid_argument(format!("failed to decode {}", name))
+            tracing::error!(error = ?err, "failed to decode {name}");
+            Status::invalid_argument(format!("failed to decode {name}"))
         })
 }

--- a/da-indexer/da-indexer-server/src/settings.rs
+++ b/da-indexer/da-indexer-server/src/settings.rs
@@ -4,7 +4,8 @@ use blockscout_service_launcher::{
     tracing::{JaegerSettings, TracingSettings},
 };
 use da_indexer_logic::{
-    celestia::l2_router::settings::L2RouterSettings, settings::IndexerSettings,
+    celestia::l2_router::settings::L2RouterSettings, s3_storage::S3StorageSettings,
+    settings::IndexerSettings,
 };
 use serde::Deserialize;
 use std::path::PathBuf;
@@ -24,6 +25,7 @@ pub struct Settings {
     pub swagger_path: PathBuf,
 
     pub database: Option<DatabaseSettings>,
+    pub s3_storage: Option<S3StorageSettings>,
     pub indexer: Option<IndexerSettings>,
     pub l2_router: Option<L2RouterSettings>,
 }
@@ -50,6 +52,7 @@ impl Settings {
                 create_database: Default::default(),
                 run_migrations: Default::default(),
             }),
+            s3_storage: None,
             indexer: Some(Default::default()),
             l2_router: None,
         }

--- a/da-indexer/justfile
+++ b/da-indexer/justfile
@@ -8,8 +8,17 @@ db-password := env_var_or_default('DB_PASSWORD', "admin")
 db-name := env_var_or_default('DB_NAME', "da_indexer")
 export DATABASE_URL := "postgres://" + db-user + ":" + db-password + "@" + db-host + ":" + db-port + "/" + db-name
 
+s3-host := env_var_or_default('S3_HOST', "localhost")
+s3-port := env_var_or_default('S3_PORT', "9000")
+s3-access-key-id := env_var_or_default('S3_ACCESS_KEY_ID', "minioadmin")
+s3-secret-access-key := env_var_or_default('S3_SECRET_ACCESS_KEY', "minioadmin")
+s3-bucket := env_var_or_default('S3_BUCKET', "bucket")
+
 docker-name := env_var_or_default('DOCKER_NAME', "da-indexer-postgres")
+s3-docker-name := env_var_or_default('S3_DOCKER_NAME', "da-indexer-minio")
+
 test-db-port := env_var_or_default('TEST_DB_PORT', "9433")
+test-s3-port := env_var_or_default('TEST_S3_PORT', "9990")
 
 
 start-postgres:
@@ -22,15 +31,23 @@ start-postgres:
 stop-postgres:
     docker kill {{docker-name}}
 
+start-minio:
+    docker run -p {{s3-port}}:9000 --name {{s3-docker-name}} --rm -d quay.io/minio/minio server /data
+
+stop-minio:
+    docker kill {{s3-docker-name}}
+
 test *args:
-    cargo test {{args}} -- --include-ignored
+    S3_ENDPOINT="http://{{s3-host}}:{{test-s3-port}}" S3_ACCESS_KEY_ID="{{s3-access-key-id}}" S3_SECRET_ACCESS_KEY="{{s3-secret-access-key}}" cargo test {{args}} -- --include-ignored
 
-test-with-db *args:
+test-with-services *args:
     -just db-port="{{test-db-port}}" db-name="" docker-name="{{docker-name}}-test" start-postgres
-    just db-port="{{test-db-port}}" db-name=""                                    test {{args}}
+    -just s3-port="{{test-s3-port}}" s3-bucket="test" s3-docker-name="{{s3-docker-name}}-test" start-minio
+    just db-port="{{test-db-port}}" db-name="" s3-port={{test-s3-port}} test {{args}}
 
-stop-test-postgres:
+stop-test-services:
     just docker-name="{{docker-name}}-test" stop-postgres
+    just s3-docker-name="{{s3-docker-name}}-test" stop-minio
 
 run:
     DA_INDEXER__DATABASE__CONNECT__URL={{DATABASE_URL}} DA_INDEXER__CONFIG=./da-indexer-server/config/celestia.toml cargo run --bin da-indexer-server


### PR DESCRIPTION
Closes blobs indexing and retrieval part of #1426. The migration of existing blob data from database into s3 storage will be added in a separate PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional S3-compatible storage support for blob data, enabling storage and retrieval from S3 or compatible services.
  * Introduced configuration options for S3 storage, including endpoint, credentials, bucket management, and concurrency controls.
  * Enhanced APIs, indexer, and server services to support blob retrieval from both database and S3 storage.

* **Improvements**
  * Updated database schema to allow blobs to store either inline data or an S3 object key with enforced mutual exclusivity.
  * Added Prometheus metrics for monitoring S3 bulk upload operations.
  * Improved error logging formatting for better clarity.

* **Chores**
  * Updated dependencies and test utilities to support S3 integration and schema changes.
  * Refactored tests to validate behavior with and without S3 storage.
  * Added workflow and development environment support for running MinIO as a local S3-compatible service.
  * Simplified server startup by centralizing initialization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->