### PR TITLE
feat(proxy-verifier): add 'is_testnet' flag to Chain response

### DIFF
--- a/proxy-verifier/config/chains.json
+++ b/proxy-verifier/config/chains.json
@@ -8,5 +8,11 @@
     "name": "Base Mainnet",
     "api_url": "https://base.blockscout.com/api/",
     "sensitive_api_key": null
+  },
+  "11155111": {
+    "name": "Ethereum Sepolia",
+    "api_url": "https://eth-sepolia.blockscout.com/api/",
+    "sensitive_api_key": null,
+    "is_testnet": true
   }
 }

--- a/proxy-verifier/proxy-verifier-proto/proto/v1/proxy-verifier.proto
+++ b/proxy-verifier/proxy-verifier-proto/proto/v1/proxy-verifier.proto
@@ -151,6 +151,7 @@ message Chain {
   string id = 1;
   string name = 2;
   string icon_url = 3;
+  bool is_testnet = 4;
 }
 
 message Contract {

--- a/proxy-verifier/proxy-verifier-proto/swagger/v1/proxy-verifier.swagger.yaml
+++ b/proxy-verifier/proxy-verifier-proto/swagger/v1/proxy-verifier.swagger.yaml
@@ -260,6 +260,8 @@ definitions:
         type: string
       iconUrl:
         type: string
+      isTestnet:
+        type: boolean
   v1Compiler:
     type: object
     properties:

--- a/proxy-verifier/proxy-verifier-server/src/config.rs
+++ b/proxy-verifier/proxy-verifier-server/src/config.rs
@@ -65,4 +65,6 @@ pub struct ChainSettings {
     pub api_url: url::Url,
     pub icon_url: Option<url::Url>,
     pub sensitive_api_key: Option<String>,
+    #[serde(default)]
+    pub is_testnet: bool,
 }

--- a/proxy-verifier/proxy-verifier-server/src/services/proxy.rs
+++ b/proxy-verifier/proxy-verifier-server/src/services/proxy.rs
@@ -90,6 +90,7 @@ async fn list_chains(proxy: &ProxyService) -> Vec<Chain> {
                 id: id.clone(),
                 name: settings.name,
                 icon_url,
+                is_testnet: settings.is_testnet,
             }
         })
         .collect()

--- a/proxy-verifier/proxy-verifier-server/tests/integration/list_chains.rs
+++ b/proxy-verifier/proxy-verifier-server/tests/integration/list_chains.rs
@@ -2,6 +2,10 @@ use crate::helpers;
 use blockscout_service_launcher::test_server;
 use pretty_assertions::assert_eq;
 use proxy_verifier_proto::blockscout::proxy_verifier::v1 as proxy_verifier_v1;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ops::Deref,
+};
 
 #[tokio::test]
 async fn test_chains_listed_in_correct_order() {
@@ -49,4 +53,67 @@ async fn test_chains_listed_in_correct_order() {
         actual_chain_ids.as_slice(),
         "Invalid order for `api/v1/verification/config` endpoint"
     );
+}
+
+#[tokio::test]
+async fn test_returns_correct_is_testnet_field() {
+    let config_file = helpers::create_temp_config(serde_json::json!({
+        "1": {
+            "name": "name",
+            "api_url": "https://name.blockscout.com/api/",
+            "sensitive_api_key": "null"
+        },
+        "2": {
+            "name": "name",
+            "api_url": "https://name.blockscout.com/api/",
+            "sensitive_api_key": "null",
+            "is_testnet": false
+        },
+        "3": {
+            "name": "name",
+            "api_url": "https://name.blockscout.com/api/",
+            "sensitive_api_key": "null",
+            "is_testnet": true
+        },
+    }));
+
+    let base = helpers::init_proxy_verifier_server(|mut settings| {
+        settings.chains_config = Some(config_file.as_ref().to_path_buf());
+        settings
+    })
+    .await;
+
+    let testnet_ids = BTreeSet::from(["3"]);
+
+    // Check chains from `api/v1/chains` endpoint
+    let response: proxy_verifier_v1::ListChainsResponse =
+        test_server::send_get_request(&base, "/api/v1/chains").await;
+    let chain_to_flags: BTreeMap<_, _> = response
+        .chains
+        .into_iter()
+        .map(|chain| (chain.id, chain.is_testnet))
+        .collect();
+    for (chain_id, is_testnet_value) in chain_to_flags.iter() {
+        assert_eq!(
+            testnet_ids.contains(chain_id.deref()),
+            *is_testnet_value,
+            "Invalid is_testnet values for {chain_id} in `api/v1/chains` endpoint"
+        );
+    }
+
+    // Check chains from `api/v1/verification/config` endpoint
+    let response: proxy_verifier_v1::VerificationConfig =
+        test_server::send_get_request(&base, "/api/v1/verification/config").await;
+    let chain_to_flags: BTreeMap<_, _> = response
+        .chains
+        .into_iter()
+        .map(|chain| (chain.id, chain.is_testnet))
+        .collect();
+    for (chain_id, is_testnet_value) in chain_to_flags.iter() {
+        assert_eq!(
+            testnet_ids.contains(chain_id.deref()),
+            *is_testnet_value,
+            "Invalid is_testnet values for {chain_id} in `api/v1/verification/config` endpoint"
+        );
+    }
 }


### PR DESCRIPTION
Required for https://github.com/blockscout/frontend/issues/2836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for identifying testnet chains, including a new entry for the Ethereum Sepolia testnet.
  * API responses now include an isTestnet field to indicate whether a blockchain network is a testnet.

* **Bug Fixes**
  * Ensured accurate reporting of the isTestnet field in API responses for all supported chains.

* **Tests**
  * Introduced integration tests to verify the correct handling of the isTestnet field in API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->