### PR TITLE
fix(da-indexer): make disperser decoding message size configurable

### DIFF
--- a/da-indexer/da-indexer-logic/src/eigenda/client.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/client.rs
@@ -22,13 +22,19 @@ pub struct Client {
 }
 
 impl Client {
-    pub async fn new(disperser_endpoint: &str, retry_delays: Vec<u64>) -> Result<Self> {
+    pub async fn new(
+        disperser_endpoint: &str,
+        disperser_max_decoding_message_size: usize,
+        retry_delays: Vec<u64>,
+    ) -> Result<Self> {
         // Is required as rustls cannot unambiguously determine the default provider
         // out of enabled features only. This happens because different external crates
         // depend on rustls and as a result both `ring` and `aws-lc-rs` features are enabled.
         crypto::CryptoProvider::install_default(crypto::ring::default_provider())
             .expect("installing default CryptoProvider failed");
-        let client = DisperserClient::connect(disperser_endpoint.to_string()).await?;
+        let client = DisperserClient::connect(disperser_endpoint.to_string())
+            .await?
+            .max_decoding_message_size(disperser_max_decoding_message_size);
         let retry_delays = retry_delays.into_iter().map(Duration::from_secs).collect();
         Ok(Self {
             retry_delays,

--- a/da-indexer/da-indexer-logic/src/eigenda/da.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/da.rs
@@ -35,7 +35,12 @@ impl EigenDA {
         settings: IndexerSettings,
     ) -> Result<Self> {
         let provider = EthProvider::new(&settings.rpc.url).await?;
-        let client = Client::new(&settings.disperser_url, vec![5, 15, 30]).await?;
+        let client = Client::new(
+            &settings.disperser_url,
+            settings.disperser_max_decoding_message_size,
+            vec![5, 15, 30],
+        )
+        .await?;
         let start_from = settings
             .start_block
             .unwrap_or(provider.get_block_number().await?);

--- a/da-indexer/da-indexer-logic/src/eigenda/settings.rs
+++ b/da-indexer/da-indexer-logic/src/eigenda/settings.rs
@@ -6,12 +6,19 @@ use serde_with::serde_as;
 #[serde(deny_unknown_fields)]
 pub struct IndexerSettings {
     pub disperser_url: String,
+    #[serde(default = "disperser_max_decoding_message_size")]
+    pub disperser_max_decoding_message_size: usize,
     pub address: String,
     pub rpc: RpcSettings,
     pub start_block: Option<u64>,
     pub creation_block: u64,
     pub save_batch_size: u64,
     pub pruning_block_threshold: u64,
+}
+
+/// 32 Mb
+fn disperser_max_decoding_message_size() -> usize {
+    32 * 1024 * 1024
 }
 
 #[serde_as]
@@ -26,6 +33,7 @@ impl Default for IndexerSettings {
     fn default() -> Self {
         Self {
             disperser_url: "https://disperser-holesky.eigenda.xyz:443".to_string(),
+            disperser_max_decoding_message_size: disperser_max_decoding_message_size(),
             address: "0xD4A7E1Bd8015057293f0D0A557088c286942e84b".to_string(),
             rpc: RpcSettings {
                 url: "https://holesky.drpc.org".to_string(),


### PR DESCRIPTION
Set default value to 32 Mb. 

Should fix the following errors:
```
failed to fetch blob: Status {
    code: OutOfRange,
    message: "Error, decoded message length too large: found 16777221 bytes, the limit is: 4194304 bytes",
    metadata: MetadataMap {
        headers: {
            "date": "Tue, 22 Jul 2025 21:58:48 GMT",
            "content-type": "application/grpc",
            "strict-transport-security": "max-age=31536000; includeSubDomains",
            "cf-cache-status": "DYNAMIC",
            "set-cookie": "__cf_bm=oXvMurqwyTrFiY3C3gZSDeJAlZAZSFqhG.MwwSIKAP0-1753221528-1.0.1.1-o_52fZB1yxdlw0jAXPPPtMilzjGpMJh0jiAgwRJISVMfmd1hu8iV0M8LNKz89hRdm_sDlxPBL98UHD0aRtHJ6w.sip6bMl3crc4lfu1cs6s; path=/; expires=Tue, 22-Jul-25 22:28:48 GMT; domain=.eigenda.xyz; HttpOnly; Secure; SameSite=None",
            "server": "cloudflare",
            "cf-ray": "96363397bd1f0b5e-AMS",
        },
    },
    source: None,
}, retrying batch_id=255657 blob_index=68 delay=5s
```