### PR TITLE
feat(da-indexer): add s3 storage timeout settings

### DIFF
--- a/da-indexer/da-indexer-logic/src/common/tests.rs
+++ b/da-indexer/da-indexer-logic/src/common/tests.rs
@@ -34,6 +34,7 @@ mod s3_storage {
             save_concurrency_limit: None,
             create_bucket: false,
             validate_on_initialization: true,
+            timeout: Default::default(),
         })
         .await
         .expect("cannot initialize s3 storage")


### PR DESCRIPTION
Periodically data cannot be written inside minio storage. We would like to specify timeout values, thus