### PR TITLE
Evgenkor/multichain/blocks to bigint

### DIFF
--- a/multichain-aggregator/multichain-aggregator-entity/src/block_ranges.rs
+++ b/multichain-aggregator/multichain-aggregator-entity/src/block_ranges.rs
@@ -5,8 +5,8 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "block_ranges")]
 pub struct Model {
-    pub min_block_number: i32,
-    pub max_block_number: i32,
+    pub min_block_number: i64,
+    pub max_block_number: i64,
     #[sea_orm(primary_key, auto_increment = false)]
     pub chain_id: i64,
     pub created_at: DateTime,

--- a/multichain-aggregator/multichain-aggregator-entity/src/tokens.rs
+++ b/multichain-aggregator/multichain-aggregator-entity/src/tokens.rs
@@ -6,6 +6,12 @@ use sea_orm::entity::prelude::*;
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq)]
 #[sea_orm(table_name = "tokens")]
 pub struct Model {
+    #[sea_orm(
+        primary_key,
+        auto_increment = false,
+        column_type = "VarBinary(StringLen::None)"
+    )]
+    pub address_hash: Vec<u8>,
     #[sea_orm(primary_key, auto_increment = false)]
     pub chain_id: i64,
     #[sea_orm(column_type = "Text", nullable)]
@@ -14,12 +20,6 @@ pub struct Model {
     pub symbol: Option<String>,
     pub decimals: Option<i16>,
     pub token_type: TokenType,
-    #[sea_orm(
-        primary_key,
-        auto_increment = false,
-        column_type = "VarBinary(StringLen::None)"
-    )]
-    pub address_hash: Vec<u8>,
     #[sea_orm(column_type = "Text", nullable)]
     pub icon_url: Option<String>,
     pub fiat_value: Option<Decimal>,

--- a/multichain-aggregator/multichain-aggregator-logic/src/services/channel.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/services/channel.rs
@@ -22,5 +22,5 @@ impl ChannelHandler for Channel {
 #[derive(Serialize)]
 pub struct LatestBlockUpdateMessage {
     pub chain_id: ChainId,
-    pub block_number: i32,
+    pub block_number: i64,
 }

--- a/multichain-aggregator/multichain-aggregator-logic/src/types/block_ranges.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/block_ranges.rs
@@ -13,8 +13,8 @@ impl From<BlockRange> for Model {
     fn from(v: BlockRange) -> Self {
         Self {
             chain_id: v.chain_id,
-            min_block_number: v.min_block_number as i32,
-            max_block_number: v.max_block_number as i32,
+            min_block_number: v.min_block_number as i64,
+            max_block_number: v.max_block_number as i64,
             created_at: Default::default(),
             updated_at: Default::default(),
         }

--- a/multichain-aggregator/multichain-aggregator-migration/src/lib.rs
+++ b/multichain-aggregator/multichain-aggregator-migration/src/lib.rs
@@ -9,6 +9,7 @@ mod m20250604_091215_add_token_and_coin_balances;
 mod m20250611_103754_add_counters;
 mod m20250721_093013_make_token_balance_nullable;
 mod m20250723_084105_add_tokens;
+mod m20250729_111157_change_block_ranges_block_number_to_bigint;
 
 pub struct Migrator;
 
@@ -24,6 +25,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250611_103754_add_counters::Migration),
             Box::new(m20250721_093013_make_token_balance_nullable::Migration),
             Box::new(m20250723_084105_add_tokens::Migration),
+            Box::new(m20250729_111157_change_block_ranges_block_number_to_bigint::Migration),
         ]
     }
 }

--- a/multichain-aggregator/multichain-aggregator-migration/src/m20250729_111157_change_block_ranges_block_number_to_bigint.rs
+++ b/multichain-aggregator/multichain-aggregator-migration/src/m20250729_111157_change_block_ranges_block_number_to_bigint.rs
@@ -1,0 +1,23 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            ALTER TABLE block_ranges ALTER COLUMN min_block_number TYPE bigint;
+            ALTER TABLE block_ranges ALTER COLUMN max_block_number TYPE bigint;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let sql = r#"
+            ALTER TABLE block_ranges ALTER COLUMN min_block_number TYPE integer;
+            ALTER TABLE block_ranges ALTER COLUMN max_block_number TYPE integer;
+        "#;
+        crate::from_sql(manager, sql).await
+    }
+}

--- a/multichain-aggregator/multichain-aggregator-server/tests/import.rs
+++ b/multichain-aggregator/multichain-aggregator-server/tests/import.rs
@@ -46,7 +46,7 @@ async fn test_import_interop_messages() {
     .await;
 
     let get_token = || async {
-        entity::tokens::Entity::find_by_id((1, token_address_hash.clone().to_vec()))
+        entity::tokens::Entity::find_by_id((token_address_hash.clone().to_vec(), 1))
             .one(db.client().as_ref())
             .await
             .unwrap()


### PR DESCRIPTION
### Change block_ranges min/max block number columns to bigint

This PR introduces a database migration that changes the types of the `min_block_number` and `max_block_number` columns in the `block_ranges` table from `integer` to `bigint`. This allows the system to support block numbers larger than 2,147,483,647, ensuring compatibility with larger chains.

- Migration is non-destructive; all existing data is preserved.
- Includes up and down migration scripts.
- Prepares the codebase for future updates to use i64/bigint in application logic.

This PR is needed to proceed working with #1454. I would greatly appreciate it if you could review it at your earliest convenience.