### PR TITLE
feat(multi): allow many token type filters

### DIFF
--- a/multichain-aggregator/Cargo.lock
+++ b/multichain-aggregator/Cargo.lock
@@ -3327,6 +3327,7 @@ dependencies = [
  "blockscout-service-launcher",
  "config 0.13.4",
  "env-collector",
+ "itertools 0.14.0",
  "multichain-aggregator-entity",
  "multichain-aggregator-logic",
  "multichain-aggregator-migration",

--- a/multichain-aggregator/Cargo.toml
+++ b/multichain-aggregator/Cargo.toml
@@ -64,6 +64,7 @@ cached = { version = "0.55", default-features = false }
 config = "0.13"
 chrono = "0.4.38"
 env-collector = { git = "https://github.com/blockscout/blockscout-rs", version = "0.3.0" }
+itertools = "0.14"
 regex = "1.10"
 reqwest = "0.12"
 rust_decimal = "1.37"

--- a/multichain-aggregator/multichain-aggregator-logic/src/services/cluster.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/services/cluster.rs
@@ -131,7 +131,7 @@ impl Cluster {
         &self,
         db: &DatabaseConnection,
         address: AddressAlloy,
-        token_type: Option<TokenType>,
+        token_types: Vec<TokenType>,
         page_size: u64,
         page_token: Option<ListAddressTokensPageToken>,
     ) -> Result<
@@ -146,7 +146,7 @@ impl Cluster {
         let res = address_token_balances::list_by_address(
             db,
             address,
-            token_type,
+            token_types,
             cluster_chain_ids,
             page_size,
             page_token,

--- a/multichain-aggregator/multichain-aggregator-proto/proto/v1/cluster-explorer.proto
+++ b/multichain-aggregator/multichain-aggregator-proto/proto/v1/cluster-explorer.proto
@@ -128,7 +128,8 @@ message GetAddressResponse {
 message ListAddressTokensRequest {
   string cluster_id = 1;
   string address_hash = 2;
-  blockscout.multichainAggregator.v1.TokenType type = 3;
+  // List of comma-separated token types to filter by. See `TokenType`.
+  string type = 3;
   optional uint32 page_size = 4;
   optional string page_token = 5;
 }

--- a/multichain-aggregator/multichain-aggregator-proto/src/lib.rs
+++ b/multichain-aggregator/multichain-aggregator-proto/src/lib.rs
@@ -10,7 +10,6 @@ pub mod blockscout {
     }
 
     pub mod cluster_explorer {
-        use crate::blockscout::multichain_aggregator;
         pub mod v1 {
             include!(concat!(
                 env!("OUT_DIR"),

--- a/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
+++ b/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
@@ -171,17 +171,10 @@ paths:
           required: true
           type: string
         - name: type
+          description: List of comma-separated token types to filter by. See `TokenType`.
           in: query
           required: false
           type: string
-          enum:
-            - TOKEN_TYPE_UNSPECIFIED
-            - TOKEN_TYPE_ERC_20
-            - TOKEN_TYPE_ERC_721
-            - TOKEN_TYPE_ERC_1155
-            - TOKEN_TYPE_ERC_404
-            - TOKEN_TYPE_ERC_7802
-          default: TOKEN_TYPE_UNSPECIFIED
         - name: page_size
           in: query
           required: false

--- a/multichain-aggregator/multichain-aggregator-server/Cargo.toml
+++ b/multichain-aggregator/multichain-aggregator-server/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = { workspace = true }
 blockscout-service-launcher = { workspace = true }
 blockscout-chains = { workspace = true }
 config = { workspace = true }
+itertools = { workspace = true }
 sea-orm = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/multichain-aggregator/multichain-aggregator-server/src/services/cluster_explorer.rs
+++ b/multichain-aggregator/multichain-aggregator-server/src/services/cluster_explorer.rs
@@ -1,8 +1,9 @@
 use crate::{
     proto::{cluster_explorer_service_server::ClusterExplorerService, *},
-    services::utils::{PageTokenExtractor, page_token_to_proto, parse_query},
+    services::utils::{PageTokenExtractor, page_token_to_proto, parse_map_result, parse_query},
     settings::ApiSettings,
 };
+use itertools::Itertools;
 use multichain_aggregator_logic::{
     error::ServiceError, services::cluster::Cluster,
     types::addresses::proto_token_type_to_db_token_type,
@@ -133,14 +134,21 @@ impl ClusterExplorerService for ClusterExplorer {
         let inner = request.into_inner();
 
         let cluster = self.try_get_cluster(&inner.cluster_id)?;
-        let token_type = proto_token_type_to_db_token_type(inner.r#type());
+        let token_types = parse_map_result(&inner.r#type, |v| {
+            let val = serde_json::Value::String(v.to_string());
+            serde_json::from_value(val)
+        })?
+        .into_iter()
+        .unique()
+        .filter_map(proto_token_type_to_db_token_type)
+        .collect();
         let address = parse_query(inner.address_hash)?;
 
         let page_size = self.normalize_page_size(inner.page_size);
         let page_token = inner.page_token.extract_page_token()?;
 
         let (tokens, next_page_token) = cluster
-            .list_address_tokens(&self.db, address, token_type, page_size as u64, page_token)
+            .list_address_tokens(&self.db, address, token_types, page_size as u64, page_token)
             .await?;
 
         let items = tokens

--- a/multichain-aggregator/multichain-aggregator-server/src/services/utils.rs
+++ b/multichain-aggregator/multichain-aggregator-server/src/services/utils.rs
@@ -1,6 +1,6 @@
 use multichain_aggregator_logic::page_token::PageTokenFormat;
 use multichain_aggregator_proto::blockscout::multichain_aggregator::v1::Pagination;
-use std::str::FromStr;
+use std::{fmt::Display, str::FromStr};
 use tonic::Status;
 
 #[allow(clippy::result_large_err)]
@@ -10,6 +10,20 @@ where
     <T as FromStr>::Err: std::fmt::Display,
 {
     T::from_str(&input).map_err(|e| Status::invalid_argument(format!("invalid value {input}: {e}")))
+}
+
+#[allow(clippy::result_large_err)]
+#[inline]
+pub fn parse_map_result<'a, E, T, F>(input: &'a str, f: F) -> Result<Vec<T>, Status>
+where
+    E: Display,
+    F: FnMut(&'a str) -> Result<T, E>,
+{
+    input
+        .split(',')
+        .map(f)
+        .collect::<Result<Vec<T>, _>>()
+        .map_err(|e| Status::invalid_argument(format!("invalid argument {input}: {e}")))
 }
 
 pub trait PageTokenExtractor<T: PageTokenFormat> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Address token listing now supports filtering by multiple token types in a single request. Provide a comma-separated list of types in the query to retrieve matching tokens; pagination and ordering remain unchanged.
- Documentation
  - API spec updated: the query parameter “type” is now a free-form, comma-separated string with guidance in the description.
- Chores
  - Added a new shared dependency to improve internal parsing and utility support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->