### PR TITLE
feat(multi): Multiple counters import

### DIFF
--- a/multichain-aggregator/multichain-aggregator-logic/src/repository/counters.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/repository/counters.rs
@@ -42,6 +42,7 @@ where
                 .value(GlobalCountersColumn::UpdatedAt, Expr::current_timestamp())
                 .to_owned(),
         )
+        .do_nothing()
         .exec_without_returning(db)
         .await?;
 

--- a/multichain-aggregator/multichain-aggregator-logic/src/services/import.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/services/import.rs
@@ -60,15 +60,11 @@ pub async fn batch_import(
         .inspect_err(|e| {
             tracing::error!(error = ?e, "failed to upsert tokens");
         })?;
-    if let Some(counters) = request.counters
-        && let Some(global) = counters.global
-    {
-        repository::counters::upsert_chain_counters(&tx, global)
-            .await
-            .inspect_err(|e| {
-                tracing::error!(error = ?e, "failed to upsert chain counters");
-            })?;
-    }
+    repository::counters::upsert_many(&tx, request.counters)
+        .await
+        .inspect_err(|e| {
+            tracing::error!(error = ?e, "failed to upsert chain counters");
+        })?;
 
     tx.commit().await?;
 

--- a/multichain-aggregator/multichain-aggregator-logic/src/types/batch_import_request.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/batch_import_request.rs
@@ -28,7 +28,7 @@ pub struct BatchImportRequest {
     pub address_coin_balances: Vec<AddressCoinBalance>,
     pub address_token_balances: Vec<AddressTokenBalance>,
     pub tokens: Vec<TokenUpdate>,
-    pub counters: Option<Counters>,
+    pub counters: Vec<Counters>,
 }
 
 macro_rules! opt_parse {
@@ -153,8 +153,9 @@ impl TryFrom<proto::BatchImportRequest> for BatchImportRequest {
                 .collect::<Result<Vec<_>, _>>()?,
             counters: value
                 .counters
+                .into_iter()
                 .map(|c| Counters::try_from((chain_id, c)))
-                .transpose()?,
+                .collect::<Result<Vec<_>, _>>()?,
         })
     }
 }

--- a/multichain-aggregator/multichain-aggregator-proto/build.rs
+++ b/multichain-aggregator/multichain-aggregator-proto/build.rs
@@ -48,6 +48,7 @@ fn compile(
         .field_attribute("BatchImportRequest.interop_messages", "#[serde(default)]")
         .field_attribute("BatchImportRequest.address_coin_balances", "#[serde(default)]")
         .field_attribute("BatchImportRequest.address_token_balances", "#[serde(default)]")
+        .field_attribute("BatchImportRequest.counters", "#[serde(default)]")
         .field_attribute("BatchImportRequest.tokens", "#[serde(default)]")
         .field_attribute("BatchImportRequest.AddressImport.token_type", "#[serde(default)]")
         .field_attribute("BatchImportRequest.TokenImport.Metadata.token_type", "#[serde(default)]")

--- a/multichain-aggregator/multichain-aggregator-proto/proto/v1/multichain-aggregator.proto
+++ b/multichain-aggregator/multichain-aggregator-proto/proto/v1/multichain-aggregator.proto
@@ -213,7 +213,7 @@ message BatchImportRequest {
   repeated InteropMessageImport interop_messages = 5;
   repeated AddressCoinBalanceImport address_coin_balances = 6;
   repeated AddressTokenBalanceImport address_token_balances = 7;
-  optional CountersImport counters = 8;
+  repeated CountersImport counters = 8;
   repeated TokenImport tokens = 9;
   string api_key = 10;
 }

--- a/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
+++ b/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
@@ -889,7 +889,10 @@ definitions:
           type: object
           $ref: '#/definitions/BatchImportRequestAddressTokenBalanceImport'
       counters:
-        $ref: '#/definitions/BatchImportRequestCountersImport'
+        type: array
+        items:
+          type: object
+          $ref: '#/definitions/BatchImportRequestCountersImport'
       tokens:
         type: array
         items:


### PR DESCRIPTION
This PR introduces bulk counters import for the chain. It is intended for importing historical data.

Old import scheme:
```
{
  "chain_id": "10",
  "counters": {
    "timestamp": "1740000000",
    "global_counters": {
      "daily_transactions_number": "1234",
      "total_transactions_number": "999888777",
      "total_addresses_number": "1000000"
    }
  },
  "api_key": "..."
}
```

New import scheme:
```
{
  "chain_id": "10",
  "counters": [
    {
      "timestamp": "1730000000",
      "global_counters": {
        "daily_transactions_number": "989",
        "total_transactions_number": "1237781",
        "total_addresses_number": "1000000"
      }
    },
    {
      "timestamp": "1740000000",
      "global_counters": {
        "daily_transactions_number": "1234",
        "total_transactions_number": "999888777",
        "total_addresses_number": "1000000"
      }
    }
  ],
  "api_key": "..."
}
```