### PR TITLE
feat(multi): change cluster nft type to token

### DIFF
--- a/multichain-aggregator/multichain-aggregator-logic/src/types/address_token_balances.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/address_token_balances.rs
@@ -114,14 +114,12 @@ pub struct ChainValue {
     pub value: BigDecimal,
 }
 
-impl TryFrom<AggregatedAddressTokenBalance>
+impl From<AggregatedAddressTokenBalance>
     for proto::list_address_tokens_response::AggregatedTokenBalanceInfo
 {
-    type Error = ParseError;
-
-    fn try_from(v: AggregatedAddressTokenBalance) -> Result<Self, Self::Error> {
-        Ok(Self {
-            token: Some(v.token.try_into()?),
+    fn from(v: AggregatedAddressTokenBalance) -> Self {
+        Self {
+            token: Some(v.token.into()),
             token_id: v.token_id.map(|t| t.to_string()),
             value: v.value.to_plain_string(),
             chain_values: v
@@ -129,6 +127,6 @@ impl TryFrom<AggregatedAddressTokenBalance>
                 .into_iter()
                 .map(|c| (c.chain_id.to_string(), c.value.to_plain_string()))
                 .collect(),
-        })
+        }
     }
 }

--- a/multichain-aggregator/multichain-aggregator-logic/src/types/tokens.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/tokens.rs
@@ -1,6 +1,5 @@
 use super::ChainId;
 use crate::{
-    error::ParseError,
     proto,
     types::{addresses::db_token_type_to_proto_token_type, sea_orm_wrappers::SeaOrmAddress},
 };
@@ -143,11 +142,9 @@ impl From<ChainInfo> for proto::aggregated_token_info::ChainInfo {
     }
 }
 
-impl TryFrom<AggregatedToken> for proto::AggregatedTokenInfo {
-    type Error = ParseError;
-
-    fn try_from(value: AggregatedToken) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<AggregatedToken> for proto::AggregatedTokenInfo {
+    fn from(value: AggregatedToken) -> Self {
+        Self {
             address_hash: value.address_hash.to_string(),
             circulating_market_cap: value.circulating_market_cap.map(|c| c.to_string()),
             decimals: value.decimals.map(|d| d.to_string()),
@@ -162,7 +159,7 @@ impl TryFrom<AggregatedToken> for proto::AggregatedTokenInfo {
                 value.chain_info.chain_id.to_string(),
                 value.chain_info.into(),
             )]),
-        })
+        }
     }
 }
 

--- a/multichain-aggregator/multichain-aggregator-proto/proto/v1/cluster-explorer.proto
+++ b/multichain-aggregator/multichain-aggregator-proto/proto/v1/cluster-explorer.proto
@@ -259,12 +259,12 @@ message SearchAddressesResponse {
 }
 
 message SearchNftsResponse {
-  repeated blockscout.multichainAggregator.v1.Address items = 1;
+  repeated AggregatedTokenInfo items = 1;
   blockscout.multichainAggregator.v1.Pagination next_page_params = 2;
 }
 
 message SearchTokensResponse {
-  repeated blockscout.multichainAggregator.v1.Token items = 1;
+  repeated AggregatedTokenInfo items = 1;
   blockscout.multichainAggregator.v1.Pagination next_page_params = 2;
 }
 
@@ -289,7 +289,7 @@ message ClusterQuickSearchResponse {
   repeated blockscout.multichainAggregator.v1.Hash transactions = 3;
   repeated blockscout.multichainAggregator.v1.ChainBlockNumber block_numbers = 4;
   repeated blockscout.multichainAggregator.v1.MarketplaceDapp dapps = 5;
-  repeated blockscout.multichainAggregator.v1.Token tokens = 6;
-  repeated blockscout.multichainAggregator.v1.Address nfts = 7;
+  repeated AggregatedTokenInfo tokens = 6;
+  repeated AggregatedTokenInfo nfts = 7;
   repeated blockscout.multichainAggregator.v1.Domain domains = 8;
 }

--- a/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
+++ b/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
@@ -1447,12 +1447,12 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1Token'
+          $ref: '#/definitions/v1AggregatedTokenInfo'
       nfts:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1Address'
+          $ref: '#/definitions/v1AggregatedTokenInfo'
       domains:
         type: array
         items:
@@ -1859,7 +1859,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1Address'
+          $ref: '#/definitions/v1AggregatedTokenInfo'
       next_page_params:
         $ref: '#/definitions/v1Pagination'
   v1SearchTokensResponse:
@@ -1869,7 +1869,7 @@ definitions:
         type: array
         items:
           type: object
-          $ref: '#/definitions/v1Token'
+          $ref: '#/definitions/v1AggregatedTokenInfo'
       next_page_params:
         $ref: '#/definitions/v1Pagination'
   v1SearchTransactionsResponse:

--- a/multichain-aggregator/multichain-aggregator-server/src/services/cluster_explorer.rs
+++ b/multichain-aggregator/multichain-aggregator-server/src/services/cluster_explorer.rs
@@ -162,13 +162,8 @@ impl ClusterExplorerService for ClusterExplorer {
             )
             .await?;
 
-        let items = tokens
-            .into_iter()
-            .map(|t| t.try_into().map_err(ServiceError::from))
-            .collect::<Result<Vec<_>, _>>()?;
-
         Ok(Response::new(ListAddressTokensResponse {
-            items,
+            items: tokens.into_iter().map(|t| t.into()).collect(),
             next_page_params: page_token_to_proto(next_page_token, page_size),
         }))
     }
@@ -196,10 +191,7 @@ impl ClusterExplorerService for ClusterExplorer {
             .await?;
 
         Ok(Response::new(ListClusterTokensResponse {
-            items: tokens
-                .into_iter()
-                .map(|t| t.try_into().map_err(ServiceError::from))
-                .collect::<Result<Vec<_>, _>>()?,
+            items: tokens.into_iter().map(|t| t.into()).collect(),
             next_page_params: page_token_to_proto(next_page_token, page_size),
         }))
     }
@@ -217,9 +209,7 @@ impl ClusterExplorerService for ClusterExplorer {
         let token = cluster.get_aggregated_token(address, chain_id).await?;
 
         Ok(Response::new(GetAggregatedTokenResponse {
-            token: token
-                .map(|t| t.try_into().map_err(ServiceError::from))
-                .transpose()?,
+            token: token.map(|t| t.into()),
         }))
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Breaking Changes
  - Search (tokens & NFTs) and Quick Search responses now return aggregated token info entries instead of prior token/address shapes; clients must update parsing and expectations.

- Improvements
  - Search and quick results include consolidated, richer token information for clearer display and filtering.

- Documentation
  - API specification updated to reflect the new aggregated token response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->