### PR TITLE
fix(proxy-verifier): update recognition of self-destructed contracts to support latest api

### DIFF
--- a/proxy-verifier/proxy-verifier-logic/src/address_details.rs
+++ b/proxy-verifier/proxy-verifier-logic/src/address_details.rs
@@ -121,13 +121,16 @@ async fn fetch_and_apply_smart_contract_endpoint_response(
         Error::internal("Error while retrieving smart-contract details")
     })?;
 
-    let runtime_code = smart_contract.deployed_bytecode.ok_or_else(|| {
-        tracing::warn!(
-            contract_address = address_details.address.to_hex(),
-            "Address is contract, but does not contain runtime code"
-        );
-        Error::no_runtime_code()
-    })?;
+    let runtime_code = smart_contract
+        .deployed_bytecode
+        .filter(|code| !code.is_empty())
+        .ok_or_else(|| {
+            tracing::warn!(
+                contract_address = address_details.address.to_hex(),
+                "Address is contract, but does not contain runtime code"
+            );
+            Error::no_runtime_code()
+        })?;
     address_details.runtime_code = runtime_code.into();
     address_details.creation_code = smart_contract.creation_bytecode.map(|value| value.into());
 

--- a/proxy-verifier/proxy-verifier-server/src/config.rs
+++ b/proxy-verifier/proxy-verifier-server/src/config.rs
@@ -37,7 +37,7 @@ impl ChainsSettings {
         self.0
     }
 
-    pub fn insertion_iter(&self) -> indexmap::map::Iter<String, ChainSettings> {
+    pub fn insertion_iter(&self) -> indexmap::map::Iter<'_, String, ChainSettings> {
         self.inner().get_range(..).unwrap().iter()
     }
 


### PR DESCRIPTION
Before, self-destructed contracts returned `null` in a response to `api/v2/smart-contracts` endpoint. Now they return `"0x"` value instead. This PR makes recognition of such contracts as self-destructed.

Also, fixed cargo clippy warnings