### PR TITLE
fix(stats): reducing CI/CD time

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -58,9 +58,9 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: true
-          docker-images: true
-          swap-storage: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
 
       - name: Set Swap Space
         id: swapfile


### PR DESCRIPTION
To reduce the time needed to complete the autotests, the following cleanup steps were disabled:
- **large-packages** — cleans approximately 4.8 GB, but takes a long time
- **docker-images** — cleans nothing
- **swap-storage** — removes the swap, but it will be restored again in the next step.

So the current setup cleans approximately 22 GB (which is more than needed to pass all tests).
However, the cleanup step now takes about 20 seconds, compared to 2–3 minutes in the default setup.

