### PR TITLE
fix(multi): rename protocol to protocol_id

### DIFF
--- a/multichain-aggregator/multichain-aggregator-logic/src/types/domains.rs
+++ b/multichain-aggregator/multichain-aggregator-logic/src/types/domains.rs
@@ -150,14 +150,14 @@ impl From<DomainInfo> for Domain {
 #[derive(Debug, Clone)]
 pub struct BasicDomainInfo {
     pub name: String,
-    pub protocol: String,
+    pub protocol_id: String,
 }
 
 impl From<DomainInfo> for BasicDomainInfo {
     fn from(v: DomainInfo) -> Self {
         Self {
             name: v.name,
-            protocol: v.protocol.short_name,
+            protocol_id: v.protocol.id,
         }
     }
 }
@@ -166,7 +166,7 @@ impl From<BasicDomainInfo> for proto::BasicDomainInfo {
     fn from(v: BasicDomainInfo) -> Self {
         Self {
             name: v.name,
-            protocol: v.protocol,
+            protocol_id: v.protocol_id,
         }
     }
 }

--- a/multichain-aggregator/multichain-aggregator-proto/proto/v1/cluster-explorer.proto
+++ b/multichain-aggregator/multichain-aggregator-proto/proto/v1/cluster-explorer.proto
@@ -158,7 +158,7 @@ message GetAddressRequest {
 
 message BasicDomainInfo {
   string name = 1;
-  string protocol = 2;
+  string protocol_id = 2;
 }
 
 message GetAddressResponse {

--- a/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
+++ b/multichain-aggregator/multichain-aggregator-proto/swagger/v1/multichain-aggregator.swagger.yaml
@@ -1441,7 +1441,7 @@ definitions:
     properties:
       name:
         type: string
-      protocol:
+      protocol_id:
         type: string
   v1BatchImportRequest:
     type: object


### PR DESCRIPTION
in 
```
curl https://multichain-aggregator.k8s-dev.blockscout.com/api/v1/clusters/interop/addresses/0xE2E631E1485a8d79Eba6716987E2a7949b2C7a49 | jq
```

we can see that protocol is short_name instead of id:

```
[
  {
    "name": "vitalik.eth",
    "protocol": "ENS"
  }
]
```

suggest to use id instead of short name