### PR TITLE
chore(stats): Adjusting update groups for multichain and interchain modes

### DIFF
--- a/stats/config/interchain/update_groups.json
+++ b/stats/config/interchain/update_groups.json
@@ -1,17 +1,17 @@
 {
   "schedules": {
-    "total_interchain_messages_group": "0 10 0 * * * *",
-    "total_interchain_messages_sent_group": "0 10 0 * * * *",
-    "total_interchain_messages_received_group": "0 10 0 * * * *",
-    "total_interchain_transfers_group": "0 10 0 * * * *",
-    "total_interchain_transfers_sent_group": "0 10 0 * * * *",
-    "total_interchain_transfers_received_group": "0 10 0 * * * *",
-    "total_interchain_transfer_users_group": "0 10 0 * * * *",
-    "new_messages_interchain_group": "0 10 0 * * * *",
-    "new_messages_sent_interchain_group": "0 10 0 * * * *",
-    "new_messages_received_interchain_group": "0 10 0 * * * *",
-    "new_transfers_interchain_group": "0 10 0 * * * *",
-    "new_transfers_sent_interchain_group": "0 10 0 * * * *",
-    "new_transfers_received_interchain_group": "0 10 0 * * * *"
+    "total_interchain_messages_group": "0 0 */2 * * * *",
+    "total_interchain_messages_sent_group": "0 0 */2 * * * *",
+    "total_interchain_messages_received_group": "0 0 */2 * * * *",
+    "total_interchain_transfers_group": "0 0 */2 * * * *",
+    "total_interchain_transfers_sent_group": "0 0 */2 * * * *",
+    "total_interchain_transfers_received_group": "0 0 */2 * * * *",
+    "total_interchain_transfer_users_group": "0 30 0 * * * *",
+    "new_messages_interchain_group": "0 0 */2 * * * *",
+    "new_messages_sent_interchain_group": "0 0 */2 * * * *",
+    "new_messages_received_interchain_group": "0 0 */2 * * * *",
+    "new_transfers_interchain_group": "0 0 */2 * * * *",
+    "new_transfers_sent_interchain_group": "0 0 */2 * * * *",
+    "new_transfers_received_interchain_group": "0 0 */2 * * * *"
   }
 }

--- a/stats/config/multichain/update_groups.json
+++ b/stats/config/multichain/update_groups.json
@@ -1,13 +1,13 @@
 {
     "schedules": {
-        "total_interop_messages_group": "0 2 * * * * *",
-        "total_interop_transfers_group":  "0 2 * * * * *",
-        "total_multichain_txns_group": "0 10 0 * * * *",
-        "total_multichain_addresses_group": "0 10 0 * * * *",
-        "new_txns_multichain_group": "0 10 0 * * * *",
-        "new_txns_multichain_window_group": "0 10 0 * * * *",
-        "txns_growth_multichain_group": "0 10 0 * * * *",
-        "accounts_growth_multichain_group": "0 10 0 * * * *",
-        "yesterday_txns_multichain_group": "0 10 0 * * * *"
+        "total_interop_messages_group": "0 */10 * * * * *",
+        "total_interop_transfers_group":  "0 */10 * * * * *",
+        "total_multichain_txns_group": "0 30 * * * * *",
+        "total_multichain_addresses_group": "0 30 * * * * *",
+        "new_txns_multichain_group": "0 30 * * * * *",
+        "new_txns_multichain_window_group": "0 30 * * * * *",
+        "txns_growth_multichain_group": "0 30 * * * * *",
+        "accounts_growth_multichain_group": "0 30 * * * * *",
+        "yesterday_txns_multichain_group": "0 30 0 * * * *"
     }
 }


### PR DESCRIPTION
For multichain mode, the schedules were updated in accordance with the actual environment variables applied to the deployment.

For interchain mode, almost all counters and charts are set to update once every two hours.