### PR TITLE
feat(bens): make max protocols from user input configurable

### DIFF
--- a/blockscout-ens/README.md
+++ b/blockscout-ens/README.md
@@ -40,6 +40,7 @@ Service is **multi-chain**, meaning that only one instance of `graph-node`, `pos
 | `BENS__TRACING__ENABLED`                         |                          |                                                               | `true`         |
 | `BENS__TRACING__FORMAT`                          |                          |                                                               | `default`      |
 | `BENS__SUBGRAPHS_READER__REFRESH_CACHE_DISABLED` |                          |                                                               | `false`        |
+| `BENS__SUBGRAPHS_READER__MAX_PROTOCOLS_FROM_USER_INPUT` |                    | max protocols per request when chain id is omitted; `null` disables the limit | `5`            |
 | `BENS__REPLICA_DATABASE__CONNECT__URL`           | true                     | e.g. `postgresql://postgres:postgres@localhost:5433/postgres` |                |
 | `BENS__REPLICA_DATABASE__HEALTH_CHECK_INTERVAL`  |                          |                                                               | `10`           |
 | `BENS__REPLICA_DATABASE__MAX_LAG`                |                          |                                                               | `300`          |

--- a/blockscout-ens/bens-logic/examples/resolve_benchmark.rs
+++ b/blockscout-ens/bens-logic/examples/resolve_benchmark.rs
@@ -77,7 +77,7 @@ async fn main() -> Result<(), anyhow::Error> {
             },
         ),
     ]);
-    let reader = SubgraphReader::initialize(db, networks, protocol_infos).await?;
+    let reader = SubgraphReader::initialize(db, networks, protocol_infos, None).await?;
 
     let addresses = vec![
         "0x0292f204513eeafe8c032ffc4cb4c7e10eca908c",

--- a/blockscout-ens/bens-logic/src/protocols/protocoler.rs
+++ b/blockscout-ens/bens-logic/src/protocols/protocoler.rs
@@ -17,13 +17,15 @@ use tera::Tera;
 use url::Url;
 
 const MAX_NETWORKS_LIMIT: usize = 5;
-const MAX_PROTOCOLS_FROM_USER_INPUT: usize = 5;
 const PROTOCOL_DAPP_URL_TEMPLATE_NAME: &str = "protocol_dapp_url";
 
 #[derive(Debug, Clone)]
 pub struct Protocoler {
     networks: BTreeMap<i64, Network>,
     protocols: BTreeMap<String, Protocol>,
+    /// Maximum number of protocols a user may specify in a single protocol-scoped
+    /// request (network id omitted). `None` disables the limit.
+    max_protocols_from_user_input: Option<usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -264,6 +266,7 @@ impl Protocoler {
     pub fn initialize(
         networks: impl IntoIterator<Item = (i64, Network)>,
         protocols: impl IntoIterator<Item = (String, Protocol)>,
+        max_protocols_from_user_input: Option<usize>,
     ) -> Result<Self, anyhow::Error> {
         let networks = networks.into_iter().collect::<BTreeMap<_, _>>();
         let protocols = protocols.into_iter().collect::<BTreeMap<_, _>>();
@@ -291,6 +294,7 @@ impl Protocoler {
         Ok(Self {
             networks,
             protocols,
+            max_protocols_from_user_input,
         })
     }
 
@@ -397,11 +401,13 @@ impl Protocoler {
             let deduped = protocols.into_iter().collect::<HashSet<_>>();
             let protocols = self.protocols_by_slugs(deduped)?;
             if let Some(protocols) = NonEmpty::from_vec(protocols) {
-                if protocols.len() > MAX_PROTOCOLS_FROM_USER_INPUT {
-                    return Err(ProtocolError::TooManyProtocols {
-                        specified: protocols.len(),
-                        max: MAX_PROTOCOLS_FROM_USER_INPUT,
-                    });
+                if let Some(max) = self.max_protocols_from_user_input {
+                    if protocols.len() > max {
+                        return Err(ProtocolError::TooManyProtocols {
+                            specified: protocols.len(),
+                            max,
+                        });
+                    }
                 }
                 return Ok(protocols);
             }
@@ -771,7 +777,8 @@ mod tests {
             ),
         ];
 
-        Protocoler::initialize(networks, protocols).expect("should initialize successfully")
+        Protocoler::initialize(networks, protocols, Some(5))
+            .expect("should initialize successfully")
     }
 
     #[rstest]

--- a/blockscout-ens/bens-logic/src/subgraph/reader/init.rs
+++ b/blockscout-ens/bens-logic/src/subgraph/reader/init.rs
@@ -29,6 +29,7 @@ impl SubgraphReader {
         db: Arc<ReadWriteRepo>,
         networks: HashMap<i64, Network>,
         protocol_infos: HashMap<String, ProtocolInfo>,
+        max_protocols_from_user_input: Option<usize>,
     ) -> Result<Self, anyhow::Error> {
         let deployments = sql::get_deployments(db.read_db().get_postgres_connection_pool())
             .await?
@@ -78,7 +79,8 @@ impl SubgraphReader {
             .collect::<HashMap<_, _>>();
 
         tracing::info!(networks =? networks.keys().collect::<Vec<_>>(), "initialized subgraph reader");
-        let protocoler = Protocoler::initialize(networks, protocols)?;
+        let protocoler =
+            Protocoler::initialize(networks, protocols, max_protocols_from_user_input)?;
         let patcher = SubgraphPatcher::new();
         let this = Self::new(db, protocoler, patcher);
         this.init_cache().await.context("init cache tables")?;

--- a/blockscout-ens/bens-logic/src/test_utils.rs
+++ b/blockscout-ens/bens-logic/src/test_utils.rs
@@ -188,7 +188,7 @@ pub async fn mocked_reader(pool: PgPool) -> SubgraphReader {
             .expect("ReadWriteRepo for tests"),
     );
     let (networks, protocols) = mocked_networks_and_protocols().await;
-    SubgraphReader::initialize(db, networks, protocols)
+    SubgraphReader::initialize(db, networks, protocols, Some(5))
         .await
         .expect("failed to init reader")
 }

--- a/blockscout-ens/bens-server/src/server.rs
+++ b/blockscout-ens/bens-server/src/server.rs
@@ -83,6 +83,7 @@ pub async fn run(settings: Settings) -> Result<(), anyhow::Error> {
         tracing::info!("running migrations");
         bens_logic::migrations::run(db_repo.main_db().get_postgres_connection_pool()).await?;
     }
+    let max_protocols_from_user_input = settings.subgraphs_reader.max_protocols_from_user_input;
     let networks = settings
         .subgraphs_reader
         .networks
@@ -137,9 +138,14 @@ pub async fn run(settings: Settings) -> Result<(), anyhow::Error> {
         protocols.keys().collect::<Vec<_>>()
     );
 
-    let subgraph_reader = SubgraphReader::initialize(db_repo.clone(), networks, protocols)
-        .await
-        .context("failed to initialize subgraph-reader")?;
+    let subgraph_reader = SubgraphReader::initialize(
+        db_repo.clone(),
+        networks,
+        protocols,
+        max_protocols_from_user_input,
+    )
+    .await
+    .context("failed to initialize subgraph-reader")?;
     let subgraph_reader = Arc::new(subgraph_reader);
     let domains_extractor = Arc::new(DomainsExtractorService::new(subgraph_reader.clone()));
     let multichain_domains = Arc::new(MultichainDomainsService::new(subgraph_reader.clone()));

--- a/blockscout-ens/bens-server/src/settings.rs
+++ b/blockscout-ens/bens-server/src/settings.rs
@@ -49,10 +49,18 @@ pub struct SubgraphsReaderSettings {
     pub refresh_cache_schedule: String,
     #[serde(default)]
     pub refresh_cache_disabled: bool,
+    /// Maximum number of protocols a user may specify in a single protocol-scoped
+    /// request (chain id omitted). `None` disables the limit.
+    #[serde(default = "default_max_protocols_from_user_input")]
+    pub max_protocols_from_user_input: Option<usize>,
 }
 
 fn default_refresh_cache_schedule() -> String {
     "0 0 * * * *".to_string() // every hour
+}
+
+fn default_max_protocols_from_user_input() -> Option<usize> {
+    None
 }
 
 impl Default for SubgraphsReaderSettings {
@@ -62,6 +70,7 @@ impl Default for SubgraphsReaderSettings {
             protocols: Default::default(),
             refresh_cache_schedule: default_refresh_cache_schedule(),
             refresh_cache_disabled: false,
+            max_protocols_from_user_input: default_max_protocols_from_user_input(),
         }
     }
 }


### PR DESCRIPTION
Replace the hardcoded MAX_PROTOCOLS_FROM_USER_INPUT const with an optional `max_protocols_from_user_input` setting threaded through SubgraphReader/Protocoler. `None` disables the limit.