### PR TITLE
feat(bens): add all_protocols flag to GetAddressMultichain

### DIFF
--- a/blockscout-ens/bens-logic/src/protocols/protocoler.rs
+++ b/blockscout-ens/bens-logic/src/protocols/protocoler.rs
@@ -386,14 +386,28 @@ impl Protocoler {
         Ok(protocols)
     }
 
+    /// Returns every deployed protocol across all networks.
+    pub fn all_deployed_protocols(&self) -> Result<NonEmpty<DeployedProtocol<'_>>, ProtocolError> {
+        let protocols = self.iter_deployed_protocols().collect::<Vec<_>>();
+        NonEmpty::from_vec(protocols).ok_or_else(|| {
+            ProtocolError::ProtocolNotFound("no deployed protocols found".to_string())
+        })
+    }
+
     pub fn deployed_protocols_from_user_input(
         &self,
         network_id: Option<i64>,
         protocols: Option<NonEmpty<String>>,
+        all_protocols: bool,
     ) -> Result<NonEmpty<DeployedProtocol<'_>>, ProtocolError> {
+        // `all_protocols` without a network means every protocol on every network.
+        if all_protocols && network_id.is_none() {
+            return self.all_deployed_protocols();
+        }
         if let Some(network_id) = network_id {
-            // If network id is provided, this is a network-specific request and provided protocols are filters
-            let maybe_filter = protocols;
+            // If network id is provided, this is a network-specific request and provided protocols are filters.
+            // `all_protocols` drops the filter so every protocol on the network is returned.
+            let maybe_filter = if all_protocols { None } else { protocols };
             return self.protocols_of_network(network_id, maybe_filter);
         }
         if let Some(protocols) = protocols {
@@ -427,8 +441,9 @@ impl Protocoler {
         &self,
         network_id: Option<i64>,
         protocols: Option<NonEmpty<String>>,
+        all_protocols: bool,
     ) -> Result<NonEmpty<&Protocol>, ProtocolError> {
-        self.deployed_protocols_from_user_input(network_id, protocols)
+        self.deployed_protocols_from_user_input(network_id, protocols, all_protocols)
             .map(|nonempty| nonempty.map(|p| p.protocol))
     }
 
@@ -872,19 +887,27 @@ mod tests {
     // }
 
     #[rstest]
-    #[case(Some(1), None, vec!["ens"])]
-    #[case(None, Some(vec!["ens".to_string()]), vec!["ens"])]
-    #[case(Some(1337), None, vec!["ens", "gnosis"])]
-    #[case(Some(1337), Some(vec!["ens".to_string()]), vec!["ens"])]
-    #[case(None, None, vec!["ens"])] // fallback to mainnet
+    #[case(Some(1), None, false, vec!["ens"])]
+    #[case(None, Some(vec!["ens".to_string()]), false, vec!["ens"])]
+    #[case(Some(1337), None, false, vec!["ens", "gnosis"])]
+    #[case(Some(1337), Some(vec!["ens".to_string()]), false, vec!["ens"])]
+    #[case(None, None, false, vec!["ens"])] // fallback to mainnet
+    #[case(None, None, true, vec!["ens", "gnosis"])] // all_protocols: every deployed protocol
+    #[case(None, Some(vec!["ens".to_string()]), true, vec!["ens", "gnosis"])] // all_protocols ignores filter
+    #[case(Some(1337), Some(vec!["ens".to_string()]), true, vec!["ens", "gnosis"])] // all_protocols scoped to chain
     fn test_protocols_of_user_input_success(
         protocoler: Protocoler,
         #[case] network_id: Option<i64>,
         #[case] protocols_input: Option<Vec<String>>,
+        #[case] all_protocols: bool,
         #[case] expected_slugs: Vec<&str>,
     ) {
         let protocols_input = protocols_input.map(|slugs| NonEmpty::from_vec(slugs).unwrap());
-        let result = protocoler.deployed_protocols_from_user_input(network_id, protocols_input);
+        let result = protocoler.deployed_protocols_from_user_input(
+            network_id,
+            protocols_input,
+            all_protocols,
+        );
         assert!(result.is_ok());
         let protocols = result.unwrap();
         let actual_slugs: Vec<&str> = protocols
@@ -897,7 +920,8 @@ mod tests {
     #[rstest]
     fn test_protocols_of_user_input_invalid_protocol(protocoler: Protocoler) {
         let protocols_input = nonempty!["nonexistent".to_string()];
-        let result = protocoler.deployed_protocols_from_user_input(None, Some(protocols_input));
+        let result =
+            protocoler.deployed_protocols_from_user_input(None, Some(protocols_input), false);
         assert!(result.is_err());
         match result.unwrap_err() {
             ProtocolError::ProtocolNotFound(name) => assert_eq!(name, "nonexistent"),

--- a/blockscout-ens/bens-logic/src/subgraph/reader/impl_read.rs
+++ b/blockscout-ens/bens-logic/src/subgraph/reader/impl_read.rs
@@ -117,9 +117,11 @@ impl SubgraphReader {
         &self,
         input: LookupDomainInput,
     ) -> Result<PaginatedList<LookupOutput>, SubgraphReadError> {
-        let protocols = self
-            .protocoler
-            .deployed_protocols_from_user_input(input.network_id, input.protocols)?;
+        let protocols = self.protocoler.deployed_protocols_from_user_input(
+            input.network_id,
+            input.protocols,
+            false,
+        )?;
         let find_domains_input = if let Some(name) = input.name {
             // special logic for lookup by name, no error returned if name is invalid! wow, so cool!
             let Ok(clean_name) = CleanName::new(&name) else {
@@ -181,9 +183,11 @@ impl SubgraphReader {
         if address_should_be_ignored(&input.address) {
             return Ok(PaginatedList::empty());
         }
-        let protocols = self
-            .protocoler
-            .protocols_from_user_input(input.network_id, input.protocols.clone())?;
+        let protocols = self.protocoler.protocols_from_user_input(
+            input.network_id,
+            input.protocols.clone(),
+            false,
+        )?;
         let domains = sql::find_resolved_addresses(self.pg_pool(), protocols, &input).await?;
         let output = lookup_output_from_domains(domains, &self.protocoler)?;
         let paginated = input
@@ -200,9 +204,11 @@ impl SubgraphReader {
         if address_should_be_ignored(&input.address) {
             return Ok(Default::default());
         }
-        let protocols = self
-            .protocoler
-            .protocols_from_user_input(input.network_id, input.protocols.clone())?;
+        let protocols = self.protocoler.protocols_from_user_input(
+            input.network_id,
+            input.protocols.clone(),
+            input.all_protocols,
+        )?;
         let maybe_domain_name = resolve_addresses(self.pg_pool(), protocols, vec![input.address])
             .await?
             .into_iter()
@@ -237,13 +243,14 @@ impl SubgraphReader {
         owned_by: bool,
         network_id: Option<i64>,
         protocols: Option<NonEmpty<String>>,
+        all_protocols: bool,
     ) -> Result<i64, SubgraphReadError> {
         if address_should_be_ignored(&address) {
             return Ok(Default::default());
         }
-        let protocols = self
-            .protocoler
-            .protocols_from_user_input(network_id, protocols)?;
+        let protocols =
+            self.protocoler
+                .protocols_from_user_input(network_id, protocols, all_protocols)?;
         let only_active = true;
         let count = sql::count_domains_by_address(
             self.pg_pool(),
@@ -271,9 +278,9 @@ impl SubgraphReader {
         &self,
         input: BatchResolveAddressNamesInput,
     ) -> Result<BTreeMap<Address, String>, SubgraphReadError> {
-        let protocols = self
-            .protocoler
-            .protocols_from_user_input(input.network_id, input.protocols)?;
+        let protocols =
+            self.protocoler
+                .protocols_from_user_input(input.network_id, input.protocols, false)?;
         // remove duplicates
         let addresses = remove_addresses_from_batch(input.addresses);
         let addresses_len = addresses.len();

--- a/blockscout-ens/bens-logic/src/subgraph/reader/types.rs
+++ b/blockscout-ens/bens-logic/src/subgraph/reader/types.rs
@@ -130,6 +130,7 @@ pub struct GetAddressInput {
     pub address: Address,
     pub network_id: Option<i64>,
     pub protocols: Option<NonEmpty<String>>,
+    pub all_protocols: bool,
 }
 
 impl Default for DomainPaginationInput {

--- a/blockscout-ens/bens-proto/proto/multichain_domains.proto
+++ b/blockscout-ens/bens-proto/proto/multichain_domains.proto
@@ -100,6 +100,9 @@ message GetAddressMultichainRequest {
   optional int64 chain_id = 2;
   // comma separated list of protocol ids. Default is ENS protocol only
   optional string protocols = 3;
+  // If true, search across all supported protocols and ignore `protocols`.
+  // When `chain_id` is set, the search is scoped to all protocols on that chain.
+  bool all_protocols = 4 [(google.api.field_behavior) = OPTIONAL];
 }
 
 message BatchResolveAddressesMultichainRequest {

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.openapi-v3.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.openapi-v3.yaml
@@ -286,6 +286,13 @@ paths:
         name: protocols
         schema:
           type: string
+      - description: |-
+          If true, search across all supported protocols and ignore `protocols`.
+          When `chain_id` is set, the search is scoped to all protocols on that chain.
+        in: query
+        name: all_protocols
+        schema:
+          type: boolean
       responses:
         '200':
           content:

--- a/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
+++ b/blockscout-ens/bens-proto/swagger/bens.swagger.yaml
@@ -47,6 +47,13 @@ paths:
           in: query
           required: false
           type: string
+        - name: all_protocols
+          description: |-
+            If true, search across all supported protocols and ignore `protocols`.
+            When `chain_id` is set, the search is scoped to all protocols on that chain.
+          in: query
+          required: false
+          type: boolean
       tags:
         - MultichainDomains
   /api/v1/addresses:batch-resolve:

--- a/blockscout-ens/bens-server/src/conversion/domain.rs
+++ b/blockscout-ens/bens-server/src/conversion/domain.rs
@@ -79,6 +79,7 @@ pub fn get_address_from_inner(
         network_id: Some(inner.chain_id),
         address,
         protocols: inner.protocol_id.map(|p| nonempty![p]),
+        all_protocols: false,
     })
 }
 

--- a/blockscout-ens/bens-server/src/conversion/multichain.rs
+++ b/blockscout-ens/bens-server/src/conversion/multichain.rs
@@ -84,6 +84,7 @@ pub fn multichain_get_address_from_proto(
         address: address_from_str_inner(&proto.address)?,
         network_id: proto.chain_id,
         protocols: split_protocols(proto.protocols),
+        all_protocols: proto.all_protocols,
     };
     Ok(input)
 }

--- a/blockscout-ens/bens-server/src/services/domain_extractor.rs
+++ b/blockscout-ens/bens-server/src/services/domain_extractor.rs
@@ -124,7 +124,14 @@ impl DomainsExtractor for DomainsExtractorService {
 
         let resolved_domains_count = self
             .subgraph_reader
-            .count_domains_by_address(input.address, true, false, Some(chain_id), input.protocols)
+            .count_domains_by_address(
+                input.address,
+                true,
+                false,
+                Some(chain_id),
+                input.protocols,
+                false,
+            )
             .await
             .map_err(|e| map_subgraph_error(e, Some(self.subgraph_reader.pg_pool())))?
             as i32;

--- a/blockscout-ens/bens-server/src/services/multichain_domains.rs
+++ b/blockscout-ens/bens-server/src/services/multichain_domains.rs
@@ -124,7 +124,14 @@ impl MultichainDomains for MultichainDomainsService {
 
         let resolved_domains_count = self
             .subgraph_reader
-            .count_domains_by_address(input.address, true, false, chain_id, input.protocols)
+            .count_domains_by_address(
+                input.address,
+                true,
+                false,
+                chain_id,
+                input.protocols,
+                input.all_protocols,
+            )
             .await
             .map_err(|e| conversion::map_subgraph_error(e, Some(self.subgraph_reader.pg_pool())))?
             as i32;


### PR DESCRIPTION
Add an opt-in all_protocols flag to GetAddressMultichainRequest so the endpoint can resolve an address against every supported protocol instead of only the mainnet ENS default. Scope respects chain_id: when set, all protocols on that chain; otherwise all protocols across all networks.