### PR TITLE
chore(interchain-indexer): Tune Docker Compose Deployment

### DIFF
--- a/interchain-indexer/docker/README.md
+++ b/interchain-indexer/docker/README.md
@@ -110,6 +110,8 @@ docker-compose logs -f SERVICE_NAME
 - `backend`: the main Blockscout API Backend
 - `interchain-indexer`: Universal Bridge Indexer
 - `frontend`: Blockscout frontend web-server
+- `stats`: Blocksout instance statistic service
+- `stats-interchain`: Universal Bridge Indexer statistic service
 
 ## 4. Usage: Frontend, API, Swagger, and metrics
 

--- a/interchain-indexer/docker/config/bridges.json
+++ b/interchain-indexer/docker/config/bridges.json
@@ -9,6 +9,7 @@
         "ui_url": null,
         "docs_url": null,
         "home_chain_id": 8021,
+        "process_unknown_chains": false,
         "contracts": [
             {
                 "chain_id": 43114,

--- a/interchain-indexer/docker/docker-compose.yml
+++ b/interchain-indexer/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     depends_on:
       - db
       - redis-db
-    image: ghcr.io/evgenkor/blockscout-private:9.3.5
+    image: ghcr.io/evgenkor/blockscout-private:11.1.2
     pull_policy: always
     restart: always
     stop_grace_period: 5m
@@ -58,7 +58,7 @@ services:
       INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: true
       INDEXER_DISABLE_HOT_SMART_CONTRACTS_FETCHER: true
       DISABLE_MARKET: 'true'
-      ECTO_USE_SSL: false
+      ECTO_SSL_MODE: disable
       DISABLE_EXCHANGE_RATES: true
       SUPPORTED_CHAINS: "[]"
     ports:
@@ -96,15 +96,15 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  stats:
+  stats-interchain:
     image: ghcr.io/blockscout/stats:v2.14.1
-    container_name: 'stats'
+    container_name: 'stats-interchain'
     restart: always
     depends_on:
       - db
       - interchain-indexer
     ports:
-      - "8080:8080"
+      - "8081:8080"
     environment:
       STATS__MODE: interchain
       STATS__INTERCHAIN_PRIMARY_ID: 8021
@@ -120,13 +120,35 @@ services:
       STATS__SERVER__HTTP__CORS__ENABLED: true
       STATS__SERVER__HTTP__CORS__ALLOWED_ORIGIN: '*'
 
+  stats:
+    image: ghcr.io/blockscout/stats:v2.15.0
+    container_name: 'stats'
+    restart: always
+    depends_on:
+      - db
+      - backend
+      - stats-interchain
+    ports:
+      - "8080:8080"
+    environment:
+      STATS__MODE: blockscout
+      STATS__BLOCKSCOUT_API_URL: http://localhost:4000
+      STATS__DB_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/stats
+      STATS__INDEXER_DB_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout
+      STATS__CREATE_DATABASE: true
+      STATS__RUN_MIGRATIONS: true
+      STATS__SERVER__HTTP__ENABLED: true
+      STATS__SERVER__HTTP__ADDR: 0.0.0.0:8080
+      STATS__SERVER__HTTP__CORS__ENABLED: true
+      STATS__SERVER__HTTP__CORS__ALLOWED_ORIGIN: '*'
+      STATS__LINKED_STATS__BASE_URL: http://localhost:8080
+
   frontend:
     depends_on:
       - backend
       - caddy
-    image: ghcr.io/evgenkor/frontend-private:cross-chain-alpha.0
+    image: ghcr.io/evgenkor/frontend-private:v2.8.0
     pull_policy: always
-    platform: linux/amd64
     restart: always
     container_name: 'frontend'
     environment:

--- a/interchain-indexer/docker/docker-compose.yml
+++ b/interchain-indexer/docker/docker-compose.yml
@@ -40,6 +40,10 @@ services:
     container_name: 'backend'
     command: sh -c 'bin/blockscout eval "Elixir.Explorer.ReleaseTasks.create_and_migrate()" && bin/blockscout start'
     environment:
+      APPLICATION_MODE: all
+      COIN: NUMINE
+      COIN_NAME: NUMINE
+      DISABLE_MARKET: true
       ETHEREUM_JSONRPC_VARIANT: geth
       ETHEREUM_JSONRPC_HTTP_URL: https://subnets.avax.network/numi/mainnet/rpc
       ETHEREUM_JSONRPC_TRACE_URL: https://subnets.avax.network/numi/mainnet/rpc
@@ -53,16 +57,18 @@ services:
       DATABASE_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout
       SECRET_KEY_BASE: 56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN # TODO: default, please change
       NETWORK: EVM
-      PORT: 4000 
+      +PORT: 4000 
       INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: true
       INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: true
       INDEXER_DISABLE_HOT_SMART_CONTRACTS_FETCHER: true
-      DISABLE_MARKET: 'true'
+      MIGRATION_DELETE_ZERO_VALUE_INTERNAL_TRANSACTIONS_ENABLED: true
+      MIGRATION_SHRINK_INTERNAL_TRANSACTIONS_BATCH_SIZE: 100
       ECTO_SSL_MODE: disable
       DISABLE_EXCHANGE_RATES: true
       SUPPORTED_CHAINS: "[]"
     ports:
       - "4000:4000"
+      - "81:80"
     links:
       - db:database
     # volumes:
@@ -91,13 +97,14 @@ services:
       INTERCHAIN_INDEXER__METRICS__ADDR: 0.0.0.0:6060
       INTERCHAIN_INDEXER__SERVER__HTTP__CORS__ENABLED: true
       INTERCHAIN_INDEXER__SERVER__HTTP__CORS__ALLOWED_ORIGIN: '*'
+      RUST_LOG: info,alloy_transport_http=warn
     volumes:
       - ./config:/app/config
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
   stats-interchain:
-    image: ghcr.io/blockscout/stats:v2.14.1
+    image: ghcr.io/blockscout/stats:v2.15.0
     container_name: 'stats-interchain'
     restart: always
     depends_on:
@@ -132,7 +139,8 @@ services:
       - "8080:8080"
     environment:
       STATS__MODE: blockscout
-      STATS__BLOCKSCOUT_API_URL: http://localhost:4000
+      #STATS__BLOCKSCOUT_API_URL: http://backend:4000
+      STATS__IGNORE_BLOCKSCOUT_API_ABSENCE: true
       STATS__DB_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/stats
       STATS__INDEXER_DB_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout
       STATS__CREATE_DATABASE: true
@@ -141,7 +149,7 @@ services:
       STATS__SERVER__HTTP__ADDR: 0.0.0.0:8080
       STATS__SERVER__HTTP__CORS__ENABLED: true
       STATS__SERVER__HTTP__CORS__ALLOWED_ORIGIN: '*'
-      STATS__LINKED_STATS__BASE_URL: http://localhost:8080
+      STATS__LINKED_STATS__BASE_URL: http://stats-interchain:8080
 
   frontend:
     depends_on:
@@ -154,6 +162,7 @@ services:
     environment:
       NEXT_PUBLIC_API_HOST: localhost
       NEXT_PUBLIC_STATS_API_HOST: http://localhost:8080
+      NEXT_PUBLIC_STATS_API_BASE_PATH: /
       FAVICON_MASTER_URL: https://ash.center/img/ash-logo.svg # TODO: set to actual logo
       NEXT_PUBLIC_NETWORK_NAME: NUMINE
       NEXT_PUBLIC_NETWORK_ID: 8021
@@ -164,8 +173,7 @@ services:
       NEXT_PUBLIC_INTERCHAIN_INDEXER_API_HOST: http://localhost:8050
       NEXT_PUBLIC_CROSS_CHAIN_TXS_ENABLED: true
       NEXT_PUBLIC_HOMEPAGE_CHARTS: "['daily_txs']"
-      #NEXT_PUBLIC_STATS_API_HOST: ""
-      #NEXT_PUBLIC_STATS_API_BASE_PATH: /stats-service
+      
   caddy:
     depends_on:
       - backend

--- a/interchain-indexer/docker/docker-compose.yml
+++ b/interchain-indexer/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     depends_on:
       - db
       - redis-db
-    image: ghcr.io/evgenkor/blockscout-private:11.1.2
+    image: ghcr.io/evgenkor/blockscout-private:11.1.3
     pull_policy: always
     restart: always
     stop_grace_period: 5m
@@ -41,8 +41,6 @@ services:
     command: sh -c 'bin/blockscout eval "Elixir.Explorer.ReleaseTasks.create_and_migrate()" && bin/blockscout start'
     environment:
       APPLICATION_MODE: all
-      COIN: NUMINE
-      COIN_NAME: NUMINE
       DISABLE_MARKET: true
       ETHEREUM_JSONRPC_VARIANT: geth
       ETHEREUM_JSONRPC_HTTP_URL: https://subnets.avax.network/numi/mainnet/rpc
@@ -52,12 +50,12 @@ services:
       # You can remove/comment the following 4 lines for newly created network
       FIRST_BLOCK: 557000
       TRACE_FIRST_BLOCK: 557000
-      # INDEXER_CATCHUP_BLOCKS_BATCH_SIZE: 20
-      # INDEXER_CATCHUP_BLOCKS_CONCURRENCY: 1
+      INDEXER_CATCHUP_BLOCKS_BATCH_SIZE: 20
+      INDEXER_CATCHUP_BLOCKS_CONCURRENCY: 1
       DATABASE_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout
       SECRET_KEY_BASE: 56NtB48ear7+wMSf0IQuWDAAazhpb31qyc7GiyspBP2vh7t5zlCsF5QDv76chXeN # TODO: default, please change
       NETWORK: EVM
-      +PORT: 4000 
+      PORT: 4000 
       INDEXER_DISABLE_PENDING_TRANSACTIONS_FETCHER: true
       INDEXER_DISABLE_INTERNAL_TRANSACTIONS_FETCHER: true
       INDEXER_DISABLE_HOT_SMART_CONTRACTS_FETCHER: true
@@ -139,8 +137,7 @@ services:
       - "8080:8080"
     environment:
       STATS__MODE: blockscout
-      #STATS__BLOCKSCOUT_API_URL: http://backend:4000
-      STATS__IGNORE_BLOCKSCOUT_API_ABSENCE: true
+      STATS__BLOCKSCOUT_API_URL: http://backend:4000
       STATS__DB_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/stats
       STATS__INDEXER_DB_URL: postgresql://postgres:ceWb1MeLBEeOIfk65gU8EjF8@db:5432/blockscout
       STATS__CREATE_DATABASE: true


### PR DESCRIPTION
## Summary

- Updates the Docker Compose stack to newer backend, frontend, and stats images.
- Splits stats into separate Blockscout and interchain stats services.
- Wires frontend stats configuration to the Blockscout stats service while linking interchain stats internally.
