### PR TITLE
fix(bens): make all_protocols fields optional in deserialization

### DIFF
--- a/blockscout-ens/bens-proto/build.rs
+++ b/blockscout-ens/bens-proto/build.rs
@@ -39,14 +39,18 @@ fn compile(
             "LookupAddressRequest.sort",
             "LookupAddressRequest.order",
             "GetDomainNameMultichainRequest.only_active",
+            "GetAddressMultichainRequest.all_protocols",
             "LookupDomainNameMultichainRequest.only_active",
             "LookupDomainNameMultichainRequest.sort",
             "LookupDomainNameMultichainRequest.order",
+            "LookupDomainNameMultichainRequest.all_protocols",
             "LookupAddressMultichainRequest.only_active",
             "LookupAddressMultichainRequest.sort",
             "LookupAddressMultichainRequest.order",
+            "LookupAddressMultichainRequest.all_protocols",
             "ListDomainEventsMultichainRequest.sort",
             "ListDomainEventsMultichainRequest.order",
+            "BatchResolveAddressesMultichainRequest.all_protocols",
         ],
     );
     config.compile_protos(protos, includes)?;


### PR DESCRIPTION
Add #[serde(default)] to the all_protocols fields on the multichain address/domain requests so clients can omit the field instead of it being required during JSON/query deserialization.