### PR TITLE
chore(types): create dev workflow

### DIFF
--- a/.github/workflows/npm-publisher-dev.yml
+++ b/.github/workflows/npm-publisher-dev.yml
@@ -1,0 +1,40 @@
+name: Publish types package to NPM (dev)
+# This workflow is used to publish the dev version (before release) of the types packages to npm.
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'Service whose type package to publish'
+        type: choice
+        required: true
+        options:
+          - blockscout-ens
+          - interchain-indexer
+          - multichain-aggregator
+          - multichain-search
+          - stats
+          - tac-operation-lifecycle
+          - user-ops-indexer
+          - visualizer
+
+jobs:
+  version:
+    name: Resolve dev package version
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.set.outputs.package_version }}
+    steps:
+      - name: Set version from commit SHA
+        id: set
+        run: echo "package_version=0.0.1-beta.${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Build and publish
+    needs: version
+    uses: ./.github/workflows/npm-publisher.yml
+    with:
+      project_name: ${{ inputs.service }}
+      version: ${{ needs.version.outputs.package_version }}
+    secrets:
+      inherit

--- a/.github/workflows/npm-publisher.yml
+++ b/.github/workflows/npm-publisher.yml
@@ -8,9 +8,18 @@ on:
                 type: string
                 required: true
             project_name:
-                description: Project name
-                type: string
+                description: 'Service whose type package to publish'
+                type: choice
                 required: true
+                options:
+                  - blockscout-ens
+                  - interchain-indexer
+                  - multichain-aggregator
+                  - multichain-search
+                  - stats
+                  - tac-operation-lifecycle
+                  - user-ops-indexer
+                  - visualizer
     workflow_call:
         inputs:
             version:


### PR DESCRIPTION
Create dev Github workflow for publishing types packages from dev branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new workflow to publish dev npm package versions on demand.
  * Dev builds now use a version format based on the current commit SHA.

* **Chores**
  * Restricted publishing inputs to a fixed list of supported package names.
  * Improved consistency by reusing the same publishing flow for both standard and dev releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->