### PR TITLE
feat(sourcify): add v2 async verification client

### DIFF
--- a/libs/blockscout-client/crate/tests/it_works.rs
+++ b/libs/blockscout-client/crate/tests/it_works.rs
@@ -56,7 +56,7 @@ async fn health(#[future] api_client: ApiClient) {
     let health_api = api_client.health_api();
     let health = health_api.health().await.expect("Failed to get health");
     let success = health.try_as_success().cloned().unwrap_or_else(|| {
-        panic!("failed to get health: {:?}", &health.entity);
+        panic!("failed to get health: {:?}", health.entity);
     });
     assert_eq!(success.healthy, Some(true));
     assert!(success
@@ -72,7 +72,7 @@ async fn health(#[future] api_client: ApiClient) {
         .all(|c| c.is_ascii_digit()),);
     let health_v1 = health_api.health_v1().await.expect("Failed to get health");
     let success = health_v1.try_as_success().cloned().unwrap_or_else(|| {
-        panic!("failed to get health: {:?}", &health_v1.entity);
+        panic!("failed to get health: {:?}", health_v1.entity);
     });
     assert_eq!(success.healthy, Some(true));
     assert_eq!(

--- a/libs/env-collector/src/lib.rs
+++ b/libs/env-collector/src/lib.rs
@@ -856,7 +856,7 @@ mod tests {
         let markdown = default_markdown_content();
         let mut vars = Envs::from_markdown(markdown, Some("cool_postfix".to_string())).unwrap();
         // purge indices for correct comparison
-        for (_, var) in vars.vars.iter_mut() {
+        for var in vars.vars.values_mut() {
             var.table_index = None;
         }
         let expected = default_envs();

--- a/libs/sourcify/Cargo.toml
+++ b/libs/sourcify/Cargo.toml
@@ -16,6 +16,7 @@ reqwest-retry = "0.3.0"
 serde = { version = "1.0.164", features = ["derive"] }
 serde_json = "1.0.96"
 thiserror = "1.0.40"
+tokio = { version = "1.28.2", features = ["time"] }
 tracing = { version = "0.1.37", optional = true }
 url = "2.4.0"
 

--- a/libs/sourcify/src/client.rs
+++ b/libs/sourcify/src/client.rs
@@ -13,8 +13,15 @@ use reqwest::{Response, StatusCode};
 use reqwest_middleware::{ClientWithMiddleware, Middleware};
 use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
 use serde::{Deserialize, Serialize};
-use std::{str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc, time::Duration};
 use url::Url;
+
+/// Default interval between polls of an asynchronous verification job.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(1);
+/// Default maximum number of times an asynchronous verification job is polled
+/// before giving up. Combined with [`DEFAULT_POLL_INTERVAL`] this yields a
+/// ~120 second ceiling, which comfortably covers Etherscan imports.
+pub const DEFAULT_MAX_POLL_ATTEMPTS: u32 = 120;
 
 mod retryable_strategy {
     use reqwest::StatusCode;
@@ -54,6 +61,9 @@ mod retryable_strategy {
 pub struct ClientBuilder {
     base_url: Url,
     max_retries: u32,
+    request_timeout: Option<Duration>,
+    poll_interval: Duration,
+    max_poll_attempts: u32,
     middleware_stack: Vec<Arc<dyn Middleware>>,
 }
 
@@ -62,6 +72,9 @@ impl Default for ClientBuilder {
         Self {
             base_url: Url::from_str("https://sourcify.dev/server/").unwrap(),
             max_retries: 3,
+            request_timeout: None,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            max_poll_attempts: DEFAULT_MAX_POLL_ATTEMPTS,
             middleware_stack: vec![],
         }
     }
@@ -80,6 +93,25 @@ impl ClientBuilder {
         self
     }
 
+    /// Per-request timeout applied to every HTTP call the client makes.
+    pub fn request_timeout(mut self, request_timeout: Duration) -> Self {
+        self.request_timeout = Some(request_timeout);
+        self
+    }
+
+    /// Interval to wait between polls of an asynchronous (v2) verification job.
+    pub fn poll_interval(mut self, poll_interval: Duration) -> Self {
+        self.poll_interval = poll_interval;
+        self
+    }
+
+    /// Maximum number of times an asynchronous (v2) verification job is polled
+    /// before the client gives up with an internal error.
+    pub fn max_poll_attempts(mut self, max_poll_attempts: u32) -> Self {
+        self.max_poll_attempts = max_poll_attempts;
+        self
+    }
+
     pub fn with_middleware<M: Middleware>(self, middleware: M) -> Self {
         self.with_arc_middleware(Arc::new(middleware))
     }
@@ -90,12 +122,20 @@ impl ClientBuilder {
     }
 
     pub fn build(self) -> Client {
+        let reqwest_client = match self.request_timeout {
+            Some(timeout) => reqwest::Client::builder()
+                .timeout(timeout)
+                .build()
+                .expect("failed to build reqwest client"),
+            None => reqwest::Client::new(),
+        };
         let retry_policy = ExponentialBackoff::builder().build_with_max_retries(self.max_retries);
-        let mut client_builder = reqwest_middleware::ClientBuilder::new(reqwest::Client::new())
-            .with(RetryTransientMiddleware::new_with_policy_and_strategy(
+        let mut client_builder = reqwest_middleware::ClientBuilder::new(reqwest_client).with(
+            RetryTransientMiddleware::new_with_policy_and_strategy(
                 retry_policy,
                 retryable_strategy::SourcifyRetryableStrategy,
-            ));
+            ),
+        );
         for middleware in self.middleware_stack {
             client_builder = client_builder.with_arc(middleware);
         }
@@ -104,14 +144,18 @@ impl ClientBuilder {
         Client {
             base_url: self.base_url,
             reqwest_client: client,
+            poll_interval: self.poll_interval,
+            max_poll_attempts: self.max_poll_attempts,
         }
     }
 }
 
 #[derive(Clone)]
 pub struct Client {
-    base_url: Url,
-    reqwest_client: ClientWithMiddleware,
+    pub(crate) base_url: Url,
+    pub(crate) reqwest_client: ClientWithMiddleware,
+    pub(crate) poll_interval: Duration,
+    pub(crate) max_poll_attempts: u32,
 }
 
 impl Default for Client {
@@ -185,7 +229,7 @@ impl Client {
 }
 
 impl Client {
-    fn generate_url(&self, route: &str) -> Url {
+    pub(crate) fn generate_url(&self, route: &str) -> Url {
         self.base_url.join(route).unwrap()
     }
 

--- a/libs/sourcify/src/lib.rs
+++ b/libs/sourcify/src/lib.rs
@@ -2,12 +2,14 @@
 
 mod client;
 mod types;
+mod v2;
 
-pub use client::{Client, ClientBuilder};
+pub use client::{Client, ClientBuilder, DEFAULT_MAX_POLL_ATTEMPTS, DEFAULT_POLL_INTERVAL};
 pub use types::{
     EmptyCustomError, GetSourceFilesResponse, MatchType, VerifyFromEtherscanError,
     VerifyFromEtherscanResponse,
 };
+pub use v2::{JobContract, JobError, VerificationJob, VerifiedContract};
 
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum SourcifyError<E: std::error::Error> {
@@ -15,6 +17,11 @@ pub enum SourcifyError<E: std::error::Error> {
     InternalServerError(String),
     #[error("Chain is not supported: {0}")]
     ChainNotSupported(String),
+    /// An asynchronous (v2) verification job completed, but the contract could
+    /// not be verified (e.g. the recompiled bytecode did not match). This is a
+    /// terminal verification outcome rather than a transport or server error.
+    #[error("Verification failed: {0}")]
+    VerificationFailure(String),
     #[error("'Not Found': {0}")]
     NotFound(String),
     #[error("'Bad Request': {0}")]

--- a/libs/sourcify/src/types.rs
+++ b/libs/sourcify/src/types.rs
@@ -29,6 +29,16 @@ mod custom_error {
         fn handle_status_code(_status_code: reqwest::StatusCode, _text: &str) -> Option<Self> {
             None
         }
+
+        /// Maps a Sourcify API v2 error `customCode` (and its message) onto an
+        /// endpoint-specific custom error. The same `customCode` may carry a
+        /// different meaning depending on the endpoint (e.g. `unsupported_chain`
+        /// is a verification failure for the Etherscan import endpoint, but a
+        /// generic bad request elsewhere), so the interpretation is delegated to
+        /// the concrete custom error type of the calling flow.
+        fn handle_custom_code(_custom_code: &str, _message: &str) -> Option<Self> {
+            None
+        }
     }
 
     impl CustomError for super::EmptyCustomError {}
@@ -337,6 +347,35 @@ mod verify_from_etherscan {
             }
 
             None
+        }
+
+        // Sourcify API v2 reports Etherscan-import outcomes via `customCode`.
+        // Preserve the v1 semantics: chain/verification issues surface as
+        // verification failures, while rate limits and upstream API errors are
+        // internal (retryable) errors.
+        fn handle_custom_code(custom_code: &str, message: &str) -> Option<Self> {
+            let message = message.to_string();
+            match custom_code {
+                "unsupported_chain" => Some(VerifyFromEtherscanError::ChainNotSupported(message)),
+                // The recompiled bytecode did not match, or the contract is not
+                // verified on the upstream Etherscan instance.
+                "no_match" | "not_verified" | "contract_not_verified" => {
+                    Some(VerifyFromEtherscanError::ContractNotVerified(message))
+                }
+                "compiler_error" | "verified_with_errors" => {
+                    Some(VerifyFromEtherscanError::VerifiedWithErrors(message))
+                }
+                "cannot_generate_std_json_input" | "cannot_generate_solc_json_input" => Some(
+                    VerifyFromEtherscanError::CannotGenerateSolcJsonInput(message),
+                ),
+                "too_many_requests" | "etherscan_limit" => {
+                    Some(VerifyFromEtherscanError::TooManyRequests(message))
+                }
+                "etherscan_api_error" | "api_response_error" => {
+                    Some(VerifyFromEtherscanError::ApiResponseError(message))
+                }
+                _ => None,
+            }
         }
     }
 

--- a/libs/sourcify/src/v2.rs
+++ b/libs/sourcify/src/v2.rs
@@ -1,0 +1,455 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+//! Sourcify API v2 support.
+//!
+//! Unlike the (now sunset) v1 API, verification in v2 is asynchronous and
+//! job-based: a submission returns a `verificationId`, whose status is then
+//! polled until the job completes. Once a contract is verified, its sources and
+//! metadata are fetched from the contract endpoint.
+//!
+//! The methods here encapsulate the whole submit → poll → fetch flow so that
+//! callers keep a single `await` that returns a fully materialized
+//! [`VerifiedContract`] (or a mapped error), mirroring the ergonomics of the
+//! old synchronous v1 client.
+
+use crate::{
+    types::CustomError, Client, EmptyCustomError, Error, MatchType, SourcifyError,
+    VerifyFromEtherscanError,
+};
+use blockscout_display_bytes::{decode_hex, ToHex};
+use bytes::Bytes;
+use reqwest::{Response, StatusCode};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// A fully materialized, verified contract as returned by the v2 contract
+/// endpoint. Carries everything required to reconstruct a verification success
+/// downstream (sources, metadata, constructor arguments and the match type).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedContract {
+    pub chain_id: String,
+    pub address: Bytes,
+    pub match_type: MatchType,
+    pub sources: BTreeMap<String, String>,
+    pub metadata: serde_json::Value,
+    /// `None` means the constructor arguments were not returned by Sourcify
+    /// (though they may still exist), as opposed to an empty byte sequence.
+    pub constructor_arguments: Option<Bytes>,
+}
+
+/// Status of an asynchronous verification job (`GET /v2/verify/{id}`).
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct VerificationJob {
+    pub is_job_completed: bool,
+    #[serde(default)]
+    pub verification_id: Option<String>,
+    #[serde(default)]
+    pub contract: Option<JobContract>,
+    #[serde(default)]
+    pub error: Option<JobError>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobContract {
+    #[serde(rename = "match", default)]
+    pub match_type: Option<String>,
+    #[serde(default)]
+    pub runtime_match: Option<String>,
+    #[serde(default)]
+    pub creation_match: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct JobError {
+    pub custom_code: String,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub error_id: Option<String>,
+}
+
+impl Client {
+    /// Imports a contract verified on an Etherscan(-alike) instance into
+    /// Sourcify via API v2, waiting for the asynchronous job to complete and
+    /// returning the resulting verified contract.
+    ///
+    /// `api_key`, when provided, is forwarded to Sourcify to use against the
+    /// upstream Etherscan instance.
+    pub async fn verify_from_etherscan_v2(
+        &self,
+        chain_id: &str,
+        contract_address: Bytes,
+        api_key: Option<String>,
+    ) -> Result<VerifiedContract, Error<VerifyFromEtherscanError>> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            api_key: Option<String>,
+        }
+
+        let url = self.generate_url(&format!(
+            "v2/verify/etherscan/{chain_id}/{}",
+            ToHex::to_hex(&contract_address)
+        ));
+        let response = self
+            .reqwest_client
+            .post(url)
+            .json(&Body { api_key })
+            .send()
+            .await
+            .map_err(map_middleware_error)?;
+
+        let submitted: SubmitResponse = process_v2_response(response).await?;
+        let job = self
+            .poll_verification_job(&submitted.verification_id)
+            .await?;
+        self.finalize_job(chain_id, contract_address, job).await
+    }
+
+    /// Verifies a contract from its Solidity metadata and sources via API v2,
+    /// waiting for the asynchronous job to complete.
+    ///
+    /// If the contract is already verified, Sourcify responds with `409` and the
+    /// existing verified contract is fetched and returned instead.
+    pub async fn verify_via_metadata_v2(
+        &self,
+        chain_id: &str,
+        contract_address: Bytes,
+        sources: BTreeMap<String, String>,
+        metadata: serde_json::Value,
+        creation_transaction_hash: Option<String>,
+    ) -> Result<VerifiedContract, Error<EmptyCustomError>> {
+        #[derive(Serialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Body {
+            sources: BTreeMap<String, String>,
+            metadata: serde_json::Value,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            creation_transaction_hash: Option<String>,
+        }
+
+        let url = self.generate_url(&format!(
+            "v2/verify/metadata/{chain_id}/{}",
+            ToHex::to_hex(&contract_address)
+        ));
+        let response = self
+            .reqwest_client
+            .post(url)
+            .json(&Body {
+                sources,
+                metadata,
+                creation_transaction_hash,
+            })
+            .send()
+            .await
+            .map_err(map_middleware_error)?;
+
+        // The contract is already verified — return the stored result.
+        if response.status() == StatusCode::CONFLICT {
+            return self.get_contract_v2(chain_id, contract_address).await;
+        }
+
+        let submitted: SubmitResponse = process_v2_response(response).await?;
+        let job = self
+            .poll_verification_job(&submitted.verification_id)
+            .await?;
+        self.finalize_job(chain_id, contract_address, job).await
+    }
+
+    /// Polls `GET /v2/verify/{id}` until the job reports completion, bounded by
+    /// [`Client::max_poll_attempts`] and [`Client::poll_interval`].
+    async fn poll_verification_job<E: CustomError>(
+        &self,
+        verification_id: &str,
+    ) -> Result<VerificationJob, Error<E>> {
+        let url = self.generate_url(&format!("v2/verify/{verification_id}"));
+        for _ in 0..self.max_poll_attempts {
+            let response = self
+                .reqwest_client
+                .get(url.clone())
+                .send()
+                .await
+                .map_err(map_middleware_error)?;
+            let job: VerificationJob = process_v2_response(response).await?;
+            if job.is_job_completed {
+                return Ok(job);
+            }
+            tokio::time::sleep(self.poll_interval).await;
+        }
+
+        Err(Error::Sourcify(SourcifyError::InternalServerError(
+            format!(
+                "verification job '{verification_id}' did not complete within {} attempts",
+                self.max_poll_attempts
+            ),
+        )))
+    }
+
+    /// Resolves a completed job into either a verified contract (fetched from the
+    /// contract endpoint) or an appropriately mapped error.
+    async fn finalize_job<E: CustomError>(
+        &self,
+        chain_id: &str,
+        contract_address: Bytes,
+        job: VerificationJob,
+    ) -> Result<VerifiedContract, Error<E>> {
+        let is_matched = job
+            .contract
+            .as_ref()
+            .is_some_and(|contract| contract.match_type.is_some());
+        if is_matched {
+            return self.get_contract_v2(chain_id, contract_address).await;
+        }
+
+        if let Some(error) = job.error {
+            return Err(map_v2_error::<E>(error.custom_code, error.message, None));
+        }
+
+        Err(Error::Sourcify(SourcifyError::InternalServerError(
+            "verification job completed without a contract match or an error".to_string(),
+        )))
+    }
+
+    /// Fetches a verified contract (`GET /v2/contract/{chain}/{address}`),
+    /// requesting only the fields required to reconstruct a verification success.
+    async fn get_contract_v2<E: CustomError>(
+        &self,
+        chain_id: &str,
+        contract_address: Bytes,
+    ) -> Result<VerifiedContract, Error<E>> {
+        let url = self.generate_url(&format!(
+            "v2/contract/{chain_id}/{}",
+            ToHex::to_hex(&contract_address)
+        ));
+        let response = self
+            .reqwest_client
+            .get(url)
+            // Note: `match`/`runtimeMatch` are always-present base fields and are
+            // rejected if passed as explicit field selectors.
+            .query(&[("fields", "sources,metadata,creationBytecode")])
+            .send()
+            .await
+            .map_err(map_middleware_error)?;
+
+        let contract: ContractResponse = process_v2_response(response).await?;
+        VerifiedContract::from_response(chain_id.to_string(), contract_address, contract)
+            .map_err(|err| Error::Sourcify(SourcifyError::InternalServerError(err)))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SubmitResponse {
+    #[serde(rename = "verificationId")]
+    verification_id: String,
+}
+
+/// The `GenericErrorResponse` shape shared by all v2 error responses.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct V2ErrorResponse {
+    custom_code: String,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    error_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ContractResponse {
+    #[serde(rename = "match", default)]
+    match_type: Option<String>,
+    #[serde(default)]
+    runtime_match: Option<String>,
+    #[serde(default)]
+    sources: Option<BTreeMap<String, SourceContent>>,
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
+    #[serde(default)]
+    creation_bytecode: Option<CreationBytecode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SourceContent {
+    content: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreationBytecode {
+    #[serde(default)]
+    transformation_values: Option<TransformationValues>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TransformationValues {
+    #[serde(default)]
+    constructor_arguments: Option<String>,
+}
+
+impl VerifiedContract {
+    fn from_response(
+        chain_id: String,
+        address: Bytes,
+        response: ContractResponse,
+    ) -> Result<Self, String> {
+        let match_type = response
+            .match_type
+            .or(response.runtime_match)
+            .ok_or_else(|| "sourcify contract response is missing a match status".to_string())
+            .and_then(|value| {
+                MatchType::from_v2(&value).ok_or_else(|| format!("unknown match status: {value}"))
+            })?;
+
+        let metadata = response
+            .metadata
+            .ok_or_else(|| "sourcify contract response is missing metadata".to_string())?;
+
+        let sources = response
+            .sources
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(path, source)| (path, source.content))
+            .collect();
+
+        let constructor_arguments = response
+            .creation_bytecode
+            .and_then(|bytecode| bytecode.transformation_values)
+            .and_then(|values| values.constructor_arguments)
+            .map(|hex| decode_hex(&hex).map(Bytes::from))
+            .transpose()
+            .map_err(|err| format!("invalid constructor arguments returned by sourcify: {err}"))?;
+
+        Ok(Self {
+            chain_id,
+            address,
+            match_type,
+            sources,
+            metadata,
+            constructor_arguments,
+        })
+    }
+}
+
+impl MatchType {
+    /// Parses a Sourcify API v2 match status (`exact_match` / `match`).
+    pub(crate) fn from_v2(value: &str) -> Option<Self> {
+        match value {
+            "exact_match" => Some(MatchType::Full),
+            "match" => Some(MatchType::Partial),
+            _ => None,
+        }
+    }
+}
+
+fn map_middleware_error<E: CustomError>(error: reqwest_middleware::Error) -> Error<E> {
+    match error {
+        reqwest_middleware::Error::Middleware(err) => Error::ReqwestMiddleware(err),
+        reqwest_middleware::Error::Reqwest(err) => Error::Reqwest(err),
+    }
+}
+
+/// Deserializes a successful (`2xx`) v2 response, or maps an error response
+/// (`GenericErrorResponse`) onto the appropriate [`Error`], giving the flow's
+/// custom error type first crack at interpreting the `customCode`.
+async fn process_v2_response<T: DeserializeOwned, E: CustomError>(
+    response: Response,
+) -> Result<T, Error<E>> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response.json::<T>().await?);
+    }
+
+    let error = response.json::<V2ErrorResponse>().await?;
+    Err(map_v2_error::<E>(
+        error.custom_code,
+        error.message,
+        Some(status),
+    ))
+}
+
+/// Maps a v2 `customCode` (with optional HTTP status for the fallback) onto an
+/// [`Error`]. The concrete custom error type `E` is consulted first, so that
+/// endpoint-specific meanings (e.g. Etherscan-import failures) take precedence
+/// over the generic interpretation.
+fn map_v2_error<E: CustomError>(
+    custom_code: String,
+    message: Option<String>,
+    status: Option<StatusCode>,
+) -> Error<E> {
+    let message = message.unwrap_or_default();
+
+    if let Some(custom) = E::handle_custom_code(&custom_code, &message) {
+        return Error::Sourcify(SourcifyError::Custom(custom));
+    }
+
+    let error = match custom_code.as_str() {
+        "unsupported_chain" => SourcifyError::ChainNotSupported(message),
+        "job_not_found" | "not_found" => SourcifyError::NotFound(message),
+        // Terminal verification outcomes reported by a completed job.
+        "no_match" | "compiler_error" | "verified_with_errors" => {
+            SourcifyError::VerificationFailure(message)
+        }
+        "too_many_requests" | "etherscan_limit" => SourcifyError::UnexpectedStatusCode {
+            status_code: StatusCode::TOO_MANY_REQUESTS,
+            msg: message,
+        },
+        "internal_error" => SourcifyError::InternalServerError(message),
+        _ => match status {
+            Some(StatusCode::NOT_FOUND) => SourcifyError::NotFound(message),
+            Some(StatusCode::BAD_REQUEST) => SourcifyError::BadRequest(message),
+            Some(StatusCode::BAD_GATEWAY) => SourcifyError::BadGateway(message),
+            Some(StatusCode::INTERNAL_SERVER_ERROR) => SourcifyError::InternalServerError(message),
+            Some(status_code) => SourcifyError::UnexpectedStatusCode {
+                status_code,
+                msg: message,
+            },
+            None => SourcifyError::InternalServerError(message),
+        },
+    };
+    Error::Sourcify(error)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ClientBuilder;
+    use blockscout_display_bytes::decode_hex;
+
+    fn client() -> Client {
+        ClientBuilder::default()
+            .try_base_url("https://staging.sourcify.dev/server/")
+            .unwrap()
+            .build()
+    }
+
+    // The exact inputs of the smart-contract-verifier `chain_not_supported_fail`
+    // test: chain 2221 is not supported for Etherscan import, and v2 reports it
+    // via a `400 unsupported_chain`, which must surface as a verification-level
+    // `ChainNotSupported` (so downstream it becomes a FAILURE, not a 500).
+    #[tokio::test]
+    async fn verify_from_etherscan_v2_chain_not_supported() {
+        let address = decode_hex("0xcb566e3B6934Fa77258d68ea18E931fa75e1aaAa")
+            .unwrap()
+            .into();
+        let result = client()
+            .verify_from_etherscan_v2("2221", address, None)
+            .await
+            .expect_err("error expected");
+        assert!(
+            matches!(
+                &result,
+                Error::Sourcify(SourcifyError::Custom(
+                    VerifyFromEtherscanError::ChainNotSupported(message)
+                )) if message.contains("is not supported for importing from Etherscan")
+            ),
+            "expected Custom(ChainNotSupported) with etherscan message, got: {result:?}"
+        );
+    }
+}


### PR DESCRIPTION
Sourcify permanently sunset its API v1, so add a v2 client alongside the existing surface. v2 verification is async and job-based (submit -> poll -> fetch contract) and covers both flows:

- verify_via_metadata_v2: POST /v2/verify/metadata/{chain}/{addr}
- verify_from_etherscan_v2: POST /v2/verify/etherscan/{chain}/{addr}

Both return a rich VerifiedContract (sources, metadata, constructor arguments, match type). The poll loop is bounded by max_poll_attempts.

- ClientBuilder gains request_timeout / poll_interval / max_poll_attempts
- SourcifyError::VerificationFailure models the async no-match outcome
- CustomError::handle_custom_code hook for context-aware v2 error codes