### PR TITLE
feat(sourcify): add public get_contract_v2 lookup

### DIFF
--- a/libs/sourcify/src/v2.rs
+++ b/libs/sourcify/src/v2.rs
@@ -150,7 +150,7 @@ impl Client {
 
         // The contract is already verified — return the stored result.
         if response.status() == StatusCode::CONFLICT {
-            return self.get_contract_v2(chain_id, contract_address).await;
+            return self.fetch_contract(chain_id, contract_address).await;
         }
 
         let submitted: SubmitResponse = process_v2_response(response).await?;
@@ -202,7 +202,7 @@ impl Client {
             .as_ref()
             .is_some_and(|contract| contract.match_type.is_some());
         if is_matched {
-            return self.get_contract_v2(chain_id, contract_address).await;
+            return self.fetch_contract(chain_id, contract_address).await;
         }
 
         if let Some(error) = job.error {
@@ -211,7 +211,7 @@ impl Client {
             // instead of an error, mirroring the 409 handling on the metadata
             // endpoint (`verify_via_metadata_v2`).
             if error.custom_code == "already_verified" {
-                return self.get_contract_v2(chain_id, contract_address).await;
+                return self.fetch_contract(chain_id, contract_address).await;
             }
             return Err(map_v2_error::<E>(error.custom_code, error.message, None));
         }
@@ -221,9 +221,30 @@ impl Client {
         )))
     }
 
+    /// Fetches an already-verified contract from Sourcify (`GET
+    /// /v2/contract/{chain}/{address}`) without triggering a (re)verification.
+    ///
+    /// This is the v2 replacement for the (sunset) v1 `GET /files/any/...`
+    /// lookup: it returns the stored sources and metadata for a contract that
+    /// Sourcify has already verified, or a [`SourcifyError::NotFound`] when it
+    /// has not.
+    pub async fn get_contract_v2(
+        &self,
+        chain_id: &str,
+        contract_address: Bytes,
+    ) -> Result<VerifiedContract, Error<EmptyCustomError>> {
+        self.fetch_contract(chain_id, contract_address).await
+    }
+
     /// Fetches a verified contract (`GET /v2/contract/{chain}/{address}`),
     /// requesting only the fields required to reconstruct a verification success.
-    async fn get_contract_v2<E: CustomError>(
+    ///
+    /// Generic over the custom error type so the verification flows can reuse it
+    /// while surfacing their own endpoint-specific errors; [`get_contract_v2`]
+    /// is the public, concretely-typed entry point.
+    ///
+    /// [`get_contract_v2`]: Client::get_contract_v2
+    async fn fetch_contract<E: CustomError>(
         &self,
         chain_id: &str,
         contract_address: Bytes,


### PR DESCRIPTION
## What

Expose a public, concretely-typed `Client::get_contract_v2` on the `sourcify` lib that fetches an **already-verified** contract via `GET /v2/contract/{chain}/{address}` **without** triggering a (re)verification.

```rust
pub async fn get_contract_v2(
    &self,
    chain_id: &str,
    contract_address: Bytes,
) -> Result<VerifiedContract, Error<EmptyCustomError>>
```

## Why

After the v2 cleanup, the lib's only public methods (`verify_from_etherscan_v2`, `verify_via_metadata_v2`) submit a verification job (submit → poll → fetch). There is no public way to do a plain "do you already have this verified, give me the sources" lookup — the v2 replacement for the removed v1 `get_source_files_any` (`GET /files/any/...`).

Downstream consumers need it: `eth-bytecode-db`'s `search-sourcify-sources` path only has a chain + address and just wants the stored contract. This unblocks migrating that path off dead v1 (a follow-up PR bumps the rev and lands the migration).

## How

The `GET /v2/contract` logic already existed privately. It is reused:
- the private helper `get_contract_v2<E>` is renamed `fetch_contract<E>` (kept generic so the verify flows keep surfacing their own endpoint-specific errors);
- the new public `get_contract_v2` is a thin wrapper over it returning `Error<EmptyCustomError>`;
- 404 / `not_found` → `SourcifyError::NotFound`.

Purely additive; **no behavior change** to existing flows. `cargo clippy` / `fmt` / test-compile clean.