### PR TITLE
feat(eth-bytecode-db): migrate Sourcify lookup to API v2

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -6697,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "sourcify"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=457af68#457af68c8c09046530ec174112be6443ae34ff19"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=48a84ac#48a84acfbfd5ef8f2dad85131bf267e9038b8f54"
 dependencies = [
  "anyhow",
  "blockscout-display-bytes",
@@ -6708,6 +6708,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 1.0.65",
+ "tokio",
  "tracing",
  "url",
 ]

--- a/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/Cargo.toml
@@ -64,7 +64,7 @@ sha2 = { version = "0.10.8" }
 sha3 = { version = "0.10.8" }
 smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "232bee4" }
 solidity-metadata = { version = "1.0" }
-sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "457af68" }
+sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "48a84ac" }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
 test-log = { version = "0.2.16" }
 thiserror = { version = "1" }

--- a/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/services/database.rs
@@ -326,7 +326,7 @@ impl DatabaseService {
 
         let sourcify_result = self
             .sourcify_client
-            .get_source_files_any(chain_id, contract_address)
+            .get_contract_v2(chain_id, contract_address)
             .await
             .map_err(process_sourcify_error);
 
@@ -385,6 +385,13 @@ fn process_sourcify_error(
             ))
         }
         sourcify::Error::Sourcify(sourcify::SourcifyError::InternalServerError(_)) => {
+            tracing::error!(target: "sourcify", "{error}");
+            Some(tonic::Status::internal("sourcify responded with error"))
+        }
+        // A plain contract lookup never runs a verification job, so this
+        // terminal-outcome variant is not expected here; treat it defensively as
+        // a server-side error.
+        sourcify::Error::Sourcify(sourcify::SourcifyError::VerificationFailure(_)) => {
             tracing::error!(target: "sourcify", "{error}");
             Some(tonic::Status::internal("sourcify responded with error"))
         }

--- a/eth-bytecode-db/eth-bytecode-db-server/src/types/source.rs
+++ b/eth-bytecode-db/eth-bytecode-db-server/src/types/source.rs
@@ -59,11 +59,11 @@ impl From<search::MatchContract> for SourceWrapper {
     }
 }
 
-impl TryFrom<sourcify::GetSourceFilesResponse> for SourceWrapper {
+impl TryFrom<sourcify::VerifiedContract> for SourceWrapper {
     type Error = tonic::Status;
 
-    fn try_from(value: sourcify::GetSourceFilesResponse) -> Result<Self, Self::Error> {
-        let match_type = MatchTypeWrapper::from(value.status).into_inner();
+    fn try_from(value: sourcify::VerifiedContract) -> Result<Self, Self::Error> {
+        let match_type = MatchTypeWrapper::from(value.match_type).into_inner();
 
         let metadata: ethers::solc::artifacts::Metadata =
             serde_json::from_value(value.metadata.clone()).map_err(|err| {
@@ -241,47 +241,29 @@ mod tests {
     }
 
     #[test]
-    fn try_from_sourcify_get_source_files_response_to_proto_source() {
-        let sourcify_response: sourcify::GetSourceFilesResponse = serde_json::from_value(serde_json::json ! ({
-            "status": "full",
-            "files": [
-                {
-                    "name": "immutable-references.json",
-                    "path": "/data/repository/contracts/full_match/5/0xb5fa8e1E33df0742Fa40F7bB5f41e782eb5524c3/immutable-references.json",
-                    "content": "{\"76\":[{\"length\":32,\"start\":242}],\"90\":[{\"length\":32,\"start\":636}],\"92\":[{\"length\":32,\"start\":708}]}"
-                },
-                {
-                    "name": "library-map.json",
-                    "path": "/data/repository/contracts/full_match/5/0xb5fa8e1E33df0742Fa40F7bB5f41e782eb5524c3/library-map.json",
-                    "content": "{\"__$b01ade520cf6862e0b214d4ce779d49f2a$__\":\"77479d54e233b4b79b9e3f4cf2bd20575fdeb1bb\",\"__$21bb6923d223bd045c4cab9806bdf3594d$__\":\"4ea76bb37c82f6f453c4cbb4ae726036a7a8b820\"}"
-                },
-                {
-                    "name": "metadata.json",
-                    "path": "/data/repository/contracts/full_match/5/0xb5fa8e1E33df0742Fa40F7bB5f41e782eb5524c3/metadata.json",
-                    "content": "{\"compiler\":{\"version\":\"0.8.7+commit.e28d00a7\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_c\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"a\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"arr\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"b\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"c\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"test_array\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/C2.sol\":\"C2\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"contracts/Array.sol\":{\"keccak256\":\"0xa3c043d47c03251f392e0dcdf7c2ad5069436cc72561b2404a195d84a78fb33c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://9eeae2fe8bb3e5addd48dea0b8c5a81581b4137ad605b103b7edc35ea1ab2997\",\"dweb:/ipfs/QmRaC1FTQxkcWwmyZeZ4twQswdpcTnN5GQJ2Db7RMdf14j\"]},\"contracts/Array2.sol\":{\"keccak256\":\"0x6b5b4acc9b4f10f7df803702516752978c40cb4eadd48a218dcc0503fd7f4f88\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6f9b39fbd016e6b0c62cb3a7d8abc8981fe383c345381dfd7533a8cb8a1ded69\",\"dweb:/ipfs/QmUznGnpnz1TFuQZzjDX4NzoVFsiwRzaA2T7gZQZUoFDim\"]},\"contracts/C1.sol\":{\"keccak256\":\"0x92ca0ef5999e6bae5556c90314c3b7fe3bf95cabf8423d8415ac3d3955f524df\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1bb5f1bc39e5507da05e9d7700546f74896b47c4da076fbd744d8b6269c32a09\",\"dweb:/ipfs/QmRoabfGHHmoKTPb8vtdWFuaesoc4mUjzuSgEDE8TpeYwF\"]},\"contracts/C2.sol\":{\"keccak256\":\"0x20dd630583b88340fae8cda0a6008c0db058ee4b35d8a1f5a44bcd66ef892782\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://998e0420f165f61fec241b5fbd71f06bc150098c8981f0aeedbf5a95c240b2a0\",\"dweb:/ipfs/QmSG3mwV4zqk4NacHtf3MWSAbWW96sorEVjNBPJiWXs2LQ\"]}},\"version\":1}"
-                },
-                {
-                    "name": "Array.sol",
-                    "path": "/data/repository/contracts/full_match/5/0xb5fa8e1E33df0742Fa40F7bB5f41e782eb5524c3/sources/contracts/Array.sol",
-                    "content": "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\n// Array function to delete element at index and re-organize the array\n// so that there are no gaps between the elements.\nlibrary Array {\n    function remove(uint[] storage arr, uint index) public {\n        // Move the last element into the place to delete\n        require(arr.length > 0, \"Can't remove from empty array\");\n        arr[index] = arr[arr.length - 1];\n        arr.pop();\n    }\n}\n"
-                },
-                {
-                    "name": "Array2.sol",
-                    "path": "/data/repository/contracts/full_match/5/0xb5fa8e1E33df0742Fa40F7bB5f41e782eb5524c3/sources/contracts/Array2.sol",
-                    "content": "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\n// Array function to delete element at index and re-organize the array\n// so that there are no gaps between the elements.\nlibrary Array2 {\n    function remove(uint[] storage arr, uint index) public {\n        // Move the last element into the place to delete\n        require(arr.length > 0, \"Can't remove from empty array\");\n        arr[index] = arr[arr.length - 1];\n        arr.pop();\n    }\n}\n"
-                },
-                {
-                    "name": "C1.sol",
-                    "path": "/data/repository/contracts/full_match/5/0xb5fa8e1E33df0742Fa40F7bB5f41e782eb5524c3/sources/contracts/C1.sol",
-                    "content": "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\ncontract C1 {\n    uint256 immutable public a = 0;\n}\n\n"
-                },
-                {
-                    "name": "C2.sol",
-                    "path": "/data/repository/contracts/full_match/5/0xb5fa8e1E33df0742Fa40F7bB5f41e782eb5524c3/sources/contracts/C2.sol",
-                    "content": "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\nimport \"./C1.sol\";\nimport \"./Array.sol\";\nimport \"./Array2.sol\";\n\ncontract C2 is C1 {\n    uint[] public arr;\n\n    uint256 immutable public b = 10;\n    uint256 immutable public c;\n\n    constructor(uint256 _c) {\n        c = _c;\n    }\n\n    function test_array() public {\n        for (uint i = 0; i < 3; i++) {\n            arr.push(i);\n        }\n\n        Array.remove(arr, 1);\n        Array2.remove(arr, 1);\n\n        assert(arr.length == 1);\n        assert(arr[0] == 0);\n    }\n}\n"
-                }
-            ]
-        })).unwrap();
+    fn try_from_sourcify_verified_contract_to_proto_source() {
+        let sources = BTreeMap::from([
+            ("contracts/Array.sol".to_string(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\n// Array function to delete element at index and re-organize the array\n// so that there are no gaps between the elements.\nlibrary Array {\n    function remove(uint[] storage arr, uint index) public {\n        // Move the last element into the place to delete\n        require(arr.length > 0, \"Can't remove from empty array\");\n        arr[index] = arr[arr.length - 1];\n        arr.pop();\n    }\n}\n".to_string()),
+            ("contracts/Array2.sol".to_string(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\n// Array function to delete element at index and re-organize the array\n// so that there are no gaps between the elements.\nlibrary Array2 {\n    function remove(uint[] storage arr, uint index) public {\n        // Move the last element into the place to delete\n        require(arr.length > 0, \"Can't remove from empty array\");\n        arr[index] = arr[arr.length - 1];\n        arr.pop();\n    }\n}\n".to_string()),
+            ("contracts/C1.sol".to_string(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\ncontract C1 {\n    uint256 immutable public a = 0;\n}\n\n".to_string()),
+            ("contracts/C2.sol".to_string(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\nimport \"./C1.sol\";\nimport \"./Array.sol\";\nimport \"./Array2.sol\";\n\ncontract C2 is C1 {\n    uint[] public arr;\n\n    uint256 immutable public b = 10;\n    uint256 immutable public c;\n\n    constructor(uint256 _c) {\n        c = _c;\n    }\n\n    function test_array() public {\n        for (uint i = 0; i < 3; i++) {\n            arr.push(i);\n        }\n\n        Array.remove(arr, 1);\n        Array2.remove(arr, 1);\n\n        assert(arr.length == 1);\n        assert(arr[0] == 0);\n    }\n}\n".to_string()),
+        ]);
+
+        // Standard Solidity metadata, exactly as the v2 `GET /v2/contract`
+        // endpoint returns it under the `metadata` field.
+        let metadata: serde_json::Value = serde_json::from_str(
+            "{\"compiler\":{\"version\":\"0.8.7+commit.e28d00a7\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_c\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"a\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"arr\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"b\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"c\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"test_array\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/C2.sol\":\"C2\"},\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]},\"sources\":{\"contracts/Array.sol\":{\"keccak256\":\"0xa3c043d47c03251f392e0dcdf7c2ad5069436cc72561b2404a195d84a78fb33c\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://9eeae2fe8bb3e5addd48dea0b8c5a81581b4137ad605b103b7edc35ea1ab2997\",\"dweb:/ipfs/QmRaC1FTQxkcWwmyZeZ4twQswdpcTnN5GQJ2Db7RMdf14j\"]},\"contracts/Array2.sol\":{\"keccak256\":\"0x6b5b4acc9b4f10f7df803702516752978c40cb4eadd48a218dcc0503fd7f4f88\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://6f9b39fbd016e6b0c62cb3a7d8abc8981fe383c345381dfd7533a8cb8a1ded69\",\"dweb:/ipfs/QmUznGnpnz1TFuQZzjDX4NzoVFsiwRzaA2T7gZQZUoFDim\"]},\"contracts/C1.sol\":{\"keccak256\":\"0x92ca0ef5999e6bae5556c90314c3b7fe3bf95cabf8423d8415ac3d3955f524df\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://1bb5f1bc39e5507da05e9d7700546f74896b47c4da076fbd744d8b6269c32a09\",\"dweb:/ipfs/QmRoabfGHHmoKTPb8vtdWFuaesoc4mUjzuSgEDE8TpeYwF\"]},\"contracts/C2.sol\":{\"keccak256\":\"0x20dd630583b88340fae8cda0a6008c0db058ee4b35d8a1f5a44bcd66ef892782\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://998e0420f165f61fec241b5fbd71f06bc150098c8981f0aeedbf5a95c240b2a0\",\"dweb:/ipfs/QmSG3mwV4zqk4NacHtf3MWSAbWW96sorEVjNBPJiWXs2LQ\"]}},\"version\":1}",
+        )
+        .unwrap();
+
+        let verified_contract = sourcify::VerifiedContract {
+            chain_id: "5".to_string(),
+            address: Default::default(),
+            match_type: sourcify::MatchType::Full,
+            sources: sources.clone(),
+            metadata,
+            constructor_arguments: None,
+        };
 
         let expected = proto::Source {
             file_name: "contracts/C2.sol".to_string(),
@@ -289,12 +271,7 @@ mod tests {
             compiler_version: "0.8.7+commit.e28d00a7".to_string(),
             compiler_settings: "{\"evmVersion\":\"london\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":false,\"runs\":200},\"remappings\":[]}".to_string(),
             source_type: proto::source::SourceType::Solidity.into(),
-            source_files: BTreeMap::from([
-                ("contracts/Array.sol".into(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\n// Array function to delete element at index and re-organize the array\n// so that there are no gaps between the elements.\nlibrary Array {\n    function remove(uint[] storage arr, uint index) public {\n        // Move the last element into the place to delete\n        require(arr.length > 0, \"Can't remove from empty array\");\n        arr[index] = arr[arr.length - 1];\n        arr.pop();\n    }\n}\n".into()),
-                ("contracts/Array2.sol".into(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\n// Array function to delete element at index and re-organize the array\n// so that there are no gaps between the elements.\nlibrary Array2 {\n    function remove(uint[] storage arr, uint index) public {\n        // Move the last element into the place to delete\n        require(arr.length > 0, \"Can't remove from empty array\");\n        arr[index] = arr[arr.length - 1];\n        arr.pop();\n    }\n}\n".into()),
-                ("contracts/C1.sol".into(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\ncontract C1 {\n    uint256 immutable public a = 0;\n}\n\n".into()),
-                ("contracts/C2.sol".into(), "// SPDX-License-Identifier: MIT\npragma solidity 0.8.7;\n\nimport \"./C1.sol\";\nimport \"./Array.sol\";\nimport \"./Array2.sol\";\n\ncontract C2 is C1 {\n    uint[] public arr;\n\n    uint256 immutable public b = 10;\n    uint256 immutable public c;\n\n    constructor(uint256 _c) {\n        c = _c;\n    }\n\n    function test_array() public {\n        for (uint i = 0; i < 3; i++) {\n            arr.push(i);\n        }\n\n        Array.remove(arr, 1);\n        Array2.remove(arr, 1);\n\n        assert(arr.length == 1);\n        assert(arr[0] == 0);\n    }\n}\n".into()),
-            ]),
+            source_files: sources,
             abi: Some("[{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_c\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"a\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"arr\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"b\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"c\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"test_array\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]".into()),
             constructor_arguments: None,
             match_type: proto::source::MatchType::Full.into(),
@@ -305,7 +282,7 @@ mod tests {
             libraries: BTreeMap::new(),
         };
 
-        let result = SourceWrapper::try_from(sourcify_response)
+        let result = SourceWrapper::try_from(verified_contract)
             .expect("converting into SourceWrapper failed")
             .into_inner();
         assert_eq!(expected, result);


### PR DESCRIPTION
## What

Migrates eth-bytecode-db's `search-sourcify-sources` path off the dead Sourcify API v1 onto v2.

## Why

Sourcify permanently sunset API v1 (503 brownout). The `search_sourcify_sources` flow used `get_source_files_any` (`GET /files/any/{chain}/{address}`), which is gone. The v2 equivalent is a plain contract lookup: `GET /v2/contract/{chain}/{address}`.

## How

- **`database.rs`**: `search_sourcify_sources_internal` now calls the lib's new public `get_contract_v2` instead of `get_source_files_any`. `process_sourcify_error` gains an arm for the new `SourcifyError::VerificationFailure` variant (not reachable on a plain lookup — mapped defensively to an internal error) so the match stays exhaustive against the newer lib.
- **`types/source.rs`**: `TryFrom<sourcify::GetSourceFilesResponse>` → `TryFrom<sourcify::VerifiedContract>`. The body is essentially unchanged — `value.status` → `value.match_type`, and `sources` / `metadata` / `constructor_arguments` line up 1:1. The unit test is rebuilt around a `VerifiedContract`.
- **rev bump**: `sourcify` git rev `457af68` → `48a84ac` (which adds the public `get_contract_v2`, #1711).

The gRPC `SourcifyVerifier` proxy of the verifier is on a separate, wire-compatible surface and is unaffected.

## Testing

- `cargo check` / `clippy` / `fmt --check` clean; workspace integration tests compile (feature-unified).
- New offline unit test `try_from_sourcify_verified_contract_to_proto_source` passes.
- The live e2e `database_search.rs::search_sourcify_sources` (chain 11155111, addr `0x86797c973a67BB3641deE95b3C04075aA809c908`) is a black-box gRPC test — no v1/v2 types, so unchanged — but it's `#[ignore]` (needs Postgres) and hits real Sourcify, so it exercises the v2 path only under CI/staging.