### PR TITLE
fix(eth-bytecode-db): bump sourcify to 0e6bab8 for not-found lookups

### DIFF
--- a/eth-bytecode-db/Cargo.lock
+++ b/eth-bytecode-db/Cargo.lock
@@ -6697,7 +6697,7 @@ dependencies = [
 [[package]]
 name = "sourcify"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=48a84ac#48a84acfbfd5ef8f2dad85131bf267e9038b8f54"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=0e6bab8#0e6bab8ca00c28ad66ae1f3c7f5d530a7a4b75aa"
 dependencies = [
  "anyhow",
  "blockscout-display-bytes",

--- a/eth-bytecode-db/Cargo.toml
+++ b/eth-bytecode-db/Cargo.toml
@@ -64,7 +64,7 @@ sha2 = { version = "0.10.8" }
 sha3 = { version = "0.10.8" }
 smart-contract-verifier-proto = { git = "https://github.com/blockscout/blockscout-rs", rev = "232bee4" }
 solidity-metadata = { version = "1.0" }
-sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "48a84ac" }
+sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "0e6bab8" }
 strum = { version = "0.27", default-features = false, features = ["derive"] }
 test-log = { version = "0.2.16" }
 thiserror = { version = "1" }


### PR DESCRIPTION
Follow-up to the just-merged Sourcify v2 migration (#1712).

## Why

#1712 pinned `sourcify` at `48a84ac`, which has a bug: Sourcify v2's contract endpoint answers a **not-found** lookup with a `404` and a contract-shaped body that has **no `customCode`**:

```
HTTP 404
{"match":null,"creationMatch":null,"runtimeMatch":null,"chainId":"…","address":"…"}
```

The old client decoded every non-2xx body as `{customCode,…}`, so it failed with *"missing field `customCode`"* → `Error::Reqwest`. In eth-bytecode-db this turned **every `search_sourcify_sources` lookup of an address not verified on Sourcify (the common case) into a 500** instead of an empty result.

## Change

Bump `sourcify` rev `48a84ac` → `0e6bab8` (lib fix #1713), which maps non-`GenericErrorResponse` error bodies by HTTP status (`404` → `NotFound`, which this crate already maps to `None`). Pure dependency bump — no code changes here.

`cargo check` / `clippy` / `fmt` clean.