### PR TITLE
fix(sourcify): map etherscan not_etherscan_verified to a verification failure

### DIFF
--- a/libs/sourcify/src/types.rs
+++ b/libs/sourcify/src/types.rs
@@ -63,8 +63,14 @@ mod verify_from_etherscan {
             match custom_code {
                 "unsupported_chain" => Some(VerifyFromEtherscanError::ChainNotSupported(message)),
                 // The recompiled bytecode did not match, or the contract is not
-                // verified on the upstream Etherscan instance.
-                "no_match" | "not_verified" | "contract_not_verified" => {
+                // verified on the upstream Etherscan instance. `not_etherscan_verified`
+                // is the code Sourcify actually returns for the latter (a `404`),
+                // which must map to a verification failure rather than fall through
+                // to the generic `404 -> NotFound` handling.
+                "no_match"
+                | "not_verified"
+                | "contract_not_verified"
+                | "not_etherscan_verified" => {
                     Some(VerifyFromEtherscanError::ContractNotVerified(message))
                 }
                 "compiler_error" | "verified_with_errors" => {

--- a/libs/sourcify/src/v2.rs
+++ b/libs/sourcify/src/v2.rs
@@ -507,6 +507,25 @@ mod tests {
         );
     }
 
+    // Sourcify reports "contract not verified on Etherscan" via a `404` with
+    // `customCode: not_etherscan_verified`. The Etherscan-import flow must map it
+    // to a verification failure (-> HTTP 200 + FAILURE downstream), not let the
+    // `404` fall through to `NotFound` (-> a spurious 400).
+    #[test]
+    fn etherscan_not_verified_maps_to_contract_not_verified() {
+        let body = r#"{"customCode":"not_etherscan_verified","message":"This contract is not verified on Etherscan."}"#;
+        let error = map_error_response::<VerifyFromEtherscanError>(StatusCode::NOT_FOUND, body);
+        assert!(
+            matches!(
+                error,
+                Error::Sourcify(SourcifyError::Custom(
+                    VerifyFromEtherscanError::ContractNotVerified(_)
+                ))
+            ),
+            "expected Custom(ContractNotVerified), got: {error:?}"
+        );
+    }
+
     // A well-formed `GenericErrorResponse` is still interpreted via its
     // `customCode`, not the HTTP-status fallback.
     #[test]


### PR DESCRIPTION
## Symptom

Verifier logs a WARN on `verify-from-etherscan`:

```
InvalidArgument: This contract is not verified on Etherscan.
```

i.e. a **400** for a contract that simply isn't verified on Etherscan.

## Cause

`VerifyFromEtherscanError::handle_custom_code` matched the *guessed* codes `no_match | not_verified | contract_not_verified`. But Sourcify actually returns (confirmed against the live API and cross-checked with the [swagger](https://sourcify.dev/server/api-docs/swagger.json)):

```
HTTP 404
{"customCode":"not_etherscan_verified","message":"This contract is not verified on Etherscan."}
```

That code was unrecognized, so it fell through to the generic `404 → NotFound`, which the verifier maps to `BadRequest → Status::invalid_argument` (**400**). The intended, v1-preserving behavior — and what the old `contract_not_verified_fail` test asserted — is **HTTP 200 + status `FAILURE`**.

## Fix

Recognize `not_etherscan_verified` as `ContractNotVerified` → `Error::Verification` → **200 + FAILURE**. Added an offline unit test.

Note: the two other previously-unhandled documented codes — `duplicate_verification_request` (429 "already being verified") and `proxy_resolution_error` (500 "RPC failed") — already fall through to acceptable status-based mappings, so they're left as-is.

## Rollout

The verifier picks this up on its next `sourcify` rev bump (which should also fold in the `0e6bab8` non-`customCode` error-body fix).