### PR TITLE
fix(verifier): bump sourcify to 7b1ba7b

### DIFF
--- a/smart-contract-verifier/Cargo.lock
+++ b/smart-contract-verifier/Cargo.lock
@@ -5426,7 +5426,7 @@ dependencies = [
 [[package]]
 name = "sourcify"
 version = "0.1.0"
-source = "git+https://github.com/blockscout/blockscout-rs?rev=7ce6cd3#7ce6cd312d9f3edf279e6c7a868fc046554f1309"
+source = "git+https://github.com/blockscout/blockscout-rs?rev=7b1ba7b#7b1ba7b3439a0c9858d67deb386205daaec4ac43"
 dependencies = [
  "anyhow",
  "blockscout-display-bytes",

--- a/smart-contract-verifier/Cargo.toml
+++ b/smart-contract-verifier/Cargo.toml
@@ -59,7 +59,7 @@ serde_path_to_error = { version = "0.1.16" }
 serde_with = { version = "3" }
 sha2 = { version = "0.10" }
 solidity-metadata = { version = "1.1.0" }
-sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "7ce6cd3" }
+sourcify = { git = "https://github.com/blockscout/blockscout-rs", rev = "7b1ba7b" }
 sscanf = { version = "0.3" }
 tempfile = { version = "3.19" }
 thiserror = { version = "1.0" }


### PR DESCRIPTION
Bumps the verifier's `sourcify` git rev `7ce6cd3` → `7b1ba7b`, picking up two Sourcify v2 client fixes:

- **`0e6bab8`** — handle v2 error bodies that lack `customCode`. The contract endpoint answers a not-found lookup with a `404` + contract-shaped body (no `customCode`); the old client failed to decode it (*"missing field `customCode`"*). Now falls back to HTTP-status mapping.
- **`7b1ba7b` (#1715)** — map the etherscan `not_etherscan_verified` code to a verification failure. Importing a contract that isn't verified on Etherscan now returns **HTTP 200 + `FAILURE`** (v1-preserving) instead of `400 InvalidArgument` (which was showing up as a WARN in the verifier logs).

Pure dependency bump — no verifier code changes. `cargo check` / `clippy --all-targets` / `fmt --all --check` and full workspace test-suite compile are clean against the new rev.