### PR TITLE
fix(bens): hide unnormalized ENS primary names

### DIFF
--- a/blockscout-ens/bens-logic/src/protocols/domain_name.rs
+++ b/blockscout-ens/bens-logic/src/protocols/domain_name.rs
@@ -214,6 +214,20 @@ impl<'a> DomainNameOnProtocol<'a> {
     }
 }
 
+/// Checks that `name` is already normalized according to ENSIP-15.
+///
+/// Reverse records are user-controlled, so an unnormalized name
+/// (e.g. `Metamask.eth`) must not be exposed as a primary name:
+/// normalizing it for display would make it look like a canonical
+/// name that may belong to a different address.
+pub fn is_ens_normalized(name: &str) -> bool {
+    !name.is_empty()
+        && ENS_NORMALIZER
+            .normalize(name)
+            .map(|normalized| normalized == name)
+            .unwrap_or(false)
+}
+
 fn ens_normalize(name: &str) -> Result<String, ProtocolError> {
     let trimmed = name.trim().trim_matches(SEPARATOR);
     let normalized = ENS_NORMALIZER
@@ -359,6 +373,27 @@ mod tests {
             domain_name.label_name(),
             "43c960fa130e3eb58e7aaf65f46f76b5c607c3a9"
         )
+    }
+
+    #[test]
+    fn is_ens_normalized_works() {
+        for (name, expected) in [
+            ("vitalik.eth", true),
+            ("metamask.eth", true),
+            // unnormalized names with uppercase letters must be rejected,
+            // not lowercased into a valid-looking canonical name
+            ("Metamask.eth", false),
+            ("VitaLiK.eth", false),
+            ("LEVVV.ETH", false),
+            ("wa🇬🇲i.eth", true),
+            ("levvv.gno", true),
+            // whitespace and separators are not trimmed here
+            (" vitalik.eth", false),
+            ("vitalik.eth.", false),
+            ("", false),
+        ] {
+            assert_eq!(is_ens_normalized(name), expected, "failed for {name:?}");
+        }
     }
 
     #[test]

--- a/blockscout-ens/bens-logic/src/protocols/mod.rs
+++ b/blockscout-ens/bens-logic/src/protocols/mod.rs
@@ -4,7 +4,7 @@ mod domain_name;
 pub mod hash_name;
 mod protocoler;
 
-pub use domain_name::{CleanName, DomainName, DomainNameOnProtocol};
+pub use domain_name::{is_ens_normalized, CleanName, DomainName, DomainNameOnProtocol};
 pub use hash_name::{hash_ens_domain_name, hash_infinity_domain_name};
 pub use protocoler::*;
 

--- a/blockscout-ens/bens-logic/src/subgraph/resolve_addresses.rs
+++ b/blockscout-ens/bens-logic/src/subgraph/resolve_addresses.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     entity::subgraph::domain::DomainWithAddress,
-    protocols::{hash_name::hex, AddressResolveTechnique, DomainName, Protocol},
+    protocols::{hash_name::hex, is_ens_normalized, AddressResolveTechnique, DomainName, Protocol},
     subgraph::{sql, sql::DbErr},
 };
 use alloy::primitives::Address;
@@ -36,7 +36,21 @@ pub async fn resolve_addresses(
                 resolve_primary_name_record(pool, &protocols, &addresses).await?
             }
         };
-        result.extend(found_domains);
+        // Primary names come from user-controlled records: hide names that
+        // are not already ENSIP-15 normalized, since normalizing them for
+        // display can make them look like a canonical name of a different
+        // address (e.g. `Metamask.eth` rendered as `metamask.eth`)
+        result.extend(found_domains.into_iter().filter(|domain| {
+            let normalized = is_ens_normalized(&domain.domain_name);
+            if !normalized {
+                tracing::warn!(
+                    domain_name = domain.domain_name,
+                    resolved_address = domain.resolved_address,
+                    "hiding unnormalized primary name",
+                );
+            }
+            normalized
+        }));
     }
     Ok(result)
 }


### PR DESCRIPTION
Fixes #1698

## Problem

BENS exposes an account's ENS primary name from a user-controlled reverse record. When the reverse record is not ENSIP-15 normalized (e.g. `Metamask.eth`), downstream lookup/display normalizes (lowercases) it, so the address page shows a valid-looking canonical name (`metamask.eth`) that actually belongs to a different address. This is a spoofing/confusion vector, since anyone can set an arbitrary reverse record.

Example from the issue:
- `0x9a659894e5D115846767dB0e1685744c452E7a6e` set reverse record `Metamask.eth` and was displayed as `metamask.eth`, while the real `metamask.eth` resolves to `0x0c54FcCd2e384b4BB6f2E405Bf5Cbc15a017AaFb`.

## Solution

Following the validation suggested in the issue:

- Added `is_ens_normalized` helper in `bens-logic`: a name is only considered valid if `ensip15_normalize(name) == name`.
- Applied it as a filter in `resolve_addresses`, which is the single choke point for all primary-name resolution techniques (`AllDomains`, `ReverseRegistry`, `Addr2Name`, `PrimaryNameRecord`). Unnormalized names are now hidden (with a warning log) instead of being surfaced and lowercased.
- The existing forward-resolution check (reverse record must resolve back to the same address) is unchanged and still applies.

This covers both the single-address endpoint (`get_address`) and the batch endpoint (`batch_resolve_address_names`), so the address page simply shows no ENS name for such addresses, as confirmed desired in the issue.

## Tests

- Added `is_ens_normalized_works` unit test covering mixed-case names (`Metamask.eth`, `VitaLiK.eth`, `LEVVV.ETH`), valid normalized names (incl. emoji name `wa🇬🇲i.eth`), and edge cases (leading whitespace, trailing separator, empty string).
