### PR TITLE
fix(tac): publish the v2 protos in the types package

### DIFF
--- a/tac-operation-lifecycle/types/index.ts
+++ b/tac-operation-lifecycle/types/index.ts
@@ -1,2 +1,3 @@
 export * from './dist/tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle';
 export * from './dist/tac-operation-lifecycle-proto/proto/v1/statistic';
+export * from './dist/tac-operation-lifecycle-proto/proto/v2/tac-operation-lifecycle';

--- a/tac-operation-lifecycle/types/package.json
+++ b/tac-operation-lifecycle/types/package.json
@@ -6,7 +6,7 @@
   "types": "./index.d.ts",
   "scripts": {
     "build": "npm run compile:proto && npm run compile:ts",
-    "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=exportCommonSymbols=false --ts_proto_opt=snakeToCamel=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto ../tac-operation-lifecycle-proto/proto/v1/statistic.proto",
+    "compile:proto": "mkdir -p ./dist && protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto --ts_proto_opt=exportCommonSymbols=false --ts_proto_opt=snakeToCamel=false --ts_proto_opt=stringEnums=true --ts_proto_opt=onlyTypes=true --ts_proto_opt=emitImportedFiles=false --proto_path=../ --proto_path=../../proto/ --ts_proto_out=./dist ../tac-operation-lifecycle-proto/proto/v1/tac-operation-lifecycle.proto ../tac-operation-lifecycle-proto/proto/v1/statistic.proto ../tac-operation-lifecycle-proto/proto/v2/tac-operation-lifecycle.proto",
     "compile:ts": "tsc --declaration ./index.ts"
   },
   "repository": {


### PR DESCRIPTION
## Problem

The Read API v2 protos landed in `tac-operation-lifecycle-proto/proto/v2/` in #1720, but the npm types package still compiles only the v1 files. `compile:proto` lists the two v1 protos explicitly, and `index.ts` re-exports only those.

The consequence: `@blockscout/tac-operation-lifecycle-types@1.2.0` was published *after* #1720 merged and still contains no v2 types at all — no `status`, no `rollback`, no `error_reason`. The frontend cannot type its v2 migration (blockscout/frontend#3627) against any published version.

## Change

Two lines:

- add `proto/v2/tac-operation-lifecycle.proto` to `compile:proto`
- re-export the generated v2 module from `index.ts`

## Verification

Built locally with `protoc` 27.0:

- `dist/tac-operation-lifecycle-proto/proto/v2/` is emitted alongside `v1/`
- `V2OperationBriefDetails` carries `status`, `rollback` and `error_reason`
- `V2OperationStatus` is a string enum with exactly `pending` / `success` / `failed`
- no exported name collides with the v1 module — every v2 message and enum is `V2`-prefixed, so `export *` from both entry points is safe

## Note

The beta publish for the frontend work can be dispatched from this branch (`npm-publisher-dev.yml`, `service: tac-operation-lifecycle`) without waiting for this to merge.