### PR TITLE
fix(stats): allow clippy::result_large_err for tonic::Status returns

### DIFF
--- a/stats/stats-proto/src/lib.rs
+++ b/stats/stats-proto/src/lib.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
-#![allow(clippy::derive_partial_eq_without_eq, unused_imports)]
+#![allow(
+    clippy::derive_partial_eq_without_eq,
+    clippy::result_large_err,
+    unused_imports
+)]
 pub mod blockscout {
     pub mod stats {
         pub mod v1 {

--- a/stats/stats-server/src/read_service.rs
+++ b/stats/stats-server/src/read_service.rs
@@ -425,6 +425,7 @@ impl ReadService {
             .await
     }
 
+    #[allow(clippy::result_large_err)]
     async fn query_line_chart(
         &self,
         name: String,


### PR DESCRIPTION
## Summary
- CI's linting job uses `dtolnay/rust-toolchain@stable` with no version pin, so it already runs Rust 1.98's clippy, which added a stricter `result_large_err` check. Local dev toolchains lag behind, so clippy passes locally while [this CI run](https://github.com/blockscout/blockscout-rs/actions/runs/32843113959/job/97786766389) fails.
- `tonic::Status` is ~176 bytes (`code` + `String` + `Bytes` + `MetadataMap`/`HeaderMap` + `Option<Arc<dyn Error>>`), which trips the lint wherever a function returns `Result<_, Status>` (or `Result<Response<T>, Status>`).
- Fails in two places:
  - `stats-proto`'s tonic-build generated client code (can't be edited, it's codegen output) — suppressed via the crate's existing `#![allow(...)]` list in `stats-proto/src/lib.rs`.
  - `stats-server::ReadService::query_line_chart` — suppressed via `#[allow(clippy::result_large_err)]` on the function, matching the existing pattern already used in this repo (e.g. `multichain-aggregator-server/src/services/multichain_aggregator.rs:61`, `da-indexer-server/src/services/mod.rs`, `eth-bytecode-db-server`, `smart-contract-verifier-server`, `sig-provider-server`, `proxy-verifier-server`, `stylus-verifier-server`) for the same `tonic::Status` situation.
- `Box<Status>` isn't an option here since the return types are dictated by the tonic-generated service trait contract.

## Test plan
- [x] Updated local `rustup stable` to 1.98.0 (matching CI) to reproduce the failure locally.
- [x] `cargo clippy --all --all-targets --all-features -- -D warnings` passes clean in `stats/` after the fix.
- [x] `cargo fmt --all -- --check --config imports_granularity=Crate` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)