### PR TITLE
feat(stats): add interchain 24h message/transfer counters

### DIFF
--- a/stats/config/interchain/charts.json
+++ b/stats/config/interchain/charts.json
@@ -28,6 +28,14 @@
     "total_interchain_transfer_users": {
       "title": "Total interchain transfer users",
       "description": "Number of unique addresses that sent or received interchain transfers"
+    },
+    "new_messages_interchain_24h": {
+      "title": "New interchain messages (24h)",
+      "description": "Number of new interchain messages within the last 24 hours"
+    },
+    "new_transfers_interchain_24h": {
+      "title": "New interchain transfers (24h)",
+      "description": "Number of new interchain transfers within the last 24 hours"
     }
   },
   "line_charts": {

--- a/stats/config/interchain/layout.json
+++ b/stats/config/interchain/layout.json
@@ -3,9 +3,11 @@
     "total_interchain_messages",
     "total_interchain_messages_sent",
     "total_interchain_messages_received",
+    "new_messages_interchain_24h",
     "total_interchain_transfers",
     "total_interchain_transfers_sent",
     "total_interchain_transfers_received",
+    "new_transfers_interchain_24h",
     "total_interchain_transfer_users"
   ],
   "line_chart_categories": [

--- a/stats/config/interchain/update_groups.json
+++ b/stats/config/interchain/update_groups.json
@@ -12,6 +12,7 @@
     "new_messages_received_interchain_group": "0 0 */2 * * * *",
     "new_transfers_interchain_group": "0 0 */2 * * * *",
     "new_transfers_sent_interchain_group": "0 0 */2 * * * *",
-    "new_transfers_received_interchain_group": "0 0 */2 * * * *"
+    "new_transfers_received_interchain_group": "0 0 */2 * * * *",
+    "interchain_24h_group": "0 20 * * * * *"
   }
 }

--- a/stats/stats-server/src/runtime_setup.rs
+++ b/stats/stats-server/src/runtime_setup.rs
@@ -531,6 +531,7 @@ impl RuntimeSetup {
             Arc::new(NewTransfersInterchainGroup),
             Arc::new(NewTransfersSentInterchainGroup),
             Arc::new(NewTransfersReceivedInterchainGroup),
+            Arc::new(Interchain24hGroup),
         ]
     }
 

--- a/stats/stats/src/charts/counters/interchain/mod.rs
+++ b/stats/stats/src/charts/counters/interchain/mod.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: LicenseRef-Blockscout
 
+mod new_messages_interchain_24h;
+mod new_transfers_interchain_24h;
 mod total_interchain_messages;
 mod total_interchain_messages_received;
 mod total_interchain_messages_sent;
@@ -8,6 +10,12 @@ mod total_interchain_transfers;
 mod total_interchain_transfers_received;
 mod total_interchain_transfers_sent;
 
+pub use new_messages_interchain_24h::{
+    NewMessagesInterchain24h, NewMessagesInterchain24hStatement,
+};
+pub use new_transfers_interchain_24h::{
+    NewTransfersInterchain24h, NewTransfersInterchain24hStatement,
+};
 pub use total_interchain_messages::{TotalInterchainMessages, TotalInterchainMessagesStatement};
 pub use total_interchain_messages_received::{
     TotalInterchainMessagesReceived, TotalInterchainMessagesReceivedStatement,

--- a/stats/stats/src/charts/counters/interchain/new_messages_interchain_24h.rs
+++ b/stats/stats/src/charts/counters/interchain/new_messages_interchain_24h.rs
@@ -190,6 +190,24 @@ mod tests {
         .await;
     }
 
+    /// Unfiltered companion of [`new_messages_interchain_24h_bridge_2`]: every
+    /// message in this window belongs to bridge 2 (`id = 1` at 10:00, `id = 100`
+    /// at 11:00), so the bridge dimension drops nothing here and both cases read
+    /// `2`. Pins that, and keeps this side symmetric with
+    /// `new_transfers_interchain_24h_id_collision_window`, where the same window
+    /// is what catches a `message_id`-only join.
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_messages_interchain_24h_id_collision_window() {
+        simple_test_counter_interchain::<NewMessagesInterchain24h>(
+            "new_messages_interchain_24h_id_collision_window",
+            "2",
+            Some(dt("2023-02-06T12:00:00")),
+            InterchainFilter::default(),
+        )
+        .await;
+    }
+
     #[tokio::test]
     #[ignore = "needs database to run"]
     async fn new_messages_interchain_24h_bridge_2() {

--- a/stats/stats/src/charts/counters/interchain/new_messages_interchain_24h.rs
+++ b/stats/stats/src/charts/counters/interchain/new_messages_interchain_24h.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+//! New interchain messages in the last 24 hours, **within the configured
+//! interchain slice**.
+//!
+//! Counts `crosschain_messages` rows admitted by the shared read filter
+//! (`STATS__INTERCHAIN_FILTER__*` plus the observability horizon) whose
+//! `init_timestamp` falls in the rolling 24-hour window ending at the update
+//! time. The chart adds no term of its own beyond that window — it is the
+//! 24-hour slice of `newMessagesInterchain`, not an observability statement, so
+//! neither `src_tx_hash` nor `dst_tx_hash` is consulted.
+
+use std::ops::Range;
+
+use interchain_indexer_entity::crosschain_messages;
+
+use crate::{
+    chart_prelude::*,
+    charts::db_interaction::filters::interchain::{
+        InterchainFilter, InterchainFilterTarget, InterchainFiltered,
+    },
+    range::inclusive_range_to_exclusive,
+};
+
+pub struct NewMessagesInterchain24hStatement;
+impl_db_choice!(NewMessagesInterchain24hStatement, UsePrimaryDB);
+
+impl NewMessagesInterchain24hStatement {
+    /// Split out from `get_statement_with_context` so tests can render it with an
+    /// explicit filter and no `UpdateContext` (hence no database connections).
+    ///
+    /// `range` is `Option` only so that [`InterchainFiltered::render`] can pass
+    /// `None`, exactly as the interchain line charts do — the coverage test
+    /// counts filter-predicate renderings and needs no window.
+    /// `get_statement_with_context` is the only production caller and always
+    /// passes `Some`.
+    fn build(filter: &InterchainFilter, range: Option<Range<DateTime<Utc>>>) -> Statement {
+        use crosschain_messages::Column as C;
+        let query = filter
+            .messages_query()
+            .select_only()
+            // `PullOneNowValue<_, _, i64>` reads a column named `value`, and
+            // Postgres `COUNT(*)` is already `bigint` — no cast.
+            .expr_as(Func::count(Asterisk.into_column_ref()), "value");
+        let query = match &range {
+            Some(range) => datetime_range_filter(query, C::InitTimestamp, range),
+            None => query,
+        };
+        query.build(DbBackend::Postgres)
+    }
+}
+
+impl StatementFromUpdateTime for NewMessagesInterchain24hStatement {
+    fn get_statement_with_context(cx: &UpdateContext<'_>) -> Statement {
+        Self::build(
+            &cx.interchain_filter,
+            Some(inclusive_range_to_exclusive(interval_24h(cx.time))),
+        )
+    }
+}
+
+impl InterchainFiltered for NewMessagesInterchain24hStatement {
+    const TARGET: InterchainFilterTarget = InterchainFilterTarget::Messages;
+    const CHART_NAME: &'static str = "newMessagesInterchain24h";
+
+    fn render(filter: &InterchainFilter) -> Statement {
+        Self::build(filter, None)
+    }
+}
+
+pub type NewMessagesInterchain24hRemote =
+    RemoteDatabaseSource<PullOneNowValue<NewMessagesInterchain24hStatement, NaiveDate, i64>>;
+
+pub struct Properties;
+
+impl Named for Properties {
+    fn name() -> String {
+        "newMessagesInterchain24h".into()
+    }
+}
+
+impl ChartProperties for Properties {
+    type Resolution = NaiveDate;
+
+    fn chart_type() -> ChartType {
+        ChartType::Counter
+    }
+    fn missing_date_policy() -> MissingDatePolicy {
+        MissingDatePolicy::FillPrevious
+    }
+    fn indexing_status_requirement() -> IndexingStatus {
+        IndexingStatus::LEAST_RESTRICTIVE.with_interchain(InterchainIndexingStatus::CaughtUp)
+    }
+}
+
+pub type NewMessagesInterchain24h =
+    DirectPointLocalDbChartSource<MapToString<NewMessagesInterchain24hRemote>, Properties>;
+
+#[cfg(test)]
+mod tests {
+    use interchain_indexer_filters::ChainBridgeFilter;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::tests::{
+        mock_interchain::{
+            MOCK_SECOND_BRIDGE_ID, mock_interchain_horizon, test_interchain_filter,
+            test_interchain_filter_with_horizon, test_interchain_home_chain_filter,
+        },
+        normalize_sql,
+        point_construction::dt,
+        simple_test::simple_test_counter_interchain,
+    };
+
+    #[test]
+    fn statement_is_correct() {
+        let actual = NewMessagesInterchain24hStatement::build(
+            &test_interchain_home_chain_filter(1),
+            Some(dt("2023-01-01T00:00:00").and_utc()..dt("2023-01-02T00:00:00").and_utc()),
+        );
+        let expected = r#"
+            SELECT COUNT(*) AS "value"
+            FROM "crosschain_messages"
+            WHERE ("crosschain_messages"."src_chain_id" = 1
+                   OR "crosschain_messages"."dst_chain_id" = 1)
+              AND "crosschain_messages"."init_timestamp" < '2023-01-02 00:00:00.000000 +00:00'
+              AND "crosschain_messages"."init_timestamp" >= '2023-01-01 00:00:00.000000 +00:00'
+        "#;
+        assert_eq!(normalize_sql(expected), normalize_sql(&actual.to_string()))
+    }
+
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn update_new_messages_interchain_24h() {
+        simple_test_counter_interchain::<NewMessagesInterchain24h>(
+            "update_new_messages_interchain_24h",
+            "2",
+            Some(dt("2023-01-11T00:00:00")),
+            InterchainFilter::default(),
+        )
+        .await;
+    }
+
+    /// Catches a transfers-shaped mistake if ever copy-pasted onto messages: this
+    /// pins the messages side of the same window, filtered on the message's own
+    /// route (`home_chain_id = 3`), so only message 12 (route `1 → 3`) qualifies.
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_messages_interchain_24h_home_3() {
+        simple_test_counter_interchain::<NewMessagesInterchain24h>(
+            "new_messages_interchain_24h_home_3",
+            "1",
+            Some(dt("2023-01-11T00:00:00")),
+            test_interchain_home_chain_filter(3),
+        )
+        .await;
+    }
+
+    /// The horizon reaches the new counter: message 24's route `1→2` is inside
+    /// bridge 1's observed chain set, so it survives.
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_messages_interchain_24h_horizon() {
+        simple_test_counter_interchain::<NewMessagesInterchain24h>(
+            "new_messages_interchain_24h_horizon",
+            "1",
+            Some(dt("2023-02-09T11:00:00")),
+            test_interchain_filter_with_horizon(
+                ChainBridgeFilter::default(),
+                Some(mock_interchain_horizon()),
+            ),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_messages_interchain_24h_bridge_2() {
+        simple_test_counter_interchain::<NewMessagesInterchain24h>(
+            "new_messages_interchain_24h_bridge_2",
+            "2",
+            Some(dt("2023-02-06T12:00:00")),
+            test_interchain_filter(ChainBridgeFilter {
+                bridge_ids: Some(vec![MOCK_SECOND_BRIDGE_ID]),
+                ..Default::default()
+            }),
+        )
+        .await;
+    }
+}

--- a/stats/stats/src/charts/counters/interchain/new_messages_interchain_24h.rs
+++ b/stats/stats/src/charts/counters/interchain/new_messages_interchain_24h.rs
@@ -156,8 +156,25 @@ mod tests {
         .await;
     }
 
+    /// Unfiltered baseline for [`new_messages_interchain_24h_horizon`]: the
+    /// window holds exactly message 24, so the horizon case's `1` means "the
+    /// message survived the horizon", not "the window happened to be empty".
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_messages_interchain_24h_horizon_baseline() {
+        simple_test_counter_interchain::<NewMessagesInterchain24h>(
+            "new_messages_interchain_24h_horizon_baseline",
+            "1",
+            Some(dt("2023-02-09T11:00:00")),
+            InterchainFilter::default(),
+        )
+        .await;
+    }
+
     /// The horizon reaches the new counter: message 24's route `1→2` is inside
-    /// bridge 1's observed chain set, so it survives.
+    /// bridge 1's observed chain set, so it survives — same count as
+    /// [`new_messages_interchain_24h_horizon_baseline`], while the same window's
+    /// transfer is dropped (see `new_transfers_interchain_24h_horizon`).
     #[tokio::test]
     #[ignore = "needs database to run"]
     async fn new_messages_interchain_24h_horizon() {

--- a/stats/stats/src/charts/counters/interchain/new_transfers_interchain_24h.rs
+++ b/stats/stats/src/charts/counters/interchain/new_transfers_interchain_24h.rs
@@ -199,6 +199,30 @@ mod tests {
         .await;
     }
 
+    /// The anchor that fails on a `message_id`-only join, and the reason it must
+    /// stay **unfiltered**. The window holds both bridge-2 messages (`id = 1` at
+    /// 10:00 with two transfers, `id = 100` at 11:00 with one) — and bridge 2's
+    /// `id = 1` collides with bridge 1's message 1 (2022-12-20), whose own two
+    /// transfers sit outside the window but are eligible while nothing filters
+    /// them out. The composite `(message_id, bridge_id)` join keeps the two
+    /// messages apart and yields `3`; joining on `message_id` alone fans bridge
+    /// 1's transfers onto bridge 2's in-window message and yields `5`.
+    ///
+    /// [`new_transfers_interchain_24h_bridge_2`] cannot do this job: restricting
+    /// to bridge 2 removes bridge 1's transfers from the scan, so a broken join
+    /// still reads `3` there.
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_transfers_interchain_24h_id_collision_window() {
+        simple_test_counter_interchain::<NewTransfersInterchain24h>(
+            "new_transfers_interchain_24h_id_collision_window",
+            "3",
+            Some(dt("2023-02-06T12:00:00")),
+            InterchainFilter::default(),
+        )
+        .await;
+    }
+
     #[tokio::test]
     #[ignore = "needs database to run"]
     async fn new_transfers_interchain_24h_bridge_2() {

--- a/stats/stats/src/charts/counters/interchain/new_transfers_interchain_24h.rs
+++ b/stats/stats/src/charts/counters/interchain/new_transfers_interchain_24h.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: LicenseRef-Blockscout
+
+//! New interchain transfers in the last 24 hours, **within the configured
+//! interchain slice**.
+//!
+//! Counts `crosschain_transfers` rows admitted by the shared read filter, which
+//! is evaluated on the transfer's own `token_src_chain_id` /
+//! `token_dst_chain_id` / `bridge_id` — never on the joined message's route. The
+//! composite join to `crosschain_messages` exists **only** to reach
+//! `init_timestamp`, since a transfer has no timestamp of its own; never
+//! hand-write that join. The chart is the 24-hour slice of
+//! `newTransfersInterchain`, not an observability statement, so neither
+//! `src_tx_hash` nor `dst_tx_hash` is consulted.
+
+use std::ops::Range;
+
+use interchain_indexer_entity::crosschain_messages;
+
+use crate::{
+    chart_prelude::*,
+    charts::db_interaction::filters::interchain::{
+        InterchainFilter, InterchainFilterTarget, InterchainFiltered,
+    },
+    range::inclusive_range_to_exclusive,
+};
+
+pub struct NewTransfersInterchain24hStatement;
+impl_db_choice!(NewTransfersInterchain24hStatement, UsePrimaryDB);
+
+impl NewTransfersInterchain24hStatement {
+    /// Split out from `get_statement_with_context` so tests can render it with an
+    /// explicit filter and no `UpdateContext` (hence no database connections).
+    ///
+    /// `range` is `Option` only so that [`InterchainFiltered::render`] can pass
+    /// `None`, exactly as the interchain line charts do — the coverage test
+    /// counts filter-predicate renderings and needs no window.
+    /// `get_statement_with_context` is the only production caller and always
+    /// passes `Some`.
+    fn build(filter: &InterchainFilter, range: Option<Range<DateTime<Utc>>>) -> Statement {
+        let time_axis = crosschain_messages::Column::InitTimestamp;
+        let query = filter
+            .transfers_joined_query()
+            .select_only()
+            // `PullOneNowValue<_, _, i64>` reads a column named `value`, and
+            // Postgres `COUNT(*)` is already `bigint` — no cast.
+            .expr_as(Func::count(Asterisk.into_column_ref()), "value");
+        let query = match &range {
+            Some(range) => datetime_range_filter(query, time_axis, range),
+            None => query,
+        };
+        query.build(DbBackend::Postgres)
+    }
+}
+
+impl StatementFromUpdateTime for NewTransfersInterchain24hStatement {
+    fn get_statement_with_context(cx: &UpdateContext<'_>) -> Statement {
+        Self::build(
+            &cx.interchain_filter,
+            Some(inclusive_range_to_exclusive(interval_24h(cx.time))),
+        )
+    }
+}
+
+impl InterchainFiltered for NewTransfersInterchain24hStatement {
+    const TARGET: InterchainFilterTarget = InterchainFilterTarget::Transfers;
+    const CHART_NAME: &'static str = "newTransfersInterchain24h";
+
+    fn render(filter: &InterchainFilter) -> Statement {
+        Self::build(filter, None)
+    }
+}
+
+pub type NewTransfersInterchain24hRemote =
+    RemoteDatabaseSource<PullOneNowValue<NewTransfersInterchain24hStatement, NaiveDate, i64>>;
+
+pub struct Properties;
+
+impl Named for Properties {
+    fn name() -> String {
+        "newTransfersInterchain24h".into()
+    }
+}
+
+impl ChartProperties for Properties {
+    type Resolution = NaiveDate;
+
+    fn chart_type() -> ChartType {
+        ChartType::Counter
+    }
+    fn missing_date_policy() -> MissingDatePolicy {
+        MissingDatePolicy::FillPrevious
+    }
+    fn indexing_status_requirement() -> IndexingStatus {
+        IndexingStatus::LEAST_RESTRICTIVE.with_interchain(InterchainIndexingStatus::CaughtUp)
+    }
+}
+
+pub type NewTransfersInterchain24h =
+    DirectPointLocalDbChartSource<MapToString<NewTransfersInterchain24hRemote>, Properties>;
+
+#[cfg(test)]
+mod tests {
+    use interchain_indexer_filters::ChainBridgeFilter;
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::tests::{
+        mock_interchain::{
+            MOCK_SECOND_BRIDGE_ID, mock_interchain_horizon, test_interchain_filter,
+            test_interchain_filter_with_horizon, test_interchain_home_chain_filter,
+        },
+        normalize_sql,
+        point_construction::dt,
+        simple_test::simple_test_counter_interchain,
+    };
+
+    #[test]
+    fn statement_is_correct() {
+        let actual = NewTransfersInterchain24hStatement::build(
+            &test_interchain_home_chain_filter(1),
+            Some(dt("2023-01-01T00:00:00").and_utc()..dt("2023-01-02T00:00:00").and_utc()),
+        );
+        let expected = r#"
+            SELECT COUNT(*) AS "value"
+            FROM "crosschain_transfers"
+            INNER JOIN "crosschain_messages"
+                ON "crosschain_transfers"."message_id" = "crosschain_messages"."id"
+               AND "crosschain_transfers"."bridge_id" = "crosschain_messages"."bridge_id"
+            WHERE ("crosschain_transfers"."token_src_chain_id" = 1
+                   OR "crosschain_transfers"."token_dst_chain_id" = 1)
+              AND "crosschain_messages"."init_timestamp" < '2023-01-02 00:00:00.000000 +00:00'
+              AND "crosschain_messages"."init_timestamp" >= '2023-01-01 00:00:00.000000 +00:00'
+        "#;
+        assert_eq!(normalize_sql(expected), normalize_sql(&actual.to_string()))
+    }
+
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn update_new_transfers_interchain_24h() {
+        simple_test_counter_interchain::<NewTransfersInterchain24h>(
+            "update_new_transfers_interchain_24h",
+            "6",
+            Some(dt("2023-01-11T00:00:00")),
+            InterchainFilter::default(),
+        )
+        .await;
+    }
+
+    /// The case that fails if the transfers statement filters on the joined
+    /// message's route instead of the transfer's own token chains: on
+    /// 2023-01-10 the window holds message 12 (route `1→3`, two transfers with
+    /// token chains `(1,3)`) and message 13 (route `2→1`, four transfers with
+    /// `(2,1)`). With `home_chain_id = 3` only message 12 and its two transfers
+    /// qualify.
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_transfers_interchain_24h_home_3() {
+        simple_test_counter_interchain::<NewTransfersInterchain24h>(
+            "new_transfers_interchain_24h_home_3",
+            "2",
+            Some(dt("2023-01-11T00:00:00")),
+            test_interchain_home_chain_filter(3),
+        )
+        .await;
+    }
+
+    /// Proves the observability horizon reaches the new counters: message 24's
+    /// route `1→2` is inside bridge 1's observed chain set so the message
+    /// survives, while its transfer's token chains `3→4` are not, so the
+    /// transfer is dropped.
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_transfers_interchain_24h_horizon() {
+        simple_test_counter_interchain::<NewTransfersInterchain24h>(
+            "new_transfers_interchain_24h_horizon",
+            "0",
+            Some(dt("2023-02-09T11:00:00")),
+            test_interchain_filter_with_horizon(
+                ChainBridgeFilter::default(),
+                Some(mock_interchain_horizon()),
+            ),
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_transfers_interchain_24h_bridge_2() {
+        simple_test_counter_interchain::<NewTransfersInterchain24h>(
+            "new_transfers_interchain_24h_bridge_2",
+            "3",
+            Some(dt("2023-02-06T12:00:00")),
+            test_interchain_filter(ChainBridgeFilter {
+                bridge_ids: Some(vec![MOCK_SECOND_BRIDGE_ID]),
+                ..Default::default()
+            }),
+        )
+        .await;
+    }
+}

--- a/stats/stats/src/charts/counters/interchain/new_transfers_interchain_24h.rs
+++ b/stats/stats/src/charts/counters/interchain/new_transfers_interchain_24h.rs
@@ -164,6 +164,22 @@ mod tests {
         .await;
     }
 
+    /// Unfiltered baseline for [`new_transfers_interchain_24h_horizon`]. Without
+    /// it that test's `0` is ambiguous — a broken statement returns `0` just as
+    /// readily as a correctly applied horizon. This pins the same window at `1`,
+    /// so the drop to `0` is attributable to the horizon.
+    #[tokio::test]
+    #[ignore = "needs database to run"]
+    async fn new_transfers_interchain_24h_horizon_baseline() {
+        simple_test_counter_interchain::<NewTransfersInterchain24h>(
+            "new_transfers_interchain_24h_horizon_baseline",
+            "1",
+            Some(dt("2023-02-09T11:00:00")),
+            InterchainFilter::default(),
+        )
+        .await;
+    }
+
     /// Proves the observability horizon reaches the new counters: message 24's
     /// route `1→2` is inside bridge 1's observed chain set so the message
     /// survives, while its transfer's token chains `3→4` are not, so the

--- a/stats/stats/src/charts/db_interaction/filters/interchain.rs
+++ b/stats/stats/src/charts/db_interaction/filters/interchain.rs
@@ -114,8 +114,8 @@ pub enum InterchainFilterTarget {
 pub trait InterchainFiltered {
     /// Which of the two predicates this statement is required to apply.
     const TARGET: InterchainFilterTarget;
-    /// How many times the predicate appears in the rendered SQL. `1` for twelve
-    /// of the thirteen; `2` for `totalInterchainTransferUsers`, whose UNION has
+    /// How many times the predicate appears in the rendered SQL. `1` for fourteen
+    /// of the fifteen; `2` for `totalInterchainTransferUsers`, whose UNION has
     /// two arms over the same table.
     const EXPECTED_APPLICATIONS: usize = 1;
     /// The public chart id this statement serves.

--- a/stats/stats/src/charts/interchain_filter_coverage.rs
+++ b/stats/stats/src/charts/interchain_filter_coverage.rs
@@ -4,7 +4,7 @@
 //!
 //! This module exists so that "every interchain chart applies the shared
 //! predicate" is a property a test checks rather than a claim a reviewer
-//! re-verifies by reading thirteen files. Before the filter was introduced, four
+//! re-verifies by reading fifteen files. Before the filter was introduced, four
 //! of the fifteen interchain chart families silently ignored filtering
 //! altogether — precisely because coverage was procedural.
 //!
@@ -45,6 +45,7 @@ use crate::{
         InterchainFilter, InterchainFilterConfig, InterchainFilterTarget, InterchainFiltered,
     },
     counters::interchain::{
+        NewMessagesInterchain24hStatement, NewTransfersInterchain24hStatement,
         TotalInterchainMessagesReceivedStatement, TotalInterchainMessagesSentStatement,
         TotalInterchainMessagesStatement, TotalInterchainTransferUsersStatement,
         TotalInterchainTransfersReceivedStatement, TotalInterchainTransfersSentStatement,
@@ -97,6 +98,8 @@ fn registry() -> Vec<CoverageEntry> {
         NewTransfersInterchainStatement,
         NewTransfersSentInterchainStatement,
         NewTransfersReceivedInterchainStatement,
+        NewMessagesInterchain24hStatement,
+        NewTransfersInterchain24hStatement,
     ]
 }
 

--- a/stats/stats/src/charts/interchain_indexing_status_coverage.rs
+++ b/stats/stats/src/charts/interchain_indexing_status_coverage.rs
@@ -32,7 +32,8 @@ use crate::{
     counters::{
         TotalZetachainCrossChainTxns,
         interchain::{
-            TotalInterchainMessages, TotalInterchainMessagesReceived, TotalInterchainMessagesSent,
+            NewMessagesInterchain24h, NewTransfersInterchain24h, TotalInterchainMessages,
+            TotalInterchainMessagesReceived, TotalInterchainMessagesSent,
             TotalInterchainTransferUsers, TotalInterchainTransfers,
             TotalInterchainTransfersReceived, TotalInterchainTransfersSent,
         },
@@ -68,7 +69,7 @@ macro_rules! coverage_entries {
     };
 }
 
-/// All 15 interchain chart families. The failure message names the one-line fix
+/// All 17 interchain chart families. The failure message names the one-line fix
 /// (add `.with_interchain(InterchainIndexingStatus::CaughtUp)` /
 /// `fn indexing_status_requirement()`) rather than leaving the reader to
 /// rediscover it.
@@ -89,6 +90,8 @@ fn registry() -> Vec<CoverageEntry> {
         NewTransfersReceivedInterchain,
         MessagesGrowthSentInterchain,
         MessagesGrowthReceivedInterchain,
+        NewMessagesInterchain24h,
+        NewTransfersInterchain24h,
     ]
 }
 
@@ -113,7 +116,7 @@ fn every_interchain_chart_declares_the_interchain_axis() {
 ///
 /// A new interchain chart must appear in `config/interchain/charts.json` to be
 /// enabled at all, so adding one without registering it here fails this test.
-/// None of the 15 families remaps `implementation` today (verified against
+/// None of the 17 families remaps `implementation` today (verified against
 /// `config/interchain/charts.json`), so the config key equals the served id for
 /// all of them; still resolve through `implementation` the same way
 /// `interchain_filter_coverage`'s layer 2 does, so this stays correct if that

--- a/stats/stats/src/update_groups_interchain.rs
+++ b/stats/stats/src/update_groups_interchain.rs
@@ -114,3 +114,9 @@ construct_update_group!(NewTransfersReceivedInterchainGroup {
         NewTransfersReceivedInterchainYearly,
     ],
 });
+
+// The two rolling-24h counters share one group so that both resolve against the
+// same `cx.time` and therefore describe the same 24-hour window.
+construct_update_group!(Interchain24hGroup {
+    charts: [NewMessagesInterchain24h, NewTransfersInterchain24h],
+});


### PR DESCRIPTION

## Summary

- Adds two counters to `Mode::Interchain`: `newMessagesInterchain24h` and
  `newTransfersInterchain24h`, each a rolling 24-hour `COUNT(*)` ending at the
  update time — the same counting principle as `newTxns24h` / `newContracts24h`
  in Blockscout mode.
- Both read through the shared interchain read filter, so
  `STATS__INTERCHAIN_FILTER__*` and the per-cycle observability horizon apply to
  them exactly as to every other interchain chart. This is enforced by the
  existing coverage guards, not by review.
- Served by id through the generic counters endpoint. Purely additive: no
  migration, no proto change, no behavioural change to any existing chart.

## Implementation Plan

- Two new chart modules under `stats/src/charts/counters/interchain/`. Each
  follows the pipeline all 7 existing interchain counters use —
  `StatementFromUpdateTime` → `RemoteDatabaseSource<PullOneNowValue<…, NaiveDate, i64>>`
  → `MapToString` → `DirectPointLocalDbChartSource` — with a window term added.
- The messages statement starts from `InterchainFilter::messages_query()` and
  windows `crosschain_messages.init_timestamp`. The transfers statement starts
  from `InterchainFilter::transfers_joined_query()` — the filter stays on the
  transfer's own `token_src_chain_id` / `token_dst_chain_id` / `bridge_id`, and
  the composite `(message_id, bridge_id)` join exists only to reach the parent
  message's `init_timestamp`, since a transfer has no timestamp of its own.
- Both obtain the window as
  `inclusive_range_to_exclusive(interval_24h(cx.time))` and apply it with
  `datetime_range_filter` — the form the interchain module already uses for
  every range term, so the counters' SQL stays comparable with the daily
  `newMessagesInterchain` / `newTransfersInterchain` charts.
- Both `Properties` declare `ChartType::Counter`,
  `MissingDatePolicy::FillPrevious`, and
  `IndexingStatus::LEAST_RESTRICTIVE.with_interchain(InterchainIndexingStatus::CaughtUp)`,
  matching the existing interchain counters.
- Both statements registered in `interchain_filter_coverage::registry()` and
  both chart types in `interchain_indexing_status_coverage::registry()`; the
  hardcoded family counts in those modules' doc comments and in
  `InterchainFiltered::EXPECTED_APPLICATIONS`'s doc updated (13 → 15
  statements, 15 → 17 chart families).
- One new `Interchain24hGroup` holding both counters, registered in
  `RuntimeSetup::all_update_groups()`. A single group means both counters
  resolve against the same `cx.time`, so the two numbers always describe the
  same 24-hour window.

## API Changes

- Two new counter ids in the generic counters response for interchain
  deployments: `newMessagesInterchain24h`, `newTransfersInterchain24h`.
- No change to `get_main_page_interchain_stats` /
  `proto_v1::MainPageInterchainStats`, and no `stats-proto` change.

## ENV / Config Changes

No `Settings` field added, renamed or removed — the generated env table in
`README.md` is untouched and `just check-envs` needs no follow-up. Three
interchain config files change:

- `config/interchain/charts.json` — two new `counters` entries, enabled by
  default:
  - `new_messages_interchain_24h` — "New interchain messages (24h)"
  - `new_transfers_interchain_24h` — "New interchain transfers (24h)"
- `config/interchain/layout.json` — both ids added to `counters_order`, each
  directly after its family's `total_*` counters. **This changes the display
  order of the interchain counters block on the frontend.**
- `config/interchain/update_groups.json` — `"interchain_24h_group": "0 20 * * * * *"`
  (hourly at :20). This is a new cadence for interchain mode, where the other
  groups run every 2 hours at `:00`; the `:20` offset keeps the two off each
  other. Cost is two `COUNT(*)` queries per hour against the indexer DB.

The new chart ids automatically gain the usual per-chart overrides
(`STATS_CHARTS__COUNTERS__NEW_MESSAGES_INTERCHAIN_24H__{ENABLED,TITLE,DESCRIPTION}`)
through the existing override reader; nothing declares them explicitly.

## Database / Migration Impact

None. No migration and no backfill. Two `charts` rows are created by
`DefaultCreate` on the first startup after deploy, and each holds one
`chart_data` row per update date. Existing interchain charts are untouched.

## Testing

Run locally on this branch:

- `cargo fmt --all --check` — clean.
- `just check` (`cargo check` + `cargo clippy --all --all-targets --all-features -- -D warnings`)
  — clean.
- `just test-with-db interchain_24h` — 12 passed, 0 failed. That covers both
  no-DB SQL snapshots and all 10 DB-backed cases.
- The four interchain coverage guards pass:
  `every_interchain_statement_applies_the_filter`,
  `registry_covers_every_configured_interchain_chart`,
  `every_interchain_chart_declares_the_interchain_axis`,
  `interchain_axis_registry_covers_every_configured_interchain_chart`.

What the tests actually pin, beyond the happy path:

- **SQL snapshots** — the transfers snapshot asserts the composite join emits
  both `(message_id, bridge_id)` halves and that transfer predicates are
  table-qualified (six column names are shared between the two tables).
- **`home_chain_id = 3` at `2023-01-11T00:00:00`** → 1 message / 2 transfers.
  This is the case that fails if the transfers statement filters on the joined
  message's route instead of the transfer's own token chains: the window holds
  message 12 (route `1→3`, two transfers with token chains `(1,3)`) and message
  13 (route `2→1`, four transfers with `(2,1)`).
- **Horizon at `2023-02-09T11:00:00`** → 1 message / 0 transfers, against an
  unfiltered baseline of 1 / 1 on the same window. Proves the observability
  horizon reaches the new counters: message 24's route `1→2` is inside bridge
  1's observed chain set so the message survives, while its transfer's token
  chains `3→4` are not. The baseline is what makes the transfers `0`
  attributable to the horizon rather than to an empty window.
- **`bridge_ids = [2]` at `2023-02-06T12:00:00`** → 2 messages / 3 transfers.
  Bridge dimension applied inside a window, on rows that all belong to the
  second bridge — which also reuses a numeric message id, so a
  `message_id`-only join would inflate the transfers count here.

Runtime behaviour was verified by the author against a live interchain stand.

## Follow-ups

- **Query cost is unmeasured on production-sized data**, in particular the
  transfers variant's windowed `COUNT(*)` over the composite join. Worth an
  `EXPLAIN` on a real stand; if it is expensive, the cadence in
  `config/interchain/update_groups.json` is the adjustment, not the design.
- **Expected discrepancies, not bugs.** A 24-hour rolling counter does not equal
  the last day of `newMessagesInterchain` / `newTransfersInterchain` (rolling vs
  calendar window). Separately, and pre-existing:
  `sent + received ≠ total` for the directional interchain charts, because each
  directional side carries a tx-hash observability term.
- Directional 24h variants (`…Sent24h` / `…Received24h`) are deliberately out of
  scope. They would need the tx-hash observability term, not just a chain-id
  predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rolling 24-hour interchain counters for new messages and transfers.
  - Added both counters to the interchain charts dashboard and update schedule.
  - Ensured message and transfer metrics use the same 24-hour reporting window.

- **Documentation**
  - Updated interchain chart coverage documentation to reflect the expanded metrics.

- **Tests**
  - Added coverage for filtering, time windows, bridge selection, and indexing status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->