### PR TITLE
perf(stats): optimize slow chart queries

### DIFF
--- a/stats/.memory-bank/rules/database.md
+++ b/stats/.memory-bank/rules/database.md
@@ -94,6 +94,69 @@ indexer entity re-exported from a sibling crate
 (`blockscout_db::entity::blocks`) when one exists, falling back to
 `FromQueryResult` + a raw `Statement` otherwise.
 
+## Keep Time Filters Sargable
+
+Indexer tables are large and every time-bounded chart query depends on a
+b-tree index over the filtered timestamp column
+(`blocks_timestamp_index`, `transactions_block_timestamp_index`,
+`transactions_created_contract_code_indexed_at_index`, ...). Postgres does not
+rearrange predicates algebraically, so the column has to appear **bare** on one
+side of the comparison:
+
+```sql
+-- Indexable: the column is compared to a constant
+WHERE blocks.timestamp >= $1 AND blocks.timestamp <= $2
+
+-- NOT indexable: the column sits inside an expression, so the planner
+-- can only sequential-scan the whole table
+WHERE $1 - blocks.timestamp at time zone 'UTC' <= interval '24 hours'
+```
+
+Both forms describe the same interval, which is why the second one survived in
+`interval_24h_filter` for a long time — it just made `newContracts24h`,
+`newVerifiedContracts24h` and `newOperationalTxns24h` scan their whole table
+on every update. Use `interval_24h_filter`/`datetime_range_filter`
+(`stats/src/charts/db_interaction/utils.rs`) rather than writing a bound by
+hand, and keep any new predicate in the same shape. Casting the *bound* is
+fine; casting or offsetting the *column* is not.
+
+Comparing a `timestamp without time zone` column against a bound passed as
+`DateTime<Utc>` (i.e. `timestamptz`) is fine: those cross-type operators are
+members of the `datetime_ops` btree operator family, so they still produce an
+index qual, and the session timezone is always UTC (see
+`.memory-bank/gotchas.md`).
+
+## Prefer `GROUP BY` Over `DISTINCT ON` For "First Row Per Key"
+
+`DISTINCT ON (key) ... ORDER BY key, ts` and `MIN(ts) ... GROUP BY key` mean the
+same thing, but only the second can be executed as a **partial aggregate**, i.e.
+collapsed inside each parallel worker before `Gather`. `DISTINCT ON` has no
+partial form: its `Unique` step runs in the leader, so every input row is
+funnelled through a single process.
+
+Measured on a production indexer (~3M `user_operations`, `EXPLAIN` only, no
+`ANALYZE`):
+
+| | `DISTINCT ON` | `GROUP BY` |
+|---|---|---|
+| rows through `Gather Merge` | 11,841,502 | 335,544 |
+| total estimated cost | 6,143,162 | 4,370,269 |
+
+Note what the planner did *not* do, contrary to the obvious assumption: it never
+full-sorted the input. It read `user_operations` through
+`user_operations_sender_factory_index` to get `sender` order for free and then
+ran an `Incremental Sort` with `sender` as the presorted key, which is cheap
+(+114K cost). So the win is parallelism, not sort-vs-hash — don't justify this
+rewrite by "avoiding a sort".
+
+The `GROUP BY` form also frees the planner to seq-scan instead of walking that
+index (1.99M vs 2.26M estimated, and far better real I/O locality on a
+full-table read). `new_aa_wallets.rs` uses the `GROUP BY` form for these reasons.
+
+`new_accounts.rs` still uses `DISTINCT ON (from_address_hash)`; it is the same
+rewrite, but with a much higher group cardinality, so it wants an `EXPLAIN`
+against a real indexer before being changed.
+
 ## Mode-Dispatching Read Helpers
 
 Several read helpers branch on `Mode` to hit the right indexer schema, e.g.

--- a/stats/stats/src/charts/counters/blockscout_instance/new_contracts_24h.rs
+++ b/stats/stats/src/charts/counters/blockscout_instance/new_contracts_24h.rs
@@ -57,7 +57,26 @@ pub type NewContracts24h =
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{point_construction::dt, simple_test::simple_test_counter};
+    use crate::tests::{normalize_sql, point_construction::dt, simple_test::simple_test_counter};
+
+    /// The 24h bounds must compare the bare column against constants, so that
+    /// `transactions_created_contract_code_indexed_at_index` stays usable.
+    #[test]
+    fn statement_is_correct() {
+        let actual = NewContracts24hStatement::get_statement(
+            dt("2025-01-02T00:00:00").and_utc(),
+            &IndexerMigrations::latest(),
+        );
+
+        let expected = r#"
+            SELECT COUNT(*) AS "value"
+            FROM "transactions"
+            WHERE "transactions"."status" = 1
+                AND ("transactions"."created_contract_code_indexed_at" >= '2025-01-01 00:00:00.000000 +00:00'
+                AND "transactions"."created_contract_code_indexed_at" <= '2025-01-02 00:00:00.000000 +00:00')
+        "#;
+        assert_eq!(normalize_sql(expected), normalize_sql(&actual.to_string()))
+    }
 
     #[tokio::test]
     #[ignore = "needs database to run"]

--- a/stats/stats/src/charts/counters/blockscout_instance/txns_stats_24h/mod.rs
+++ b/stats/stats/src/charts/counters/blockscout_instance/txns_stats_24h/mod.rs
@@ -19,9 +19,17 @@ impl StatementFromRange for TxnsStatsStatement {
     fn get_statement(
         range: Option<Range<DateTime<Utc>>>,
         completed_migrations: &IndexerMigrations,
-        _enabled_update_charts_recursive: &HashSet<ChartKey>,
+        enabled_update_charts_recursive: &HashSet<ChartKey>,
     ) -> Statement {
         use sea_orm::prelude::*;
+
+        // `count_op_stack_operational` has exactly one consumer
+        // (`OpStackNewOperationalTxns24h`), so on every chain where that counter
+        // is off, its per-row `FILTER` runs over a full day of transactions and
+        // the result is discarded. Gated the same way as in
+        // `NewTxnsCombinedStatement`.
+        let count_op_stack_transactions = enabled_update_charts_recursive
+            .contains(&op_stack_new_operational_txns_24h::Properties::key());
 
         // see `statement_is_correct` for resulting SQL statement
         let fee_query = Expr::cust_with_exprs(
@@ -38,10 +46,16 @@ impl StatementFromRange for TxnsStatsStatement {
         .mul(transactions::Column::GasUsed.into_simple_expr());
 
         let count_query = Func::count(transactions::Column::Hash.into_simple_expr());
-        let count_op_stack_query = Expr::cust(format!(
-            r#"COUNT("transactions"."hash") FILTER (WHERE {})"#,
-            op_stack_operational_transactions_filter("transactions")
-        ));
+        let count_op_stack_query = if count_op_stack_transactions {
+            Expr::cust(format!(
+                r#"COUNT("transactions"."hash") FILTER (WHERE {})"#,
+                op_stack_operational_transactions_filter("transactions")
+            ))
+        } else {
+            // `TxnsStatsValue::count_op_stack_operational` is an `i64`, so the
+            // placeholder has to come back as `bigint`, not `integer`.
+            Expr::cust("CAST(0 AS bigint)")
+        };
         let sum_query = Expr::expr(Func::sum(fee_query.clone()))
             .div(ETHER)
             .cast_as(Alias::new("FLOAT"));
@@ -86,11 +100,37 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     use crate::{
+        ChartProperties,
         data_source::{kinds::remote_db::StatementFromRange, types::IndexerMigrations},
         tests::{normalize_sql, point_construction::dt},
     };
 
-    use super::TxnsStatsStatement;
+    use super::{TxnsStatsStatement, op_stack_new_operational_txns_24h};
+
+    /// Without `opStackNewOperationalTxns24h` enabled, the operational count is
+    /// a constant rather than a per-row `FILTER` over a day of transactions.
+    #[test]
+    fn statement_skips_op_stack_count_when_disabled() {
+        let actual = TxnsStatsStatement::get_statement(
+            Some(dt("2025-01-01T00:00:00").and_utc()..dt("2025-01-02T00:00:00").and_utc()),
+            &IndexerMigrations::latest(),
+            &HashSet::new(),
+        );
+
+        let expected = r#"
+            SELECT COUNT("transactions"."hash") AS "count",
+                CAST(0 AS bigint) AS "count_op_stack_operational",
+                CAST((SUM((COALESCE("transactions"."gas_price", "blocks"."base_fee_per_gas" + LEAST("transactions"."max_priority_fee_per_gas", "transactions"."max_fee_per_gas" - "blocks"."base_fee_per_gas"))) * "transactions"."gas_used") / 1000000000000000000) AS FLOAT) AS "fee_sum",
+                CAST((AVG((COALESCE("transactions"."gas_price", "blocks"."base_fee_per_gas" + LEAST("transactions"."max_priority_fee_per_gas", "transactions"."max_fee_per_gas" - "blocks"."base_fee_per_gas"))) * "transactions"."gas_used") / 1000000000000000000) AS FLOAT) AS "fee_average"
+            FROM "blocks"
+            INNER JOIN "transactions" ON "blocks"."hash" = "transactions"."block_hash"
+            WHERE "transactions"."block_timestamp" < '2025-01-02 00:00:00.000000 +00:00'
+                AND "transactions"."block_timestamp" >= '2025-01-01 00:00:00.000000 +00:00'
+                AND "blocks"."timestamp" < '2025-01-02 00:00:00.000000 +00:00'
+                AND "blocks"."timestamp" >= '2025-01-01 00:00:00.000000 +00:00'
+        "#;
+        assert_eq!(normalize_sql(expected), normalize_sql(&actual.to_string()))
+    }
 
     #[test]
     fn statement_is_correct() {
@@ -98,7 +138,7 @@ mod tests {
         let actual = TxnsStatsStatement::get_statement(
             Some(dt("2025-01-01T00:00:00").and_utc()..dt("2025-01-02T00:00:00").and_utc()),
             &IndexerMigrations::latest(),
-            &HashSet::new(),
+            &HashSet::from([op_stack_new_operational_txns_24h::Properties::key()]),
         );
 
         let expected = r#"

--- a/stats/stats/src/charts/db_interaction/utils.rs
+++ b/stats/stats/src/charts/db_interaction/utils.rs
@@ -2,24 +2,29 @@
 
 use std::ops::Range;
 
+use crate::utils::interval_24h;
 use chrono::{DateTime, Utc};
 use sea_orm::{
     ColumnTrait, QueryFilter,
-    sea_query::{Expr, SimpleExpr},
+    sea_query::{Expr, ExprTrait, SimpleExpr},
 };
 
+/// Filter for the 24 hours preceding `filter_24h_until` (both ends inclusive).
+///
+/// `timestamp_expr` is kept bare on the left-hand side of both comparisons so
+/// that a b-tree index on the underlying column stays usable. The equivalent
+/// `filter_24h_until - column at time zone 'UTC' <= interval '24 hours'` form
+/// wraps the column in an expression, which is not sargable and makes postgres
+/// sequential-scan the whole table.
 pub fn interval_24h_filter(
     timestamp_expr: SimpleExpr,
     filter_24h_until: DateTime<Utc>,
 ) -> SimpleExpr {
-    Expr::cust_with_exprs(
-        "$1 - $2 at time zone 'UTC' <= interval '24 hours'",
-        [Expr::value(filter_24h_until), timestamp_expr.clone()],
-    )
-    .and(Expr::cust_with_exprs(
-        "$1 - $2 at time zone 'UTC' >= interval '0 hours'",
-        [Expr::value(filter_24h_until), timestamp_expr],
-    ))
+    let interval = interval_24h(filter_24h_until);
+    timestamp_expr
+        .clone()
+        .gte(Expr::value(*interval.start()))
+        .and(timestamp_expr.lte(Expr::value(*interval.end())))
 }
 
 pub fn datetime_range_filter<Q: QueryFilter, C: ColumnTrait>(

--- a/stats/stats/src/charts/lines/blockscout_instance/user_ops/new_aa_wallets.rs
+++ b/stats/stats/src/charts/lines/blockscout_instance/user_ops/new_aa_wallets.rs
@@ -24,17 +24,22 @@ impl StatementFromRange for NewAccountAbstractionWalletsStatement {
 
         sql_with_range_filter_opt!(
             DbBackend::Postgres,
+            // `GROUP BY`+`MIN` rather than `DISTINCT ON` on purpose: they mean
+            // the same thing here, but only `GROUP BY` can run as a *partial*
+            // (per-worker) aggregate. `DISTINCT ON` has to funnel every user
+            // operation through the leader for its `Unique` step. Measured on
+            // a production indexer (~3M user ops): 336K rows through
+            // `Gather Merge` instead of 11.8M, 4.37M vs 6.14M total cost.
             r#"
                 SELECT "first_user_op"."date" AS "date",
                     COUNT(*)::TEXT AS "value"
                 FROM
-                    (SELECT DISTINCT ON ("sender") CAST("blocks"."timestamp" AS date) AS "date"
+                    (SELECT CAST(MIN("blocks"."timestamp") AS date) AS "date"
                     FROM "user_operations"
                     INNER JOIN "blocks" ON "user_operations"."block_hash" = "blocks"."hash"
                     WHERE "blocks"."consensus" = TRUE
                         AND "blocks"."timestamp" != to_timestamp(0) {filter}
-                    ORDER BY "user_operations"."sender" ASC,
-                            "blocks"."timestamp" ASC
+                    GROUP BY "user_operations"."sender"
                 ) AS "first_user_op"
                 GROUP BY "first_user_op"."date"
             "#,
@@ -138,7 +143,36 @@ pub type NewAccountAbstractionWalletsYearly = DirectVecLocalDbChartSource<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::simple_test::simple_test_chart;
+    use crate::tests::{normalize_sql, point_construction::dt, simple_test::simple_test_chart};
+
+    /// The per-sender aggregation must stay a `GROUP BY` (see the note in
+    /// `get_statement`); `DISTINCT ON` blocks partial aggregation and pushes
+    /// every user operation through the leader process.
+    #[test]
+    fn statement_is_correct() {
+        let actual = NewAccountAbstractionWalletsStatement::get_statement(
+            Some(dt("2025-01-01T00:00:00").and_utc()..dt("2025-01-02T00:00:00").and_utc()),
+            &IndexerMigrations::latest(),
+            &HashSet::new(),
+        );
+
+        let expected = r#"
+            SELECT "first_user_op"."date" AS "date",
+                COUNT(*)::TEXT AS "value"
+            FROM
+                (SELECT CAST(MIN("blocks"."timestamp") AS date) AS "date"
+                FROM "user_operations"
+                INNER JOIN "blocks" ON "user_operations"."block_hash" = "blocks"."hash"
+                WHERE "blocks"."consensus" = TRUE
+                    AND "blocks"."timestamp" != to_timestamp(0)
+                    AND "blocks"."timestamp" < '2025-01-02 00:00:00.000000 +00:00'
+                    AND "blocks"."timestamp" >= '1970-01-01 00:00:00.000000 +00:00'
+                GROUP BY "user_operations"."sender"
+            ) AS "first_user_op"
+            GROUP BY "first_user_op"."date"
+        "#;
+        assert_eq!(normalize_sql(expected), normalize_sql(&actual.to_string()))
+    }
 
     #[tokio::test]
     #[ignore = "needs database to run"]


### PR DESCRIPTION
`interval_24h_filter` built its bounds as
`now - column at time zone 'UTC' <= interval '24 hours'`. That expresses the right interval, but wrapping the column in an expression makes the predicate non-sargable, so postgres cannot use a b-tree index on it and sequential-scans the whole table. Compare the bare column against the two bounds instead. Affects `newContracts24h` (which has
`transactions_created_contract_code_indexed_at_index` available), `newVerifiedContracts24h` and Arbitrum's `newOperationalTxns24h`.

`newAccountAbstractionWallets` picked the first user operation per sender with `DISTINCT ON`. `Unique` has no partial-aggregate form, so every input row is funnelled through the leader process; `MIN(...) ... GROUP BY sender` means the same thing and collapses inside each parallel worker instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved chart query efficiency for time-based statistics and account abstraction wallet metrics.
  - Reduced unnecessary processing when optional transaction metrics are disabled.

- **Bug Fixes**
  - Improved reliability of 24-hour chart calculations and filtering, helping ensure accurate results across supported statistics.

- **Tests**
  - Added validation for generated chart queries and 24-hour time-window behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->